### PR TITLE
Added support for -b <backend> so that specific passes can be run the…

### DIFF
--- a/src/main/stanza/compilers.stanza
+++ b/src/main/stanza/compilers.stanza
@@ -5,6 +5,7 @@ defpackage firrtl/compiler :
   import firrtl/errors
   import firrtl/flo
   import firrtl/verilog
+  import firrtl/firrtl
   import firrtl/ir2
   import firrtl/ir-utils
 
@@ -41,6 +42,8 @@ public defmethod passes (c:StandardFlo) -> List<Pass> :
 
 public defstruct StandardVerilog <: Compiler :
    with-output : (() -> False) -> False with: (as-method => true)
+public defmethod backend (c:StandardVerilog) -> List<Pass> :
+  to-list $ [ Verilog(with-output(c)) ]
 public defmethod passes (c:StandardVerilog) -> List<Pass> :
    to-list $ [
       RemoveSpecialChars()     ;R
@@ -74,11 +77,23 @@ public defmethod passes (c:StandardVerilog) -> List<Pass> :
       Verilog(with-output(c))  ;R
    ]
 
+public defstruct StandardFIRRTL <: Compiler :
+   with-output : (() -> False) -> False with: (as-method => true)
+public defmethod backend (c:StandardFIRRTL) -> List<Pass> :
+  to-list $ [ FIRRTL(with-output(c)) ]
+public defmethod passes (c:StandardFIRRTL) -> List<Pass> :
+   to-list $ [
+      CheckHighForm()
+      FIRRTL(with-output(c))
+    ]
+
 
 ;============= DRIVER ======================================
-public defn run-passes (c:Circuit,comp:Compiler) : 
+public defn run-backend (c:Circuit,comp:Compiler) :
+   run-passes(c,backend(comp))
+public defn run-passes (c:Circuit,comp:Compiler) -> Circuit: 
    run-passes(c,passes(comp))
-public defn run-passes (c:Circuit,ls:List<Pass>) :
+public defn run-passes (c:Circuit,ls:List<Pass>) -> Circuit:
    var c*:Circuit = c
    println("Compiling!")
    if PRINT-CIRCUITS : println("Original Circuit")
@@ -105,3 +120,4 @@ public defn run-passes (c:Circuit,ls:List<Pass>) :
       println-all([x[0] " --- " to-float(x[1] as Int * 100) / to-float(t - start-time) "%"])
    println("==========================")
    println("Done!")
+   c*

--- a/src/main/stanza/firrtl-test-main.stanza
+++ b/src/main/stanza/firrtl-test-main.stanza
@@ -14,6 +14,7 @@
 #include("compilers.stanza")
 #include("flo.stanza")
 #include("verilog.stanza")
+#include("firrtl.stanza")
 
 ;Custom Packages
 #include("custom-passes.stanza")
@@ -61,6 +62,7 @@ defn main () :
    val pass-args = Vector<String>()
    var printvars = ""
    var last-s = ""
+   var backend = ""
 
    val prev-out = CURRENT-OUTPUT-STREAM
    CURRENT-OUTPUT-STREAM = STANDARD-ERROR
@@ -74,6 +76,7 @@ defn main () :
       else if s == "-p" : last-s = s
       else if s == "-s" : last-s = s
       else if s == "-m" : last-s = s
+      else if s == "-b" : last-s = s
       else :
          if last-s == "-i" : input = args[i]
          if last-s == "-o" : output = args[i]
@@ -82,6 +85,7 @@ defn main () :
          if last-s == "-p" : printvars = to-string([printvars args[i]])
          if last-s == "-s" : add(pass-args,args[i])
          if last-s == "-m" : add(firms,args[i])
+         if last-s == "-b" : backend = args[i]
 
    var with-output = 
       fn (f:()->False) : 
@@ -126,12 +130,17 @@ defn main () :
    set-printvars!(to-list(printvars))
    
    if compiler == false :
-      run-passes(circuit*,get-passes(to-list(pass-names)))
+      var c*:Circuit = run-passes(circuit*,get-passes(to-list(pass-names)))
+      switch {_ == backend} :
+        "verilog" : run-backend(c*,StandardVerilog(with-output))
+        "firrtl" : run-backend(c*,StandardFIRRTL(with-output))
+        else : error("Invalid backend flag!")
    else :
       switch {_ == compiler} :
          "flo" : error("Flo backend not currently supported.")
             ; run-passes(circuit*,StandardFlo(with-output))
          "verilog" : run-passes(circuit*,StandardVerilog(with-output))
+         "firrtl" : run-passes(circuit*,StandardFIRRTL(with-output))
          "verilute" : run-passes(circuit*,InstrumentedVerilog(with-output,to-list $ pass-args))
          else : error("Invalid compiler flag")
 

--- a/src/main/stanza/firrtl.stanza
+++ b/src/main/stanza/firrtl.stanza
@@ -1,0 +1,21 @@
+defpackage firrtl/firrtl :
+  import core
+  import verse
+  import firrtl/ir-utils
+  import firrtl/ir2
+
+
+;============ FIRRTL ==============
+
+public defstruct FIRRTL <: Pass :
+   with-output: (() -> False) -> False  
+public defmethod pass (b:FIRRTL) -> (Circuit -> Circuit) : emit-firrtl{with-output(b),_}
+public defmethod name (b:FIRRTL) -> String : "To FIRRTL"
+public defmethod short-name (b:FIRRTL) -> String : "To FIRRTL"
+
+;============ Utilz =============
+
+public defn emit-firrtl (with-output:(() -> False) -> False, c:Circuit) :
+  with-output $ fn () :
+    print(c)
+  c

--- a/src/main/stanza/ir-utils.stanza
+++ b/src/main/stanza/ir-utils.stanza
@@ -99,6 +99,7 @@ public defn PassExceptions (xs:Streamable<PassException>) :
 
 public definterface Compiler 
 public defmulti passes (c:Compiler) -> List<Pass>
+public defmulti backend (c:Compiler) -> List<Pass>
 public defmulti with-output (c:Compiler) -> ((() -> False) -> False)
 
 public definterface Pass

--- a/src/main/stanza/passes.stanza
+++ b/src/main/stanza/passes.stanza
@@ -6,30 +6,62 @@ defpackage firrtl/passes :
   import firrtl/primops
   import firrtl-main
   import firrtl/errors
+  import firrtl/verilog
+  import firrtl/firrtl
   import bigint2
 
 ;============== Pass List ================
 public val standard-passes = to-list $ [
-   CheckHighForm()
-   TempElimination()
-   ToWorkingIR()
-   ResolveKinds()
-   CheckKinds()
-   InferTypes()
-   CheckTypes()
-   ResolveGenders()
-   CheckGenders()
-   ExpandAccessors()
-   LowerToGround()
-   ;ExpandIndexedConnects()
-   InlineIndexed()
-   ExpandWhens()
-   InferWidths()
-   Inline()
-   SplitExp()
-   CheckLowForm()
-   ToRealIR() 
-   Pad() ]
+      RemoveSpecialChars()     ;R
+      ;RemoveScopes()           ;R
+      CheckHighForm()          ;R
+      TempElimination()        ;R
+      ToWorkingIR()            ;R -> W
+      ResolveKinds()           ;W
+      InferTypes()             ;R
+      ResolveGenders()         ;W
+      CheckGenders()           ;W
+      CheckKinds()             ;W
+      CheckTypes()             ;R
+      ExpandAccessors()        ;W
+      LowerToGround()          ;W
+      ;ExpandIndexedConnects()  ;W
+      InlineIndexed()
+      InferTypes()             ;R
+      CheckGenders()           ;W
+      ExpandWhens()            ;W
+      InferWidths()            ;R
+      ToRealIR()               ;W -> R
+      CheckWidths()            ;R
+      Pad()                    ;R
+      ConstProp()              ;R
+      SplitExp()               ;R
+      CheckWidths()            ;R
+      CheckHighForm()          ;R
+      CheckLowForm()           ;R
+      CheckInitialization()    ;R
+   ]
+
+   ;CheckHighForm()
+   ;TempElimination()
+   ;ToWorkingIR()
+   ;ResolveKinds()
+   ;CheckKinds()
+   ;InferTypes()
+   ;CheckTypes()
+   ;ResolveGenders()
+   ;CheckGenders()
+   ;ExpandAccessors()
+   ;LowerToGround()
+   ;;ExpandIndexedConnects()
+   ;InlineIndexed()
+   ;ExpandWhens()
+   ;InferWidths()
+   ;Inline()
+   ;SplitExp()
+   ;CheckLowForm()
+   ;ToRealIR() 
+   ;Pad() ]
 ;=============== WORKING IR ================================
 public definterface Kind
 public defstruct WireKind <: Kind 
@@ -2466,6 +2498,7 @@ public defn special-rename (original-sym:Symbol,new-sym:Symbol,c:Circuit) :
 public defstruct Pad <: Pass
 public defmethod pass (b:Pad) -> (Circuit -> Circuit) : pad-widths
 public defmethod name (b:Pad) -> String : "Pad Widths"
+public defmethod short-name (b:Pad) -> String : "pad-widths"
 
 ;------------ Helper Functions --------------
 defn int-width! (t:Type) -> Long :


### PR DESCRIPTION
Added support for -b <backend> so that specific passes can be run then a backend can be applied. Added firrtl compiler for emitting firrtl.

There is also now a firrtl "compiler" in the stanza implementation that essentially reads in the firrtl, checks high form (should this be removed?) then spits it back out again. Ideally tests in test/parser will work with this, but there is a small issue I need to address first.
