### PR TITLE
Add space, s/Github/GitHub/ in DontTouchException

### DIFF
--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -19,9 +19,9 @@ case class DontTouchAnnotation(target: ReferenceTarget) extends SingleTargetAnno
 
 object DontTouchAnnotation {
   class DontTouchNotFoundException(module: String, component: String) extends PassException(
-    s"Target marked dontTouch ($module.$component) not found!\n" +
-    "It was probably accidentally deleted. Please check that your custom transforms are not" +
-    "responsible and then file an issue on Github."
+    s"""|Target marked dontTouch ($module.$component) not found!
+        |It was probably accidentally deleted. Please check that your custom transforms are not responsible and then
+        |file an issue on GitHub: https://github.com/freechipsproject/firrtl/issues/new""".stripMargin
   )
 
   def errorNotFound(module: String, component: String) =


### PR DESCRIPTION
This adds a missing space in `DontTouchException` and does some additional cleanup on the message.

Previously, you would get a message with `"notresponsible"`:
```
[error] (run-main-c) firrtl.transforms.DontTouchAnnotation$DontTouchNotFoundException: Target marked dontTouch (Top3anon2.y) not found!
[error] It was probably accidentally deleted. Please check that your custom transforms are notresponsible and then file an issue on Github.

```