### PR TITLE
fix renaming of port annotations in Uniquify

### DIFF
--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -355,7 +355,9 @@ object Uniquify extends Transform {
         portTypeMap += (m.name -> uniquePortsType)
 
         ports zip uniquePortsType.fields map { case (p, f) =>
-          renames.rename(p.name, f.name)
+          (Utils.create_exps(p.name, p.tpe) zip Utils.create_exps(f.name, f.tpe)) foreach {
+            case (from, to) => renames.rename(from.serialize, to.serialize)
+          }
           Port(p.info, f.name, p.direction, f.tpe)
         }
       }


### PR DESCRIPTION
Currently `Uniquify` does not recursively add bundle type port renames to `RenameMap`. This PR changes `uniquifyPorts` so that it renames ports the same way as `uniquifyStmt`.

I'm not too familiar with the new annotation system though, so this might be incorrect.