### PR TITLE
Ignore annotations when deduping modules

### DIFF
--- a/src/main/scala/firrtl/analyses/InstanceGraph.scala
+++ b/src/main/scala/firrtl/analyses/InstanceGraph.scala
@@ -71,7 +71,7 @@ class InstanceGraph(c: Circuit) {
     */
   def findInstancesInHierarchy(module: String): Seq[Seq[WDefInstance]] = {
     val instances = graph.getVertices.filter(_.module == module).toSeq
-    instances flatMap { i => fullHierarchy(i) }
+    instances flatMap { i => fullHierarchy.getOrElse(i, Seq.empty) }
   }
 
   /** An [[firrtl.graph.EulerTour EulerTour]] representation of the [[firrtl.graph.DiGraph DiGraph]] */


### PR DESCRIPTION
Differing annotations do not necessarily mean that two modules are different. For annotations that do cause changes to a module there is `ResolvedAnnotationPaths`.