### PR TITLE
Change of FIRRTL semantics!

### DIFF
--- a/src/main/stanza/passes.stanza
+++ b/src/main/stanza/passes.stanza
@@ -1448,7 +1448,9 @@ defn merge-resets (assign:HashTable<Symbol,SymbolicValue>, resets:HashTable<Symb
    val table = HashTable<Symbol,SymbolicValue>(symbol-hash)
    for i in get-unique-keys(list(assign,resets)) do :
       table[i] = match(get?(assign,i,false),get?(resets,i,false)) : 
-            (a:SymbolicValue,r:SymbolicValue) : SVMux(rsignals[i],r,a)
+            (a:SymbolicValue,r:SymbolicValue) : 
+               if r typeof SVNul : a
+               else : SVMux(rsignals[i],r,a)
             (a:SymbolicValue,r:False) : a
             (a:False,r:SymbolicValue) : SVMux(rsignals[i],r,SVNul())
             (a:False,r:False) : error("Shouldn't be here")
@@ -1466,8 +1468,9 @@ defn build-tables (s:Stmt,
          flattn[name(s)] = true
       (s:DefRegister) : 
          assign[name(s)] = SVNul()
-         flattn[name(s)] = false
+         flattn[name(s)] = true
          rsignals[name(s)] = reset(s)
+         resets[name(s)] = SVNul()
       (s:DefAccessor) : 
          assign[name(s)] = SVNul()
          flattn[name(s)] = false
@@ -1513,6 +1516,12 @@ defn build-tables (s:Stmt,
          for x in assign-a do : println-debug(x)
          println-debug("TABLE")
          for x in assign do : println-debug(x)
+         println-debug("RESET-C")
+         for x in resets-c do : println-debug(x)
+         println-debug("RESET-A")
+         for x in resets-a do : println-debug(x)
+         println-debug("RESET")
+         for x in resets do : println-debug(x)
       (s:Connect|OnReset) : 
          val key* = match(loc(s)) :
             (e:WRef) : name(e)

--- a/test/passes/expand-whens/reg-dwoc.fir
+++ b/test/passes/expand-whens/reg-dwoc.fir
@@ -1,4 +1,4 @@
-; RUN: firrtl -i %s -o %s.v -X verilog -p c 2>&1 | tee %s.out | FileCheck %s
+; RUN: firrtl -i %s -o %s.v -X verilog -p cd 2>&1 | tee %s.out | FileCheck %s
 circuit top :
    module top :
       input clk : Clock

--- a/test/passes/expand-whens/reg-wdc.fir
+++ b/test/passes/expand-whens/reg-wdc.fir
@@ -1,5 +1,4 @@
 ; RUN: firrtl -i %s -o %s.v -X verilog -p c 2>&1 | tee %s.out | FileCheck %s
-; XFAIL: *
 circuit top :
    module top :
       input clk : Clock
@@ -16,8 +15,9 @@ circuit top :
 ; CHECK:   module top :
 ; CHECK:     wire p : UInt
 ; CHECK:     reg r : UInt, clk, reset
-; CHECK:     p := UInt("h00000001")
-; CHECK-NOT: when p : r := UInt("h00000002")
+; CHECK:     p := UInt("h1")
+; CHECK-NOT: when p : r := UInt("h2")
 
 ; CHECK: Finished Expand Whens
 
+; CHECK: Done!

--- a/test/passes/expand-whens/reg-wdoc.fir
+++ b/test/passes/expand-whens/reg-wdoc.fir
@@ -1,5 +1,4 @@
 ; RUN: firrtl -i %s -o %s.v -X verilog -p c 2>&1 | tee %s.out | FileCheck %s
-; XFAIL: *
 circuit top :
    module top :
       input clk : Clock
@@ -17,8 +16,8 @@ circuit top :
 ; CHECK:   module top :
 ; CHECK:     wire p : UInt
 ; CHECK:     reg r : UInt, clk, reset
-; CHECK:     p := UInt("h00000001")
-; CHECK-NOT:  when p : r := mux(reset, UInt("h00000001"), UInt("h00000002"))
+; CHECK:     p := UInt("h1")
+; CHECK-NOT:  when p : r := mux(reset, UInt("h1"), UInt("h2"))
 
 ; CHECK: Finished Expand Whens
 


### PR DESCRIPTION
@aswaterman, our discussed semantics are implemented. We should wait to merge until all instances of when-enclosed registers are examined. (deleted earlier pull request as it included other unnecessary commits).

Assignments to a register are no longer affected by enclosing when
statements:

when p :
  reg r : UInt,clk,reset
  r := a

will lower to:

reg r : UInt,clk,reset
r := a

instead of:

reg r : UInt,clk,reset
when p : r := a
