### PR TITLE
Escape quotes before emitting Verilog

### DIFF
--- a/src/main/stanza/passes.stanza
+++ b/src/main/stanza/passes.stanza
@@ -2436,6 +2436,8 @@ defn escape (s:String) -> String :
    for c in s do :
       if c == '\n' :
          add(s*,"\\n")
+      else if c == '"' :
+         add(s*, "\\\"")
       else :
          if c == 'x' and percent :
             add(s*,"h")

--- a/test/passes/to-verilog/escape-quote.fir
+++ b/test/passes/to-verilog/escape-quote.fir
@@ -1,0 +1,18 @@
+; RUN: firrtl -i %s -o %s.v -X verilog ; cat %s.v | FileCheck %s
+
+;CHECK: module top(
+;CHECK:    input   clk
+;CHECK: );
+;CHECK:    always @(posedge clk) begin
+;CHECK:       `ifndef SYNTHESIS
+;CHECK:          if(1'h1) begin
+;CHECK:             $fwrite(32'h80000002,"This has an escaped quote (\") in it");
+;CHECK:          end
+;CHECK:       `endif
+;CHECK:    end
+;CHECK: endmodule
+
+circuit top :
+   module top :
+      input clk : Clock
+      printf(clk, UInt<1>(1), "This has an escaped quote (\") in it")


### PR DESCRIPTION
This is necessary to handle some assertions in the current rocket-chip codebase.
