### PR TITLE
[WIP] add clock edge to enable negedge clock for some special design.

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -46,6 +46,11 @@ dir
   | 'output'
   ;
 
+edge
+  : 'posedge'
+  | 'negedge'
+  ;
+
 type 
   : 'UInt' ('<' intLit '>')?
   | 'SInt' ('<' intLit '>')?
@@ -90,7 +95,8 @@ reset_block
 
 stmt
   : 'wire' id ':' type info?
-  | 'reg' id ':' type exp ('with' ':' reset_block)? info?
+  // use edge? for back compatiable
+  | 'reg' id ':' type edge? exp ('with' ':' reset_block)? info?
   | 'mem' id ':' info? INDENT memField* DEDENT
   | 'cmem' id ':' type info?
   | 'smem' id ':' type info?

--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -107,8 +107,8 @@ stmt
   | exp '<-' exp info?
   | exp 'is' 'invalid' info?
   | when
-  | 'stop(' exp exp intLit ')' info?
-  | 'printf(' exp exp StringLit ( exp)* ')' info?
+  | 'stop(' edge? exp exp intLit ')' info?
+  | 'printf(' edge? exp exp StringLit ( exp)* ')' info?
   | 'skip' info?
   | 'attach' '(' exp+ ')' info?
   ;

--- a/src/main/proto/firrtl.proto
+++ b/src/main/proto/firrtl.proto
@@ -38,6 +38,11 @@ message Firrtl {
     }
   }
 
+  enum Edge {
+    REGISTER_EDGE_POSEDGE = 0;
+    REGISTER_EDGE_NEGEDGE = 1;
+  }
+
   message BigInt {
     // 2's complement binary representation
     bytes value = 1;
@@ -94,10 +99,6 @@ message Firrtl {
     }
 
     message Register {
-      enum Edge {
-        REGISTER_EDGE_POSEDGE = 0;
-        REGISTER_EDGE_NEGEDGE = 1;
-      }
       // Required.
       string id = 1;
       // Required.
@@ -173,6 +174,7 @@ message Firrtl {
       Expression clk = 2;
       // Required.
       Expression en = 3;
+      Edge edge = 4;
     }
 
     message Printf {
@@ -183,6 +185,7 @@ message Firrtl {
       Expression clk = 3;
       // Required.
       Expression en = 4;
+      Edge edge = 5;
     }
 
     message Skip {

--- a/src/main/proto/firrtl.proto
+++ b/src/main/proto/firrtl.proto
@@ -94,6 +94,10 @@ message Firrtl {
     }
 
     message Register {
+      enum Edge {
+        REGISTER_EDGE_POSEDGE = 0;
+        REGISTER_EDGE_NEGEDGE = 1;
+      }
       // Required.
       string id = 1;
       // Required.
@@ -102,6 +106,7 @@ message Firrtl {
       Expression clock = 3;
       Expression reset = 4;
       Expression init = 5;
+      Edge edge = 6;
     }
 
     message Memory {

--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -725,9 +725,9 @@ class VerilogEmitter extends SeqTransform with Emitter {
           declare("wire", sx.name, sx.value.tpe, sx.info)
           assign(WRef(sx.name, sx.value.tpe, NodeKind, MALE), sx.value, sx.info)
         case sx: Stop =>
-          simulate(sx.clk, sx.en, Posedge, stop(sx.ret), Some("STOP_COND"), sx.info)
+          simulate(sx.clk, sx.en, sx.edge, stop(sx.ret), Some("STOP_COND"), sx.info)
         case sx: Print =>
-          simulate(sx.clk, sx.en, Posedge, printf(sx.string, sx.args), Some("PRINTF_COND"), sx.info)
+          simulate(sx.clk, sx.en, sx.edge, printf(sx.string, sx.args), Some("PRINTF_COND"), sx.info)
         // If we are emitting an Attach, it must not have been removable in VerilogPrep
         case sx: Attach =>
           // For Synthesis

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -283,10 +283,9 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
         case "inst" => DefInstance(info, ctx.id(0).getText, ctx.id(1).getText)
         case "node" => DefNode(info, ctx.id(0).getText, visitExp(ctx_exp(0)))
 
-        case "stop(" => Stop(info, string2Int(ctx.intLit().getText), visitExp(ctx_exp(0)), visitExp(ctx_exp(1)))
+        case "stop(" => Stop(info, string2Int(ctx.intLit().getText), visitEdge(Option(ctx.edge)), visitExp(ctx_exp(0)), visitExp(ctx_exp(1)))
         case "attach" => Attach(info, ctx_exp map visitExp)
-        case "printf(" => Print(info, visitStringLit(ctx.StringLit), ctx_exp.drop(2).map(visitExp),
-          visitExp(ctx_exp(0)), visitExp(ctx_exp(1)))
+        case "printf(" => Print(info, visitStringLit(ctx.StringLit), ctx_exp.drop(2).map(visitExp), visitEdge(Option(ctx.edge)), visitExp(ctx_exp(0)), visitExp(ctx_exp(1)))
         case "skip" => EmptyStmt
       }
       // If we don't match on the first child, try the next one

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -428,10 +428,10 @@ case class Attach(info: Info, exprs: Seq[Expression]) extends Statement with Has
   def foreachString(f: String => Unit): Unit = Unit
   def foreachInfo(f: Info => Unit): Unit = f(info)
 }
-case class Stop(info: Info, ret: Int, clk: Expression, en: Expression) extends Statement with HasInfo {
-  def serialize: String = s"stop(${clk.serialize}, ${en.serialize}, $ret)" + info.serialize
+case class Stop(info: Info, ret: Int, edge: Edge, clk: Expression, en: Expression) extends Statement with HasInfo {
+  def serialize: String = s"stop(${edge.serialize} ${clk.serialize}, ${en.serialize}, $ret)" + info.serialize
   def mapStmt(f: Statement => Statement): Statement = this
-  def mapExpr(f: Expression => Expression): Statement = Stop(info, ret, f(clk), f(en))
+  def mapExpr(f: Expression => Expression): Statement = Stop(info, ret, edge,f(clk), f(en))
   def mapType(f: Type => Type): Statement = this
   def mapString(f: String => String): Statement = this
   def mapInfo(f: Info => Info): Statement = this.copy(info = f(info))
@@ -445,15 +445,16 @@ case class Print(
     info: Info,
     string: StringLit,
     args: Seq[Expression],
+    edge: Edge,
     clk: Expression,
     en: Expression) extends Statement with HasInfo {
   def serialize: String = {
-    val strs = Seq(clk.serialize, en.serialize, string.escape) ++
+    val strs = Seq(edge.serialize, clk.serialize, en.serialize, string.escape) ++
                (args map (_.serialize))
     "printf(" + (strs mkString ", ") + ")" + info.serialize
   }
   def mapStmt(f: Statement => Statement): Statement = this
-  def mapExpr(f: Expression => Expression): Statement = Print(info, string, args map f, f(clk), f(en))
+  def mapExpr(f: Expression => Expression): Statement = Print(info, string, args map f, edge, f(clk), f(en))
   def mapType(f: Type => Type): Statement = this
   def mapString(f: String => String): Statement = this
   def mapInfo(f: Info => Info): Statement = this.copy(info = f(info))

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -250,19 +250,29 @@ case class DefWire(info: Info, name: String, tpe: Type) extends Statement with I
   def foreachString(f: String => Unit): Unit = f(name)
   def foreachInfo(f: Info => Unit): Unit = f(info)
 }
+
+sealed abstract class Edge extends FirrtlNode
+case object Posedge extends Edge {
+  def serialize: String = "posedge"
+}
+case object Negedge extends Edge {
+  def serialize: String = "negedge"
+}
+
 case class DefRegister(
     info: Info,
     name: String,
     tpe: Type,
+    edge: Edge,
     clock: Expression,
     reset: Expression,
     init: Expression) extends Statement with IsDeclaration {
   def serialize: String =
-    s"reg $name : ${tpe.serialize}, ${clock.serialize} with :" +
+    s"reg $name : ${tpe.serialize}, ${edge.serialize} ${clock.serialize} with :" +
     indent("\n" + s"reset => (${reset.serialize}, ${init.serialize})" + info.serialize)
   def mapStmt(f: Statement => Statement): Statement = this
   def mapExpr(f: Expression => Expression): Statement =
-    DefRegister(info, name, tpe, f(clock), f(reset), f(init))
+    DefRegister(info, name, tpe, edge, f(clock), f(reset), f(init))
   def mapType(f: Type => Type): Statement = this.copy(tpe = f(tpe))
   def mapString(f: String => String): Statement = this.copy(name = f(name))
   def mapInfo(f: Info => Info): Statement = this.copy(info = f(info))

--- a/src/main/scala/firrtl/passes/Checks.scala
+++ b/src/main/scala/firrtl/passes/Checks.scala
@@ -168,7 +168,7 @@ object CheckHighForm extends Pass {
       val info = get_info(s) match {case NoInfo => minfo case x => x}
       s foreach checkName(info, mname, names)
       s match {
-        case DefRegister(info, name, tpe, _, reset, init) =>
+        case DefRegister(info, name, tpe, _, _, reset, init) =>
           if (hasFlip(tpe))
             errors.append(new RegWithFlipException(info, mname, name))
           if (reset.tpe == AsyncResetType && !init.isInstanceOf[Literal])

--- a/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
+++ b/src/main/scala/firrtl/passes/ConvertFixedToSInt.scala
@@ -64,10 +64,10 @@ object ConvertFixedToSInt extends Pass {
         }
       }
       def updateStmtType(s: Statement): Statement = s match {
-        case DefRegister(info, name, tpe, clock, reset, init) =>
+        case DefRegister(info, name, tpe, edge, clock, reset, init) =>
           val newType = toSIntType(tpe)
           types(name) = newType
-          DefRegister(info, name, newType, clock, reset, init) map updateExpType
+          DefRegister(info, name, newType, edge, clock, reset, init) map updateExpType
         case DefWire(info, name, tpe) =>
           val newType = toSIntType(tpe)
           types(name) = newType

--- a/src/main/scala/firrtl/passes/ExpandWhens.scala
+++ b/src/main/scala/firrtl/passes/ExpandWhens.scala
@@ -134,10 +134,10 @@ object ExpandWhens extends Pass {
         EmptyStmt
       // For simulation constructs, update simlist with predicated statement and return EmptyStmt
       case sx: Print =>
-        simlist += (if (weq(p, one)) sx else Print(sx.info, sx.string, sx.args, sx.clk, AND(p, sx.en)))
+        simlist += (if (weq(p, one)) sx else Print(sx.info, sx.string, sx.args, sx.edge,sx.clk, AND(p, sx.en)))
         EmptyStmt
       case sx: Stop =>
-        simlist += (if (weq(p, one)) sx else Stop(sx.info, sx.ret, sx.clk, AND(p, sx.en)))
+        simlist += (if (weq(p, one)) sx else Stop(sx.info, sx.ret, sx.edge, sx.clk, AND(p, sx.en)))
         EmptyStmt
       // Expand conditionally, see comments below
       case sx: Conditionally =>

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -182,7 +182,7 @@ object LowerTypes extends Transform {
           val clock = lowerTypesExp(memDataTypeMap, info, mname)(sx.clock)
           val reset = lowerTypesExp(memDataTypeMap, info, mname)(sx.reset)
           Block((es zip names) zip inits map { case ((e, n), i) =>
-            DefRegister(sx.info, n, e.tpe, clock, reset, i)
+            DefRegister(sx.info, n, e.tpe, sx.edge, clock, reset, i)
           })
       }
       // Could instead just save the type of each Module as it gets processed

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -280,7 +280,7 @@ object Uniquify extends Transform {
               (Utils.create_exps(sx.name, sx.tpe) zip Utils.create_exps(node.name, newType)) foreach {
                 case (from, to) => renames.rename(from.serialize, to.serialize)
               }
-              DefRegister(sx.info, node.name, newType, sx.clock, sx.reset, sx.init)
+              DefRegister(sx.info, node.name, newType, sx.edge, sx.clock, sx.reset, sx.init)
             } else {
               sx
             }

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -127,12 +127,12 @@ object ZeroWidth extends Transform {
         case None => EmptyStmt
         case Some(t) => DefWire(info, name, t)
       }
-    case d @ DefRegister(info, name, tpe, clock, reset, init) =>
+    case d @ DefRegister(info, name, tpe, edge, clock, reset, init) =>
       renames.delete(getRemoved(d))
       removeZero(tpe) match {
         case None => EmptyStmt
         case Some(t) =>
-         DefRegister(info, name, t, onExp(clock), onExp(reset), onExp(init))
+         DefRegister(info, name, t, edge, onExp(clock), onExp(reset), onExp(init))
       }
     case d: DefMemory =>
       renames.delete(getRemoved(d))

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -62,7 +62,7 @@ object VerilogMemDelays extends Pass {
         ((0 until n) foldLeft (wref, Seq[Statement](node))){case ((ex, stmts), i) =>
           val name = namespace newName s"${LowerTypes.loweredName(e)}_pipe_$i"
           val exx = WRef(name, e.tpe, RegKind, ug)
-          (exx, stmts ++ Seq(DefRegister(NoInfo, name, e.tpe, clk, zero, exx)) ++
+          (exx, stmts ++ Seq(DefRegister(NoInfo, name, e.tpe, Posedge, clk, zero, exx)) ++
             (if (i < n - 1 && WrappedExpression.weq(cond, one)) Seq(Connect(NoInfo, exx, ex)) else {
               val condn = namespace newName s"${LowerTypes.loweredName(e)}_en"
               val condx = WRef(condn, BoolType, NodeKind, FEMALE)

--- a/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
@@ -209,7 +209,7 @@ object WiringUtils {
     val root = getRoot(eComp)
     var tpe: Option[Type] = None
     def getType(s: Statement): Statement = s match {
-      case DefRegister(_, n, t, _, _, _) if n == root =>
+      case DefRegister(_, n, t, _, _, _, _) if n == root =>
         tpe = Some(t)
         s
       case DefWire(_, n, t) if n == root =>

--- a/src/main/scala/firrtl/proto/FromProto.scala
+++ b/src/main/scala/firrtl/proto/FromProto.scala
@@ -164,11 +164,11 @@ object FromProto {
   def convert(printf: Firrtl.Statement.Printf, info: Firrtl.SourceInfo): ir.Print = {
     val args = printf.getArgList.asScala.map(convert(_))
     val str = ir.StringLit(printf.getValue)
-    ir.Print(convert(info), str, args, convert(printf.getClk), convert(printf.getEn))
+    ir.Print(convert(info), str, args, convert(printf.getEdge), convert(printf.getClk), convert(printf.getEn))
   }
 
   def convert(stop: Firrtl.Statement.Stop, info: Firrtl.SourceInfo): ir.Stop =
-    ir.Stop(convert(info), stop.getReturnValue, convert(stop.getClk), convert(stop.getEn))
+    ir.Stop(convert(info), stop.getReturnValue, convert(stop.getEdge), convert(stop.getClk), convert(stop.getEn))
 
   def convert(mem: Firrtl.Statement.Memory, info: Firrtl.SourceInfo): ir.DefMemory = {
     val dtype = convert(mem.getType)
@@ -276,10 +276,10 @@ object FromProto {
     ir.Port(ir.NoInfo, port.getId, dir, tpe)
   }
 
-  def convert(edge: Firrtl.Statement.Register.Edge): ir.Edge = {
+  def convert(edge: Firrtl.Edge): ir.Edge = {
     edge match {
-      case Firrtl.Statement.Register.Edge.REGISTER_EDGE_POSEDGE => ir.Posedge
-      case Firrtl.Statement.Register.Edge.REGISTER_EDGE_NEGEDGE => ir.Negedge
+      case Firrtl.Edge.REGISTER_EDGE_POSEDGE => ir.Posedge
+      case Firrtl.Edge.REGISTER_EDGE_NEGEDGE => ir.Negedge
     }
   }
 

--- a/src/main/scala/firrtl/proto/FromProto.scala
+++ b/src/main/scala/firrtl/proto/FromProto.scala
@@ -118,7 +118,7 @@ object FromProto {
     ir.DefWire(convert(info), wire.getId, convert(wire.getType))
 
   def convert(reg: Firrtl.Statement.Register, info: Firrtl.SourceInfo): ir.DefRegister =
-    ir.DefRegister(convert(info), reg.getId, convert(reg.getType), convert(reg.getClock),
+    ir.DefRegister(convert(info), reg.getId, convert(reg.getType), convert(reg.getEdge), convert(reg.getClock),
                    convert(reg.getReset), convert(reg.getInit))
 
   def convert(node: Firrtl.Statement.Node, info: Firrtl.SourceInfo): ir.DefNode =
@@ -274,6 +274,13 @@ object FromProto {
     val dir = convert(port.getDirection)
     val tpe = convert(port.getType)
     ir.Port(ir.NoInfo, port.getId, dir, tpe)
+  }
+
+  def convert(edge: Firrtl.Statement.Register.Edge): ir.Edge = {
+    edge match {
+      case Firrtl.Statement.Register.Edge.REGISTER_EDGE_POSEDGE => ir.Posedge
+      case Firrtl.Statement.Register.Edge.REGISTER_EDGE_NEGEDGE => ir.Negedge
+    }
   }
 
   def convert(param: Firrtl.Module.ExternalModule.Parameter): ir.Param = {

--- a/src/main/scala/firrtl/proto/ToProto.scala
+++ b/src/main/scala/firrtl/proto/ToProto.scala
@@ -212,10 +212,11 @@ object ToProto {
               .setId(name)
               .setType(convert(tpe))
             sb.setWire(wb)
-          case ir.DefRegister(_, name, tpe, clock, reset, init) =>
+          case ir.DefRegister(_, name, tpe, edge, clock, reset, init) =>
             val rb = Firrtl.Statement.Register.newBuilder()
               .setId(name)
               .setType(convert(tpe))
+              .setEdge(convert(edge))
               .setClock(convert(clock))
               .setReset(convert(reset))
               .setInit(convert(init))
@@ -355,6 +356,11 @@ object ToProto {
         val vtb = convert(vtpe)
         tb.setVectorType(vtb)
     }
+  }
+
+  def convert(edge: ir.Edge): Firrtl.Statement.Register.Edge = edge match {
+    case ir.Posedge => Firrtl.Statement.Register.Edge.REGISTER_EDGE_POSEDGE
+    case ir.Negedge => Firrtl.Statement.Register.Edge.REGISTER_EDGE_NEGEDGE
   }
 
   def convert(direction: ir.Direction): Firrtl.Port.Direction = direction match {

--- a/src/main/scala/firrtl/proto/ToProto.scala
+++ b/src/main/scala/firrtl/proto/ToProto.scala
@@ -244,16 +244,18 @@ object ToProto {
             cs.foreach(wb.addConsequent)
             as.foreach(wb.addOtherwise)
             sb.setWhen(wb)
-          case ir.Print(_, string, args, clk, en) =>
+          case ir.Print(_, string, args, edge, clk, en) =>
             val pb = Firrtl.Statement.Printf.newBuilder()
               .setValue(string.string)
+              .setEdge(convert(edge))
               .setClk(convert(clk))
               .setEn(convert(en))
             args.foreach(a => pb.addArg(convert(a)))
             sb.setPrintf(pb)
-          case ir.Stop(_, ret, clk, en) =>
+          case ir.Stop(_, ret, edge, clk, en) =>
             val stopb = Firrtl.Statement.Stop.newBuilder()
               .setReturnValue(ret)
+              .setEdge(convert(edge))
               .setClk(convert(clk))
               .setEn(convert(en))
             sb.setStop(stopb)
@@ -358,9 +360,9 @@ object ToProto {
     }
   }
 
-  def convert(edge: ir.Edge): Firrtl.Statement.Register.Edge = edge match {
-    case ir.Posedge => Firrtl.Statement.Register.Edge.REGISTER_EDGE_POSEDGE
-    case ir.Negedge => Firrtl.Statement.Register.Edge.REGISTER_EDGE_NEGEDGE
+  def convert(edge: ir.Edge): Firrtl.Edge = edge match {
+    case ir.Posedge => Firrtl.Edge.REGISTER_EDGE_POSEDGE
+    case ir.Negedge => Firrtl.Edge.REGISTER_EDGE_NEGEDGE
   }
 
   def convert(direction: ir.Direction): Firrtl.Port.Direction = direction match {

--- a/src/main/scala/firrtl/transforms/CompleteClockEdge.scala
+++ b/src/main/scala/firrtl/transforms/CompleteClockEdge.scala
@@ -1,0 +1,30 @@
+// See LICENSE for license details.
+
+package firrtl.transforms
+
+import firrtl._
+import firrtl.ir._
+import firrtl.annotations._
+
+case class ClockEdgeAnnotation(register: ReferenceTarget, edge: Edge) extends SingleTargetAnnotation[ReferenceTarget] {
+  override val target: ReferenceTarget = register
+
+  override def duplicate(n: ReferenceTarget): Annotation = ClockEdgeAnnotation(register, edge: Edge)
+}
+
+class CompleteClockEdge extends Transform {
+  override def inputForm: CircuitForm = LowForm
+
+  override def outputForm: CircuitForm = LowForm
+
+  def addEdge(annoMap: Map[String, Edge])(s: Statement): Statement = s.mapStmt {
+    case r: DefRegister =>
+      annoMap.get(r.name) match {
+        case Some(e) => r.copy(edge = e)
+        case None => r
+      }
+    case s: Statement => s.mapStmt(addEdge(annoMap))
+  }
+
+  def execute(state: CircuitState): CircuitState = state.copy(state.circuit.copy(modules = state.circuit.modules.map(_.mapStmt(addEdge(state.annotations.collect { case ClockEdgeAnnotation(t, e) => t.name -> e }.toMap)))))
+}

--- a/src/main/scala/firrtl/transforms/CompleteClockEdge.scala
+++ b/src/main/scala/firrtl/transforms/CompleteClockEdge.scala
@@ -13,9 +13,9 @@ case class ClockEdgeAnnotation(register: ReferenceTarget, edge: Edge) extends Si
 }
 
 class CompleteClockEdge extends Transform {
-  override def inputForm: CircuitForm = LowForm
+  override def inputForm: CircuitForm = MidForm
 
-  override def outputForm: CircuitForm = LowForm
+  override def outputForm: CircuitForm = MidForm
 
   def addEdge(annoMap: Map[String, Edge])(s: Statement): Statement = s.mapStmt {
     case r: DefRegister =>

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -96,7 +96,7 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
     def getDeps(expr: Expression): Seq[LogicNode] = getDepsImpl(mod.name, instMap)(expr)
 
     def onStmt(stmt: Statement): Unit = stmt match {
-      case DefRegister(_, name, _, clock, reset, init) =>
+      case DefRegister(_, name, _, _, clock, reset, init) =>
         val node = LogicNode(mod.name, name)
         depGraph.addVertex(node)
         Seq(clock, reset, init).flatMap(getDeps(_)).foreach(ref => depGraph.addPairWithEdge(node, ref))

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -128,9 +128,9 @@ class DeadCodeElimination extends Transform with ResolvedAnnotationPaths with Re
         val node = getDeps(loc) match { case Seq(elt) => elt }
         getDeps(expr).foreach(ref => depGraph.addPairWithEdge(node, ref))
       // Simulation constructs are treated as top-level outputs
-      case Stop(_,_, clk, en) =>
+      case Stop(_, _, _, clk, en) =>
         Seq(clk, en).flatMap(getDeps(_)).foreach(ref => depGraph.addPairWithEdge(circuitSink, ref))
-      case Print(_, _, args, clk, en) =>
+      case Print(_, _, args, _, clk, en) =>
         (args :+ clk :+ en).flatMap(getDeps(_)).foreach(ref => depGraph.addPairWithEdge(circuitSink, ref))
       case Block(stmts) => stmts.foreach(onStmt(_))
       case ignore @ (_: IsInvalid | _: WDefInstance | EmptyStmt) => // do nothing

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -315,9 +315,9 @@ object DedupModules {
           builder ++= "\n" + ("  " * nindent)
           builder ++= "else :\n"
           serialize(builder, nindent + 1)(alt)
-        case Print(info, string, args, clk, en) =>
+        case Print(info, string, args, edge, clk, en) =>
           builder ++= ("  " * nindent)
-          val strs = Seq(clk.serialize, en.serialize, string.string) ++
+          val strs = Seq(edge.serialize, clk.serialize, en.serialize, string.string) ++
             (args map (_.serialize))
           builder ++= "printf(" + (strs mkString ", ") + ")" + info.serialize
         case other: Statement =>

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -80,7 +80,7 @@ object FlattenRegUpdate {
     }
 
     def onStmt(stmt: Statement): Statement = stmt.map(onStmt) match {
-      case reg @ DefRegister(_, rname, _,_, resetCond, _) =>
+      case reg @ DefRegister(_, rname, _, _, _, resetCond, _) =>
         assert(resetCond.tpe == AsyncResetType || resetCond == Utils.zero,
           "Synchronous reset should have already been made explicit!")
         val ref = WRef(reg)

--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -323,11 +323,11 @@ class GroupComponents extends firrtl.Transform {
         exprs.tail map onExpr(getWRef(exprs.head))
       case Connect(_, loc, expr) =>
         onExpr(getWRef(loc))(expr)
-      case q @ Stop(_,_, clk, en) =>
+      case q @ Stop(_, _, _, clk, en) =>
         val simName = simNamespace.newTemp
         simulations(simName) = q
         Seq(clk, en) map onExpr(WRef(simName))
-      case q @ Print(_, _, args, clk, en) =>
+      case q @ Print(_, _, args, _, clk, en) =>
         val simName = simNamespace.newTemp
         simulations(simName) = q
         (args :+ clk :+ en) map onExpr(WRef(simName))

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -22,7 +22,7 @@ class RemoveReset extends Transform {
     val resets = mutable.HashMap.empty[String, Reset]
     def onStmt(stmt: Statement): Statement = {
       stmt match {
-        case reg @ DefRegister(_, rname, _, _, reset, init)
+        case reg @ DefRegister(_, rname, _, _, _, reset, init)
             if reset != Utils.zero && reset.tpe != AsyncResetType =>
           // Add register reset to map
           resets(rname) = Reset(reset, init)

--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -57,7 +57,7 @@ class InfoSpec extends FirrtlFlatSpec {
       |r <= or(n, r)
       |y <= r""".stripMargin
     )
-    result should containTree { case DefRegister(Info1, "r", _,_,_,_) => true }
+    result should containTree { case DefRegister(Info1, "r", _, _, _, _, _) => true }
     result should containLine (s"reg [7:0] r; //$Info1")
     result should containTree { case DefNode(Info2, "w", _) => true }
     result should containLine (s"wire [7:0] w; //$Info2") // Node "w" declaration in Verilog

--- a/src/test/scala/firrtlTests/LowerTypesSpec.scala
+++ b/src/test/scala/firrtlTests/LowerTypesSpec.scala
@@ -94,7 +94,7 @@ class LowerTypesSpec extends FirrtlFlatSpec {
       """.stripMargin
     val expected = Seq("w", "x_a", "x_b", "y_0", "y_1", "y_2", "y_3", "z_0_c_d",
       "z_0_c_e", "z_0_f_0", "z_0_f_1", "z_1_c_d", "z_1_c_e", "z_1_f_0",
-      "z_1_f_1") map (x => s"reg $x : UInt<1>, clock with :") map normalized
+      "z_1_f_1") map (x => s"reg $x : UInt<1>, posedge clock with :") map normalized
 
     executeTest(input, expected)
   }
@@ -106,14 +106,14 @@ class LowerTypesSpec extends FirrtlFlatSpec {
        |    input clock : Clock
        |    input reset : UInt<1>
        |    input init : { a : UInt<1>, b : UInt<1>}[2]
-       |    reg x : { a : UInt<1>, b : UInt<1>}[2], clock with :
+       |    reg x : { a : UInt<1>, b : UInt<1>}[2], posedge clock with :
        |      reset => (reset, init)
      """.stripMargin
     val expected = Seq(
-      "reg x_0_a : UInt<1>, clock with :", "reset => (reset, init_0_a)",
-      "reg x_0_b : UInt<1>, clock with :", "reset => (reset, init_0_b)",
-      "reg x_1_a : UInt<1>, clock with :", "reset => (reset, init_1_a)",
-      "reg x_1_b : UInt<1>, clock with :", "reset => (reset, init_1_b)"
+      "reg x_0_a : UInt<1>, posedge clock with :", "reset => (reset, init_0_a)",
+      "reg x_0_b : UInt<1>, posedge clock with :", "reset => (reset, init_0_b)",
+      "reg x_1_a : UInt<1>, posedge clock with :", "reset => (reset, init_1_a)",
+      "reg x_1_b : UInt<1>, posedge clock with :", "reset => (reset, init_1_b)"
     ) map normalized
 
     executeTest(input, expected)
@@ -126,11 +126,11 @@ class LowerTypesSpec extends FirrtlFlatSpec {
         |    input clock : Clock[2]
         |    input reset : { a : UInt<1>, b : UInt<1>}
         |    input init : { a : UInt<4>, b : { c : UInt<4>, d : UInt<4>}[2]}[4]
-        |    reg foo : UInt<4>, clock[1], with :
+        |    reg foo : UInt<4>, posedge clock[1], with :
         |      reset => (reset.a, init[3].b[1].d)
       """.stripMargin
     val expected = Seq(
-      "reg foo : UInt<4>, clock_1 with :",
+      "reg foo : UInt<4>, posedge clock_1 with :",
       "reset => (reset_a, init_3_b_1_d)"
     ) map normalized
 

--- a/src/test/scala/firrtlTests/UniquifySpec.scala
+++ b/src/test/scala/firrtlTests/UniquifySpec.scala
@@ -70,14 +70,14 @@ class UniquifySpec extends FirrtlFlatSpec {
       """circuit Test :
         |  module Test :
         |    input clock : Clock
-        |    reg a : { b : UInt<1>, c : { d : UInt<2>, e : UInt<3>}[2], c_1_e : UInt<4>}[2], clock
-        |    reg a_0_c_ : UInt<5>, clock
-        |    reg a__0 : UInt<6>, clock
+        |    reg a : { b : UInt<1>, c : { d : UInt<2>, e : UInt<3>}[2], c_1_e : UInt<4>}[2], posedge clock
+        |    reg a_0_c_ : UInt<5>, posedge clock
+        |    reg a__0 : UInt<6>, posedge clock
       """.stripMargin
     val expected = Seq(
-      "reg a__ : { b : UInt<1>, c_ : { d : UInt<2>, e : UInt<3>}[2], c_1_e : UInt<4>}[2], clock with :",
-      "reg a_0_c_ : UInt<5>, clock with :",
-      "reg a__0 : UInt<6>, clock with :") map normalized
+      "reg a__ : { b : UInt<1>, c_ : { d : UInt<2>, e : UInt<3>}[2], c_1_e : UInt<4>}[2], posedge clock with :",
+      "reg a_0_c_ : UInt<5>, posedge clock with :",
+      "reg a__0 : UInt<6>, posedge clock with :") map normalized
 
     executeTest(input, expected)
   }
@@ -87,7 +87,7 @@ class UniquifySpec extends FirrtlFlatSpec {
       """circuit Test :
         |  module Test :
         |    input clock : Clock
-        |    reg x : { b : UInt<1>, c : { d : UInt<2>, e : UInt<3>}[2], c_1_e : UInt<4>}[2], clock
+        |    reg x : { b : UInt<1>, c : { d : UInt<2>, e : UInt<3>}[2], c_1_e : UInt<4>}[2], posedge clock
         |    node a = x
         |    node a_0_c_ = a[0].b
         |    node a__0  = a[1].c[0].d
@@ -108,11 +108,11 @@ class UniquifySpec extends FirrtlFlatSpec {
         |    input reset_a : UInt<1>
         |    input init : { a : UInt<4>, b : { c : UInt<4>, d : UInt<4>}[2], b_1_c : UInt<4>}[4]
         |    input init_0_a : UInt<4>
-        |    reg foo : UInt<4>, clock[1], with :
+        |    reg foo : UInt<4>, posedge clock[1], with :
         |      reset => (reset.a, init[3].b[1].d)
       """.stripMargin
     val expected = Seq(
-      "reg foo : UInt<4>, clock_[1] with :",
+      "reg foo : UInt<4>, posedge clock_[1] with :",
       "reset => (reset_.a, init_[3].b_[1].d)"
     ) map normalized
 


### PR DESCRIPTION
This PR is trying to give a native clock edge support for clock, enable the `negedge clock` in the special module like `clockgen`.
[some tools](https://github.com/ucb-bar/barstools/blob/82636b3ff43ecf6a0f0a7d46ebc2456b31e9703f/macros/src/main/scala/Utils.scala#L211) was used to generate a negedge sensitive clock, which add a `not(exp)` to clock. This work in digital logic. But in case of some synthesis tool regard the inverted clock as a new clock, I add `Edge` as an IR into the firrtl, trying to fix this fundamentally.