### PR TITLE
Make Link.fir reference relative path

### DIFF
--- a/test/features/Link.fir
+++ b/test/features/Link.fir
@@ -1,4 +1,4 @@
-; RUN: firrtl -i %s -m /Users/cusgadmin/code/stanza/firrtl/test/features/Queue.fir -o %s.v -X verilog -p c 2>&1 | tee %s.out | FileCheck %s
+; RUN: firrtl -i %s -m %S/Queue.fir -o %s.v -X verilog -p c 2>&1 | tee %s.out | FileCheck %s
 ;CHECK: Lower To Ground
 circuit Top : 
   module Top : 


### PR DESCRIPTION
Makes the test pass without needing a particular directory structure.
