### PR TITLE
Add JNI backend support

### DIFF
--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -260,6 +260,11 @@ trait BackendCompilationUtilities {
       out.write(s"${preLDFLAGS} ${sharedLibraryFlags} $$(LDFLAGS) ${postLDFLAGS}\n")
     }
     out.close()
+    // Ensure .o files are recompiled with the correct flags.
+    val objFiles = new File(dir.toString).listFiles.filter(_.getName.endsWith(".o"))
+    for (file <- objFiles) {
+      file.delete()
+    }
     Seq("make", "-C", dir.toString, "-j", "-f", outputMakefile.getName, s"${shimPieces.head}.${sharedLibraryExtension}", s"V${prefix}.${sharedLibraryExtension}")
   }
 

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -59,6 +59,12 @@ object BackendCompilationUtilities {
       // We don't know what the rest require at the moment.
     case _ => "-shared"
   }
+  /** Extra libraries to be loaded with a shared library.
+    *
+    */
+  val sharedLibraryLibraries: String = osVersion match {
+    case _ => ""
+  }
   /**
     * The include paths required to compile JNI C code.
     * This can be turned into C/C++ flags via something like:
@@ -242,7 +248,7 @@ trait BackendCompilationUtilities {
     out.write("")
     // Add lines to cover generic cpp compilation
     val JNI_CPPFLAGS = includePathsJNI.map("-I" + _.toString).mkString(" ")
-    out.write("LIBS += -lc++\n")
+    out.write(s"LIBS += ${sharedLibraryLibraries}\n")
     out.write(s"CXXFLAGS += ${JNI_CPPFLAGS} ${sharedLibraryFlags}\n")
     out.write(extraDependencies + ": %.o : %.cpp\n\techo $(PATH)\n\t$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -c -o $@ $<\n")
     makeBuffer(0) match { case r"""^(\w+)${target}:(.*)${dependencies}""" =>

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -45,7 +45,7 @@ object BackendCompilationUtilities {
   val sharedLibraryExtension: String = osVersion match {
     case MacOS => "dylib"
     case Windows => "dll"
-    case _ => ".so"
+    case _ => "so"
   }
   /**
     * The include paths required to compile JNI C code.
@@ -231,8 +231,8 @@ trait BackendCompilationUtilities {
     // Add lines to cover generic cpp compilation
     val JNI_CPPFLAGS = includePathsJNI.map("-I" + _.toString).mkString(" ")
     out.write("LIBS += -lc++\n")
-    out.write(s"JNI_CPPFLAGS = ${JNI_CPPFLAGS}\n")
-    out.write(extraDependencies + ": %.o : %.cpp\n\techo $(PATH)\n\t$(CXX) $(JNI_CPPFLAGS) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -c -o $@ $<\n")
+    out.write(s"CXXFLAGS += ${JNI_CPPFLAGS}\n")
+    out.write(extraDependencies + ": %.o : %.cpp\n\techo $(PATH)\n\t$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(OPT_FAST) -c -o $@ $<\n")
     makeBuffer(0) match { case r"""^(\w+)${target}:(.*)${dependencies}""" =>
         out.write(s"${target}.${sharedLibraryExtension}: ${dependencies} ${extraDependencies}\n")
     }

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -238,7 +238,7 @@ trait BackendCompilationUtilities {
   }
 
   def cppToExe(prefix: String, dir: File): ProcessBuilder = {
-    val commandSeq = Seq("make", "-C", dir.toString, "-j", "-f", s"V$prefix.mk", s"V$prefix")
+    val commandSeq = Seq("make", "-C", getPosixCompatibleAbsolutePath(dir.toString), "-j", "-f", s"V$prefix.mk", s"V$prefix")
     if (osVersion == OSVersion.Windows) {
       val commandString = commandSeq.mkString(" ")
       val bashFile = new File(dir, s"M${prefix}.mk.sh")

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -5,7 +5,7 @@ package firrtl.util
 import java.io._
 import java.nio.file.Files
 import java.text.SimpleDateFormat
-import java.util.Calendar
+import java.util.{Calendar, Locale}
 
 import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
 import scala.io.Source._
@@ -13,12 +13,20 @@ import BackendCompilationUtilities._
 
 object BackendCompilationUtilities {
 
-  import com.sun.javafx.PlatformUtil
   object OSVersion extends Enumeration {
     type OSVersion = Value
     val Unrecognized, Linux, MacOS, Unix, Windows = Value
   }
   import OSVersion._
+  // The following is borrowed from com.sun.javafx.PlatformUtil to avoid having to install javafx on non-Oracle JVMs.
+  //  import com.sun.javafx.PlatformUtil
+  object PlatformUtil {
+    val os: String = System.getProperty("os.name").toLowerCase(Locale.ENGLISH)
+    def isWindows = os.startsWith("windows")
+    def isLinux = os.startsWith("linux")
+    def isMac = os.startsWith("mac")
+    def isUnix = os.startsWith("unix") || os.startsWith("sunos")
+  }
   val osVersion: OSVersion = {
     if (PlatformUtil.isWindows)
       Windows

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -77,7 +77,7 @@ object BackendCompilationUtilities {
     // Find the OS-specific sub-directory (and any others)
     val includeDir = new File(new File(javaHome).getParentFile, "include")
     val subDirs = if (includeDir.exists() && includeDir.isDirectory) {
-      includeDir.listFiles.filter(_.isDirectory).map(f => getPosixCompatibleAbsolutePath(f.getAbsolutePath)).toSeq
+      includeDir.listFiles.filter(_.isDirectory).map(f => getPosixCompatiblePath(f.getAbsolutePath)).toSeq
     } else {
       Seq[String]()
     }
@@ -97,14 +97,14 @@ object BackendCompilationUtilities {
       else
         a.toString <= b.toString
     }
-    Seq(getPosixCompatibleAbsolutePath(includeDir.getAbsolutePath)) ++ (subDirs sortWith sortByOSSubDir)
+    Seq(getPosixCompatiblePath(includeDir.getAbsolutePath)) ++ (subDirs sortWith sortByOSSubDir)
   }
 
   /** A function to generate Posix compatible paths.
     * @param path - a string possibly containing Windows path delimiters,
     * @return - a string with '/' delimiters.
     */
-  def getPosixCompatibleAbsolutePath(path: String): String = {
+  def getPosixCompatiblePath(path: String): String = {
     if (osVersion == Windows)
       path.replace('\\', '/')
     else
@@ -196,7 +196,7 @@ trait BackendCompilationUtilities {
     val blackBoxVerilogList = {
       val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.FileListName)
       if(list_file.exists()) {
-        Seq("-f", getPosixCompatibleAbsolutePath(list_file.getAbsolutePath))
+        Seq("-f", getPosixCompatiblePath(list_file.getAbsolutePath))
       }
       else {
         Seq.empty[String]
@@ -207,10 +207,10 @@ trait BackendCompilationUtilities {
     val quoteDelimiter = if (osVersion == OSVersion.Windows) "'" else ""
     val command = Seq(
       "verilator",
-      "--cc", s"${getPosixCompatibleAbsolutePath(dir.getAbsolutePath)}/$dutFile.v"
+      "--cc", s"${getPosixCompatiblePath(dir.getAbsolutePath)}/$dutFile.v"
     ) ++
       blackBoxVerilogList ++
-      vSources.flatMap(file => Seq("-v", getPosixCompatibleAbsolutePath(file.getAbsolutePath))) ++
+      vSources.flatMap(file => Seq("-v", getPosixCompatiblePath(file.getAbsolutePath))) ++
       Seq("--assert",
         "-Wno-fatal",
         "-Wno-WIDTH",
@@ -223,8 +223,8 @@ trait BackendCompilationUtilities {
         s"+define+STOP_COND='!$topModule.reset'",
         "-CFLAGS",
         s"""${quoteDelimiter}-Wno-undefined-bool-conversion -O1 -DTOP_TYPE=V$dutFile -DVL_USER_FINISH -include V$dutFile.h${quoteDelimiter}""",
-        "-Mdir", getPosixCompatibleAbsolutePath(dir.getAbsolutePath),
-        "--exe", getPosixCompatibleAbsolutePath(cppHarness.getAbsolutePath))
+        "-Mdir", getPosixCompatiblePath(dir.getAbsolutePath),
+        "--exe", getPosixCompatiblePath(cppHarness.getAbsolutePath))
 
     val commandString = command.mkString(" ")
     System.out.println(s"${commandString}") // scalastyle:ignore regex
@@ -237,14 +237,14 @@ trait BackendCompilationUtilities {
       val bashWriter = new FileWriter(bashFile)
     	bashWriter.write(commandString)
     	bashWriter.close()
-    	Seq("cmd", "/c", "\"", "bash", getPosixCompatibleAbsolutePath(bashFile.getPath), "\"")
+    	Seq("cmd", "/c", "\"", "bash", getPosixCompatiblePath(bashFile.getPath), "\"")
     } else {
       command
     }
   }
 
   def cppToExe(prefix: String, dir: File): ProcessBuilder = {
-    val commandSeq = Seq("make", "-C", getPosixCompatibleAbsolutePath(dir.toString), "-j", "-f", s"V$prefix.mk", s"V$prefix")
+    val commandSeq = Seq("make", "-C", getPosixCompatiblePath(dir.toString), "-j", "-f", s"V$prefix.mk", s"V$prefix")
     // If we're on Windows, put this in a script and return the command required to invoke it.
     // In principle, we should be able to invoke bash directly with the rest of the command as arguments,
     //  but we seem to lose most of our environment variables (notably PATH) if we don't go through this
@@ -255,7 +255,7 @@ trait BackendCompilationUtilities {
       val bashWriter = new FileWriter(bashFile)
 	    bashWriter.write(commandString)
 	    bashWriter.close()
-	    Seq("cmd", "/c", "\"", "bash", getPosixCompatibleAbsolutePath(bashFile.getPath), "\"")
+	    Seq("cmd", "/c", "\"", "bash", getPosixCompatiblePath(bashFile.getPath), "\"")
     } else {
       commandSeq
     }
@@ -336,7 +336,7 @@ trait BackendCompilationUtilities {
       val bashWriter = new FileWriter(bashFile)
 	    bashWriter.write(commandString)
 	    bashWriter.close()
-	    Seq("cmd", "/c", "\"", "bash", getPosixCompatibleAbsolutePath(bashFile.getPath), "\"")
+	    Seq("cmd", "/c", "\"", "bash", getPosixCompatiblePath(bashFile.getPath), "\"")
     } else {
       commandSeq
     }


### PR DESCRIPTION
Add code to generate a shared library suitable for loading into the JVM. This assumes the target system supports `bash` and `make` (i.e., msys/mingw/cygwin on Windows systems).

Perhaps it's time to move this into chisel, where the resources required to actually build something live.
