### PR TITLE
Collapse Vectors of Single Bits to Multi-bit UInts

### DIFF
--- a/src/main/scala/firrtl/annotations/Target.scala
+++ b/src/main/scala/firrtl/annotations/Target.scala
@@ -25,6 +25,12 @@ sealed trait Target extends Named {
   /** @return Module name, if it exists */
   def moduleOpt: Option[String]
 
+  /** @return true if this is the top-module, false if this cannot be determined */
+  def isTop: Boolean = (circuitOpt, moduleOpt) match {
+    case (Some(a), Some(b)) => a == b
+    case _                  => false
+  }
+
   /** @return [[Target]] tokens */
   def tokens: Seq[TargetToken]
 

--- a/src/main/scala/firrtl/annotations/Target.scala
+++ b/src/main/scala/firrtl/annotations/Target.scala
@@ -119,9 +119,13 @@ sealed trait Target extends Named {
 
 object Target {
   def asTarget(m: ModuleTarget)(e: Expression): ReferenceTarget = e match {
-    case r: ir.Reference => m.ref(r.name)
-    case s: ir.SubIndex  => asTarget(m)(s.expr).index(s.value)
-    case s: ir.SubField  => asTarget(m)(s.expr).field(s.name)
+    case r: ir.Reference =>
+      val tokens = toTargetTokens(r.name)
+      (tokens.head, tokens.tail) match {
+        case (car: Ref, cdr) => m.ref(car.value).copy(component=cdr)
+      }
+    case s: ir.SubIndex => asTarget(m)(s.expr).index(s.value)
+    case s: ir.SubField => asTarget(m)(s.expr).field(s.name)
     case s: ir.SubAccess => asTarget(m)(s.expr).field("@" + s.index.serialize)
     case d: DoPrim       => m.ref("@" + d.serialize)
     case d: Mux          => m.ref("@" + d.serialize)

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -37,6 +37,7 @@ import scala.collection.mutable
   */
 object LowerTypes extends Transform with DependencyAPIMigration {
   override def prerequisites: Seq[TransformDependency] = Seq(
+    Dependency[firrtl.transforms.CollapseVectors], // vectors of bools are collapsed to UInts
     Dependency(RemoveAccesses), // we require all SubAccess nodes to have been removed
     Dependency(CheckTypes), // we require all types to be correct
     Dependency(InferTypes), // we require instance types to be resolved (i.e., DefInstance.tpe != UnknownType)

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -70,6 +70,7 @@ object Forms {
 
   val LowForm: Seq[TransformDependency] = MidForm ++
     Seq(
+      Dependency[firrtl.transforms.CollapseVectors],
       Dependency(passes.LowerTypes),
       Dependency(passes.Legalize),
       Dependency(firrtl.transforms.RemoveReset),

--- a/src/main/scala/firrtl/transforms/CollapseVectors.scala
+++ b/src/main/scala/firrtl/transforms/CollapseVectors.scala
@@ -1,0 +1,365 @@
+// See LICENSE For license details.
+
+package firrtl.transforms
+
+import firrtl._
+import firrtl.annotations.{CircuitTarget, ModuleTarget, ReferenceTarget, Target, TargetToken}
+import firrtl.Mappers._
+
+import scala.collection.mutable
+
+/** Collapse vectors of single-bit UInts into one UInt. Ports of the top module will *not* be collapsed.
+  *
+  * Concretely this is doing conversions of:
+  * {{{
+  * circuit Foo:
+  *   module Foo:
+  *     output out: UInt<1>[1]
+  *     wire w: UInt<1>[1]
+  *     w[0] <= UInt<1>(0)
+  *     out[0] <= w[0]
+  * }}}
+  *
+  * Into:
+  * {{{
+  * circuit Foo:
+  *   module Foo:
+  *     output out: UInt<1>[1]
+  *     wire w: UInt<1>
+  *     out[0] <= bits(w, 0, 0)
+  *     w <= UInt<1>("h0")
+  * }}}
+  */
+class CollapseVectors extends Transform {
+
+  override val inputForm = UnknownForm
+  override val outputForm = UnknownForm
+
+  override val prerequisites = firrtl.stage.Forms.MidForm
+
+  override val optionalPrerequisites = Seq.empty
+
+  override val dependents = Seq.empty
+
+  override def invalidates(a: Transform): Boolean = a match {
+    case passes.InferTypes => true
+    case _                 => false
+  }
+
+  private type BitAssignments = mutable.HashMap[BigInt, ir.Expression]
+
+  /** Convert a ReferenceTarget with some associate Type to a WRef. This is useful for situations where you have a target,
+    * but need to pass it to something that expects an expression, e.g., create_exps.
+    */
+  private def referenceTargetToWRef(target: ReferenceTarget, tpe: ir.Type): WRef =
+    WRef(n =
+           target
+             .tokens
+             .map {
+               case TargetToken.Ref(r) => r
+               case TargetToken.Field(f) => s".$f"
+               case TargetToken.Index(v) => s"[$v]" }
+             .mkString(""),
+         t = tpe )
+
+  private def onExpression(a: ir.Expression)
+                          (implicit renames: RenameMap,
+                           target: ModuleTarget,
+                           instances: mutable.Map[ReferenceTarget, ModuleTarget]): ir.Expression = a match {
+    case rhs@ WSubIndex(_, _, ir.UIntType(ir.IntWidth(w)), SourceFlow) if w == 1 => {
+      /* Type will be wrong for rhs.expr, but is cleaned up by InferTypes */
+      lazy val tmp = ir.DoPrim(PrimOps.Bits, Seq(rhs.expr), Seq(rhs.value, rhs.value), ir.UIntType(ir.IntWidth(1)))
+      Utils.kind(a) match {
+        case _@ InstanceKind => Utils.splitRef(a) match {
+          case (car, cdr) if renames.get(Target.asTarget(instances(target.ref(car.name)))(cdr)).nonEmpty =>
+            logger.debug(s"  - Replacing RHS usage of '${a.serialize}' with primop '${tmp.serialize}'")
+            tmp
+          case _ => a
+        }
+        case _ if renames.get(Target.asTarget(target)(a)).nonEmpty =>
+          logger.debug(s"  - Replacing RHS usage of '${a.serialize}' with primop '${tmp.serialize}'")
+          tmp
+        case _ => a
+      }
+    }
+    case _ => a.map(onExpression)
+  }
+
+  private def emitCat(lhs: ir.Expression,
+                      rhs: Seq[ir.Expression])
+                     (implicit namespace: Namespace): ir.Statement = {
+    logger.debug(s"  - Replacing connections to '${lhs.serialize}' with concatenations of temporaries:")
+    rhs.foreach(a => logger.debug(s"    - ${a.serialize}"))
+    /* The type will have an unknown width due to seqCat implementation */
+    ir.Connect(ir.NoInfo, lhs, seqCat(rhs))
+  }
+
+  /** For a LHS expression and a set of individual bit assignments, emit a statement that connects the individual bits to
+    * the LHS.
+    * @param lhs the left-hand side expression
+    * @param bits a mapping of indices to expressions representing the assignments to each bit
+    * @param namespace a namespace that will be used to generate temporary names
+    * @param renames a list of circuit components that have been renamed
+    * @param target the current module
+    * @param instances a mapping of instance names to module names
+    * @return a statement representing the connection (this may be multiple statements in a block)
+    */
+  private def emitCollapsed(lhs: ir.Expression,
+                            bits: BitAssignments)
+                           (implicit namespace: Namespace,
+                            renames: RenameMap,
+                            target: ModuleTarget,
+                            instances: mutable.Map[ReferenceTarget, ModuleTarget]): ir.Statement = {
+
+    /* Get the bit assignments in order by their index */
+    val orderedBits = bits.toSeq.sortBy(_._1)
+
+    /* Examine each of the bit assignments (in order) and try to determine if certain special cases are possible. These
+     * cases are:
+     *
+     *   1. Every bit is invalidated
+     *   2. Every bit is assigned to a literal
+     *   3. Every bit is assigned to the same bit in another 1-bit vector that was collapsed
+     */
+    val (isInv, isLit, isVec) = {
+      var isInvalid, isLiteral, isOrderedSubIndex = true
+      orderedBits.foreach {
+        case (_, WInvalid) =>
+          isLiteral = false
+          isOrderedSubIndex = false
+        case (_, _: ir.UIntLiteral) =>
+          isInvalid = false
+          isOrderedSubIndex = false
+        case (i, rhs @ WSubIndex(expr, j, ir.UIntType(ir.IntWidth(w)), _)) => expr.tpe match {
+          case ir.VectorType(_, s) if i == j && w == 1 && s == bits.size => Utils.kind(rhs) match {
+            case InstanceKind => Utils.splitRef(rhs) match {
+              case (car, cdr) if renames.get(Target.asTarget(instances(target.ref(car.name)))(cdr)).nonEmpty =>
+                isLiteral = false
+                isInvalid = false
+              case _ =>
+                isLiteral = false
+                isInvalid = false
+                isOrderedSubIndex = false
+            }
+            case _ if renames.get(Target.asTarget(target)(rhs)).nonEmpty =>
+              isLiteral = false
+              isInvalid = false
+            case _ =>
+              isLiteral = false
+              isInvalid = false
+              isOrderedSubIndex = false
+          }
+          case _ =>
+            isInvalid = false
+            isLiteral = false
+            isOrderedSubIndex = false
+        }
+        case _ =>
+          isInvalid = false
+          isLiteral = false
+          isOrderedSubIndex = false
+      }
+      (isInvalid, isLiteral, isOrderedSubIndex)
+    }
+
+    /* For the special cases above, handle the connections in the following way:
+     *
+     *   1. If every bit in invalidated, invalidate the entire UInt.
+     *   2. If every bit is connected to a literal, collapse the individual literals to one literal and connect to that.
+     *   3. If both the LHS and RHS were collapsed, directly connect the two.
+     *
+     * If none of these are true, then crack the LHS into node/wire temporaries, do the individual connections, and
+     * concatenate all the temporaries together to do the assignment.
+     */
+    (isInv, isLit, isVec) match {
+      case (true, _, _) =>
+        logger.debug(s"  - Invalidating '${lhs.serialize}' as every bit is invalid")
+        ir.IsInvalid(ir.NoInfo, lhs)
+      case (_, true, _) =>
+        val lit = {
+          val binaryValue = orderedBits.map{ case (_, ir.UIntLiteral(value, _)) => value }.mkString("")
+          ir.UIntLiteral(BigInt(binaryValue, 2))
+        }
+        logger.debug(s"  - Connecting '${lhs.serialize}' to '${lit.serialize}' as every bit is connected to a literal")
+        ir.Connect(ir.NoInfo, lhs, lit)
+      case (_, _, true) =>
+        val ref = bits.head._2 match { case WSubIndex(expr, _, _, _) => expr }
+        logger.debug(s"  - Directly connecting '${lhs.serialize}' to '${ref.serialize}'")
+        ir.Connect(ir.NoInfo, lhs, ref)
+      case _ =>
+        logger.debug(s"  - '${lhs.serialize}' contains sub-word assignments, will crack into nodes/wires...")
+        bits.toSeq.sortBy(_._1).foldLeft(Seq.empty[ir.Statement], Seq.empty[ir.Expression]) {
+          case ((s, e), (i, WInvalid)) =>
+            val tmpName = namespace.newName(Utils.niceName(ir.SubIndex(lhs, i.intValue, ir.UnknownType)))
+            val tmp = ir.DefWire(ir.NoInfo, tmpName, ir.UIntType(ir.IntWidth(BigInt(1))))
+            val invalid = ir.IsInvalid(ir.NoInfo, WRef(tmp))
+            logger.debug(s"  - '${lhs.serialize}[$i]' will become node '$tmpName'")
+            (s :+ tmp :+ invalid, WRef(tmp) +: e)
+          case ((s, e), (i, rhs)) =>
+            val tmpName = namespace.newName(Utils.niceName(ir.SubIndex(lhs, i.intValue, ir.UnknownType)))
+            logger.debug(s"  - '${lhs.serialize}[$i]' will become wire '$tmpName'")
+            val tmp = ir.DefNode(ir.NoInfo, tmpName, onExpression(rhs))
+            (s :+ tmp, WRef(tmp) +: e)
+        } match { case (s, e) => ir.Block(s :+ emitCat(lhs, e)) }
+    }
+  }
+
+  private def onStatement(a: ir.Statement)
+                         (implicit renames: RenameMap,
+                          target: ModuleTarget,
+                          namespace: Namespace,
+                          bitAssignments: mutable.Map[ReferenceTarget, BitAssignments],
+                          instances: mutable.Map[ReferenceTarget, ModuleTarget]): ir.Statement = a match {
+    /* As instances are found, update a mapping of instance references to modules. This is needed to disambiguate references
+     * pointing at internal components or submodule ports.
+     */
+    case WDefInstance(_, name, module, _) =>
+      instances(target.ref(name)) = target.targetParent.module(module)
+      a
+    /* Connections that involve a LHS with a subindex with a width of one may have been collapsed. If these have, then the
+     * subindex connection needs to be converted to an assignment to a temporary node. The final connection to the
+     * collapsed LHS is delayed until all temporary nodes have been assigned. This final connection is then handled with
+     * a concatenation.
+     */
+    case a@ ir.Connect(_, lhs@ WSubIndex(_, _, ir.UIntType(ir.IntWidth(w)), _), rhs) if w == 1 => Utils.kind(lhs) match {
+      case InstanceKind => Utils.splitRef(lhs) match {
+        case (car, cdr) if renames.get(Target.asTarget(instances(target.ref(car.name)))(cdr)).nonEmpty =>
+          val bits = bitAssignments.getOrElseUpdate(Target.asTarget(target)(lhs.expr), new BitAssignments)
+          bits(lhs.value) = onExpression(rhs)
+          lhs.expr.tpe match {
+            case ir.VectorType(_, s) if bits.size == s => emitCollapsed(lhs.expr, bits)
+            case _: ir.VectorType => ir.EmptyStmt
+          }
+        case _ => a.copy(expr = onExpression(rhs))
+      }
+      case _ if renames.get(Target.asTarget(target)(lhs)).nonEmpty =>
+        val bits = bitAssignments.getOrElseUpdate(Target.asTarget(target)(lhs.expr), new BitAssignments)
+        bits(lhs.value) = rhs
+        lhs.expr.tpe match {
+          case ir.VectorType(_, s) if bits.size == s => emitCollapsed(lhs.expr, bits)
+          case _: ir.VectorType => ir.EmptyStmt
+        }
+      case _ => a.copy(expr = onExpression(rhs))
+    }
+    /* Invalidations are handled in the same was as connections, except that the bit invalidation is handled via a temporary
+     * wire. The final connection can either happen in the connect case above or in the invalid case here.
+     * @todo There should be a way to DRY this out with the connect case above.
+     */
+    case a@ ir.IsInvalid(_, lhs@ WSubIndex(_, _, ir.UIntType(ir.IntWidth(w)), _)) if w == 1 => Utils.kind(lhs) match {
+      case InstanceKind => Utils.splitRef(lhs) match {
+        case (car, cdr) if renames.get(Target.asTarget(instances(target.ref(car.name)))(cdr)).nonEmpty =>
+          val bits = bitAssignments.getOrElseUpdate(Target.asTarget(target)(lhs.expr), new BitAssignments)
+          bits(lhs.value) = WInvalid
+          lhs.expr.tpe match {
+            case ir.VectorType(_, s) if bits.size == s => emitCollapsed(lhs.expr, bits)
+            case _: ir.VectorType => ir.EmptyStmt
+          }
+        case _ => a
+      }
+      case _ if renames.get(Target.asTarget(target)(lhs)).nonEmpty =>
+        val bits = bitAssignments.getOrElseUpdate(Target.asTarget(target)(lhs.expr), new BitAssignments)
+        bits(lhs.value) = WInvalid
+        /* Only emit once the whole thing is full! */
+        lhs.expr.tpe match {
+          case ir.VectorType(_, s) if bits.size == s => emitCollapsed(lhs.expr, bits)
+          case _: ir.VectorType => ir.EmptyStmt
+        }
+      case _ => a
+    }
+    /* The expression of a node is run through onType to possibly add it to the rename map. */
+    case n@ ir.DefNode(_, _, expr) =>
+      expr.map(onType(target.ref(n.name)))
+      n.map(onExpression)
+    /* Memories have extra fields that need to be renamed in addition to their type which should be separately updated. */
+    case m: ir.DefMemory =>
+      (m.readers.map(r => target.ref(m.name).field(r).field("data")) ++
+         m.writers.flatMap(w => Seq(target.ref(m.name).field(w).field("data"),
+                                    target.ref(m.name).field(w).field("mask"))) ++
+         m.readwriters.flatMap(rw => Seq(target.ref(m.name).field(rw).field("rdata"),
+                                         target.ref(m.name).field(rw).field("wdata"),
+                                         target.ref(m.name).field(rw).field("wmask"))))
+        .map(x => m.map(onType(x)))
+      m.map(onType(target.ref(m.name)))
+    /* This covers the case of Registers and Wires which do not require special casing like nodes and memories */
+    case d: ir.IsDeclaration => d.map(onType(target.ref(d.name))).map(onExpression)
+    case a => a.map(onStatement).map(onExpression)
+  }
+
+  private def onType(target: ReferenceTarget)
+                    (t: ir.Type)
+                    (implicit renames: RenameMap): ir.Type = t match {
+    case tx@ ir.VectorType(ir.UIntType(ir.IntWidth(w)), s) if w == 1 =>
+      logger.debug(s"  - Found vector of UInt<1> to collapse: ${target.serialize}")
+      Some(referenceTargetToWRef(target, tx))      // 1. Convert to WRef, then wrap in Some so we can map
+        .map(Utils.create_exps)                    // 2. Calculate all possible expressions.
+        .get                                       // 3. Option[Seq[Expression]] => Seq[Expression]
+        .map(Target.asTarget(target.moduleTarget)) // 4. Convert the expressions back to targets.
+        .foreach(renames.delete)                   // 5. Update the renames, deleting subindex
+      ir.UIntType(ir.IntWidth(s))                  // 6. Return the flattened type
+    case tx: ir.VectorType =>
+      /* TODO: Improve the performance of this so it doesn't walk every element of the vector */
+      Seq
+        .tabulate(tx.size)(target.index)           // 1. Populate one target for every index in the vector.
+        .map(targetx => tx.map(onType(targetx)))   // 2. Map over this type (redundant work, but populates renames).
+        .headOption                                // 3. Only one type matters so drop the rest.
+        .getOrElse(tx)
+    case tx: ir.BundleType =>
+      /* This is a copy-paste of BundleType.mapType, but updating the target with the bundle field */
+      ir.BundleType(tx.fields.map(x => x.copy(tpe = onType(target.field(x.name))(x.tpe))))
+    case tx =>
+      tx
+  }
+
+  /** Collapse ports that are vectors of single-bits skipping ports of the top-module
+    * @param p a port
+    * @param renames a rename map
+    * @param target the current module
+    */
+  private def onPort(p: ir.Port)
+                    (implicit renames: RenameMap,
+                     target: ModuleTarget): ir.Port =
+    if (target.isTop) {
+      p
+    } else {
+      p.map(onType(target.ref(p.name)))
+    }
+
+  private def onModule(m: ir.DefModule)
+                      (implicit renames: RenameMap,
+                       target: CircuitTarget): ir.DefModule = m match {
+    case _: ir.ExtModule => m
+    case _: ir.Module  => {
+      implicit val targetx = target.module(m.name)
+      implicit val namespace = Namespace(m)
+      implicit val bitAssignments = new mutable.HashMap[ReferenceTarget, BitAssignments]
+      implicit val instances = new mutable.HashMap[ReferenceTarget, ModuleTarget]
+      logger.debug(s"- Entering module '${m.name}':")
+      m
+        .map(onPort)
+        .map(onStatement)
+        .map(Utils.squashEmpty)
+    }
+  }
+
+  private def run(c: ir.Circuit)
+                 (implicit renames: RenameMap): ir.Circuit = {
+    implicit val target = CircuitTarget(c.main)
+
+    /* A mapping of module targets to modified modules */
+    val modulesx: Map[ModuleTarget, ir.DefModule] =
+      new analyses.InstanceGraph(c)          // 1. Generate an instance graph
+        .moduleOrder                         // 2. Topologically sort the modules (root to leaves)
+        .reverse                             // 3. Change to leaves to roots
+        .map(onModule)                       // 4. Collapse vectors (from leaves to roots)
+        .groupBy(m => target.module(m.name)) // 5. Group these by module target so we can find them later
+        .map{ case (k, v) => (k -> v.head) } // 6. Map[ModuleTarget, Seq[DefModule]] => Map[ModuleTarget, DefModule]
+
+    c.copy(modules = c.modules.map(m => modulesx(target.module(m.name))))
+  }
+
+  override protected def execute(state: CircuitState): CircuitState = {
+    implicit val renames = RenameMap()
+    state.copy(circuit = run(state.circuit), renames = Some(renames))
+  }
+
+}

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -46,8 +46,8 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
 
   "ReplSeqMem" should "generate blackbox wrappers for mems of bundle type" in {
     val input = """
-circuit Top : 
-  module Top : 
+circuit Top :
+  module Top :
     input clock : Clock
     input reset : UInt<1>
     input head_ptr : UInt<5>
@@ -87,9 +87,9 @@ circuit Top :
 
     reg p_valid : UInt<1>, clock
     reg p_address : UInt<5>, clock
-    smem mem : UInt<8>[8][32] 
-    when hsel : 
-      when p_valid : 
+    smem mem : UInt<8>[8][32]
+    when hsel :
+      when p_valid :
         write mport T_155 = mem[p_address], clock
 """.stripMargin
     val mems = Set(MemConf("mem_ext", 32, 64, Map(MaskedWritePort -> 1), Some(64)))
@@ -105,20 +105,20 @@ circuit Top :
 
   "ReplSeqMem" should "not fail with FixedPoint types " in {
     val input = """
-circuit CustomMemory : 
-  module CustomMemory : 
+circuit CustomMemory :
+  module CustomMemory :
     input clock : Clock
     input reset : UInt<1>
     output io : {flip rClk : Clock, flip rAddr : UInt<3>, dO : Fixed<16><<8>>, flip wClk : Clock, flip wAddr : UInt<3>, flip wEn : UInt<1>, flip dI : Fixed<16><<8>>}
-    
+
     io is invalid
-    smem mem : Fixed<16><<8>>[7] 
+    smem mem : Fixed<16><<8>>[7]
     read mport _T_17 = mem[io.rAddr], clock
-    io.dO <= _T_17 
-    when io.wEn : 
+    io.dO <= _T_17
+    when io.wEn :
       write mport _T_18 = mem[io.wAddr], clock
       _T_18 <= io.dI
-      skip 
+      skip
 """.stripMargin
     val mems = Set(MemConf("mem_ext", 7, 16, Map(WritePort -> 1, ReadPort -> 1), None))
     val confLoc = "ReplSeqMemTests.confTEMP"
@@ -133,20 +133,20 @@ circuit CustomMemory :
 
   "ReplSeqMem" should "not fail with Signed types " in {
     val input = """
-circuit CustomMemory : 
-  module CustomMemory : 
+circuit CustomMemory :
+  module CustomMemory :
     input clock : Clock
     input reset : UInt<1>
     output io : {flip rClk : Clock, flip rAddr : UInt<3>, dO : SInt<16>, flip wClk : Clock, flip wAddr : UInt<3>, flip wEn : UInt<1>, flip dI : SInt<16>}
-    
+
     io is invalid
-    smem mem : SInt<16>[7] 
+    smem mem : SInt<16>[7]
     read mport _T_17 = mem[io.rAddr], clock
-    io.dO <= _T_17 
-    when io.wEn : 
+    io.dO <= _T_17
+    when io.wEn :
       write mport _T_18 = mem[io.wAddr], clock
       _T_18 <= io.dI
-      skip 
+      skip
 """.stripMargin
     val mems = Set(MemConf("mem_ext", 7, 16, Map(WritePort -> 1, ReadPort -> 1), None))
     val confLoc = "ReplSeqMemTests.confTEMP"
@@ -440,8 +440,9 @@ circuit CustomMemory :
     val annos = Seq(ReplSeqMemAnnotation.parse("-c:CustomMemory:-o:" + confLoc))
     val res = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
     // TODO Until RemoveCHIRRTL is removed, enable will still drive validif for mask
-    res should containLine("mem.W0_mask_0 <= validif(io_en, io_mask_0)")
-    res should containLine("mem.W0_mask_1 <= validif(io_en, io_mask_1)")
+    res should containLine ("node _GEN_7 = validif(io_en, io_mask_0)")
+    res should containLine ("node _GEN_8 = validif(io_en, io_mask_1)")
+    res should containLine ("mem.W0_mask <= cat(_GEN_8, _GEN_7)")
     // Check the emitted conf
     checkMemConf(confLoc, mems)
     (new java.io.File(confLoc)).delete()
@@ -474,8 +475,9 @@ circuit CustomMemory :
     val annos = Seq(ReplSeqMemAnnotation.parse("-c:CustomMemory:-o:" + confLoc), InferReadWriteAnnotation)
     val res = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
     // TODO Until RemoveCHIRRTL is removed, enable will still drive validif for mask
-    res should containLine("mem.RW0_wmask_0 <= validif(io_en, io_mask_0)")
-    res should containLine("mem.RW0_wmask_1 <= validif(io_en, io_mask_1)")
+    res should containLine ("node _GEN_7 = validif(io_en, io_mask_0)")
+    res should containLine ("node _GEN_8 = validif(io_en, io_mask_1)")
+    res should containLine ("mem.RW0_wmask <= cat(_GEN_8, _GEN_7)")
     // Check the emitted conf
     checkMemConf(confLoc, mems)
     (new java.io.File(confLoc)).delete()
@@ -504,8 +506,8 @@ circuit NoMemsHere :
 
   "ReplSeqMem" should "throw an exception when encountering masks with variable granularity" in {
     val input = """
-circuit Top : 
-  module Top : 
+circuit Top :
+  module Top :
     input clock : Clock
     input wmask : {a : UInt<1>, b : UInt<1>}
     input waddr : UInt<5>
@@ -519,7 +521,7 @@ circuit Top :
         w.a <- wdata.a
     when wmask.b :
         w.b <- wdata.b
-      
+
     read mport r = testmem[raddr], clock
     rdata <- r
 """.stripMargin

--- a/src/test/scala/firrtlTests/transforms/CollapseVectorsSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/CollapseVectorsSpec.scala
@@ -1,0 +1,378 @@
+// See LICENSE for license details.
+
+package firrtlTests.transforms
+
+import firrtl._
+import firrtl.annotations.{ReferenceTarget, Target}
+import firrtl.testutils.{FirrtlFlatSpec, FirrtlMatchers}
+import firrtl.testutils.FirrtlCheckers._
+import firrtl.transforms.DontTouchAnnotation
+
+import logger.{ClassLogLevelAnnotation, Logger, LogLevel}
+
+class CollapseVectorsSpec extends FirrtlFlatSpec {
+
+  private class Canonicalize extends Transform with FirrtlMatchers {
+    override val inputForm = UnknownForm
+    override val outputForm = UnknownForm
+    override def execute(state: CircuitState) = {
+      state.copy(circuit = canonicalize(state.circuit))
+    }
+  }
+
+  private def test(
+    input: String,
+    expectedLines: Seq[String] = Seq.empty,
+    expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq.empty,
+    annotations: AnnotationSeq = Seq.empty) = {
+
+    val state = CircuitState(
+      Parser.parse(input),
+      UnknownForm,
+      EmitCircuitAnnotation(classOf[LowFirrtlEmitter]) +: annotations)
+    val output = Logger.makeScope(Seq(ClassLogLevelAnnotation("firrtl.transforms.CollapseVectors", LogLevel.Debug))) {
+      Seq( new IRToWorkingIR,
+           new ResolveAndCheck,
+           new HighFirrtlToMiddleFirrtl,
+           new transforms.CollapseVectors,
+           passes.InferTypes,
+           passes.CheckTypes,
+           passes.CheckHighForm,
+           new Canonicalize,
+           new LowFirrtlEmitter )
+        .foldLeft(state){ (a, b) => b.transform(a) }
+    }
+
+    // info(s"\n${output.circuit.serialize}")
+
+    expectedLines.foreach(output should containLine(_))
+    expectedTrees.foreach(output should containTree(_))
+  }
+
+  behavior of "CollapseVectors"
+
+  it should "flatten ports and wires on LHS and RHS" in {
+    val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    input in: {a: UInt<1>[1]}
+         |    output out: {a: UInt<1>[2]}[2]
+         |    out[0].a[0] <= UInt<1>(0)
+         |    out[0].a[1] <= UInt<1>(1)
+         |    out[1].a[0] <= not(out[0].a[0])
+         |    out[1].a[1] <= not(out[0].a[1])
+         |  module Foo:
+         |    input clock: Clock
+         |    output out: UInt<4>
+         |    inst bar of Bar
+         |    bar.in.a[0] <= UInt<1>(0)
+         |    wire tmp: UInt<1>[4]
+         |    reg tmp_d: UInt<1>[2], clock
+         |    tmp[0] <= bar.out[0].a[0]
+         |    tmp[1] <= bar.out[0].a[1]
+         |    tmp[2] <= bar.out[1].a[0]
+         |    tmp[3] <= bar.out[1].a[1]
+         |    node out_msbs = cat(tmp[3], tmp[2])
+         |    node out_lsbs = cat(tmp[1], tmp[0])
+         |    out <= cat(out_msbs, out_lsbs)
+         |""".stripMargin
+    val expectedLines = Seq(
+      "node _tmp_0 = bits(bar.out[0].a, 0, 0)",
+      "node _tmp_1 = bits(bar.out[0].a, 1, 1)",
+      "node _tmp_2 = bits(bar.out[1].a, 0, 0)",
+      "node _tmp_3 = bits(bar.out[1].a, 1, 1)",
+      "tmp <= cat(cat(_tmp_3, _tmp_2), cat(_tmp_1, _tmp_0))",
+      "node out_msbs = cat(bits(tmp, 3, 3), bits(tmp, 2, 2))",
+      "node out_lsbs = cat(bits(tmp, 1, 1), bits(tmp, 0, 0))" )
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.DefWire(_, "tmp", ir.UIntType(ir.IntWidth(w))) => w == 4 }
+    )
+
+    test(input, expectedLines, expectedTrees)
+  }
+
+  it should "propagate type changes" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    input sel: UInt<1>
+         |    wire a: UInt<1>[1]
+         |    wire b: UInt<1>[1]
+         |    wire c: UInt<1>[1]
+         |    a[0] <= UInt<1>(0)
+         |    b[0] <= UInt<1>(1)
+         |    node d = mux(sel, a, b)
+         |    c[0] <= d[0]
+         |""".stripMargin
+    val expectedLines = Seq(
+      "node d = mux(sel, a, b)",
+      "c <= d"
+    )
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.DefWire(_, "a", ir.UIntType(ir.IntWidth(w))) => w == 1 },
+      { case ir.DefWire(_, "b", ir.UIntType(ir.IntWidth(w))) => w == 1 },
+      { case ir.DefWire(_, "c", ir.UIntType(ir.IntWidth(w))) => w == 1 },
+      { case ir.Connect(_, WRef("a", _, _, _), ir.UIntLiteral(v, ir.IntWidth(w))) => v == 0 && w == 1 },
+      { case ir.Connect(_, WRef("b", _, _, _), ir.UIntLiteral(v, ir.IntWidth(w))) => v == 1 && w == 1 }
+    )
+
+    test(input, expectedLines, expectedTrees)
+  }
+
+  it should "flatten registers" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    input clock: Clock
+         |    output out: UInt<1>[2]
+         |    reg r: UInt<1>[2], clock
+         |    r[0] <= UInt<1>(1)
+         |    r[1] is invalid
+         |    out[0] <= r[0]
+         |    out[1] <= r[1]
+         |""".stripMargin
+    val expectedLines = Seq(
+      "out[0] <= bits(r, 0, 0)",
+      "out[1] <= bits(r, 1, 1)",
+    )
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.DefRegister(_, "r", ir.UIntType(_), _, _, _) => true },
+    )
+
+    test(input, expectedLines, expectedTrees)
+  }
+
+  it should "flatten wires" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    output out: UInt<1>[1]
+         |    wire w: UInt<1>[1]
+         |    w[0] <= UInt<1>(0)
+         |    out[0] <= w[0]
+         |""".stripMargin
+
+    val expectedLines = Seq(
+      "out[0] <= bits(w, 0, 0)"
+    )
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.DefWire(_, "w", ir.UIntType(_)) => true }
+    )
+
+    test(input, expectedLines, expectedTrees)
+  }
+
+  it should "flatten memories" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    input clock: Clock
+         |    input read: {flip data: UInt<1>[1]}
+         |    input write: {data: UInt<1>[1]}
+         |    input readwrite: {flip rdata: UInt<1>[1], wdata: UInt<1>[1]}
+         |    mem m:
+         |      data-type => UInt<1>[1]
+         |      depth => 4
+         |      reader => r
+         |      writer => w
+         |      readwriter => rw
+         |      read-latency => 1
+         |      write-latency => 1
+         |      read-under-write => undefined
+         |    m.r.clk <= clock
+         |    m.r.en is invalid
+         |    m.r.addr is invalid
+         |    read.data <= m.r.data
+         |    m.w.clk <= clock
+         |    m.w.en is invalid
+         |    m.w.addr is invalid
+         |    m.w.data <= write.data
+         |    m.w.mask is invalid
+         |    m.rw.clk <= clock
+         |    m.rw.en is invalid
+         |    m.rw.wmode is invalid
+         |    m.rw.addr is invalid
+         |    m.rw.wdata <= readwrite.wdata
+         |    readwrite.rdata <= m.rw.rdata
+         |    m.rw.wmask is invalid
+         |""".stripMargin
+
+    val expectedLines = Seq(
+      "read.data[0] <= bits(m.r.data, 0, 0)",
+      "node _m_w_data_0 = write.data[0]",
+      "m.w.data <= _m_w_data_0",
+      "readwrite.rdata[0] <= bits(m.rw.rdata, 0, 0)",
+      "node _m_rw_wdata_0 = readwrite.wdata[0]",
+      "m.rw.wdata <= _m_rw_wdata_0"
+    )
+
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.DefMemory(_, "m", ir.UIntType(_), _, _, _, _, _, _, _) => true }
+    )
+
+    test(input, expectedLines, expectedTrees)
+  }
+
+  it should "handle bulk connects" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    input in: {a: UInt<1>[1]}
+         |    output out: {a: UInt<1>[1]}
+         |    wire bar: {a: UInt<1>[1]}
+         |    bar <= in
+         |    out <= bar
+         |""".stripMargin
+
+    test(input)
+  }
+
+  it should "handle submodule connections" in {
+    val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    input a: UInt<1>[1]
+         |    output b: UInt<1>[1]
+         |    b[0] <= UInt<1>(0)
+         |  module Foo:
+         |    output out: UInt<1>[1]
+         |    inst bar of Bar
+         |    node baz = bar.b[0]
+         |    bar.a[0] <= baz
+         |    out[0] <= bar.b[0]
+         |""".stripMargin
+    val expectedLines = Seq(
+      """b <= UInt<1>("h0")""",
+      "node baz = bits(bar.b, 0, 0)",
+      "out[0] <= bits(bar.b, 0, 0)",
+      "node _bar_a_0 = baz",
+      "bar.a <= _bar_a_0"
+    )
+
+    test(input, expectedLines)
+  }
+
+  it should "not collapse top-level ports" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    output out: UInt<1>[2]
+         |    out[0] <= UInt<1>(0)
+         |    out[1] <= UInt<1>(1)
+         |""".stripMargin
+
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.Module(_, _, Seq(ir.Port(_, "out", _, ir.VectorType(ir.UIntType(ir.IntWidth(w)), s))), _) => w == 1 && s == 2 }
+    )
+
+    test(input, Seq.empty, expectedTrees)
+  }
+
+  it should "handle zero-sized vectors" in {
+    val input =
+      """|circuit Top:
+         |  module Foo:
+         |    output out: {a: UInt<1>}[0]
+         |    out is invalid
+         |  module Top:
+         |    inst foo of Foo
+         |""".stripMargin
+
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.Module(_, _, Seq(ir.Port(_, "out", _, ir.VectorType(_, s))), _) => s == 0 }
+    )
+
+    test(input, Seq.empty, expectedTrees)
+  }
+
+  it should "handle invalids" in {
+    val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    input in: UInt<1>[1]
+         |  module Foo:
+         |    output out: UInt<1>[1]
+         |    wire a: UInt<1>[1]
+         |    a[0] is invalid
+         |    inst bar of Bar
+         |    bar.in[0] is invalid
+         |    out[0] is invalid
+         |""".stripMargin
+    val expectedLines = Seq(
+      "a is invalid",
+      "bar.in is invalid",
+      "out[0] is invalid"
+    )
+
+    test(input, expectedLines)
+  }
+
+  it should "handle connects with LHS and RHS collapsed" in {
+    val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    input a: UInt<1>[2]
+         |    output b: UInt<1>[2]
+         |    b <= a
+         |  module Foo:
+         |    inst bar of Bar
+         |    bar.a is invalid
+         |""".stripMargin
+    val expectedLines = Seq(
+      "b <= a"
+    )
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.Module(_, "Bar", Seq(ir.Port(_, "a", _, ir.UIntType(ir.IntWidth(aw))),
+                                     ir.Port(_, "b", _, ir.UIntType(ir.IntWidth(bw)))), _) => aw == 2 && bw == 2 }
+    )
+
+    test(input, expectedLines, expectedTrees)
+  }
+
+  it should "handle connections where a RHS was *NOT* collapsed" in {
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    input a: UInt<1>[2]
+         |    wire b: UInt<1>[2]
+         |    b <= a
+         |""".stripMargin
+    val expectedLines = Seq(
+      "node _b_0 = a[0]",
+      "node _b_1 = a[1]",
+      "b <= cat(_b_1, _b_0)"
+    )
+
+    test(input, expectedLines)
+  }
+
+  ignore should "respect targets with DontTouchAnnotations" in {
+    val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    input in: UInt<1>[1]
+         |  module Foo:
+         |    input in: UInt<1>[1]
+         |    wire a: UInt<1>[1]
+         |    a[0] <= in[0]
+         |    inst bar1 of Bar
+         |    bar1.in[0] <= a[0]
+         |    inst bar2 of Bar
+         |    bar2.in[0] <= a[0]
+         |""".stripMargin
+    val annotations = Seq(
+      "~Foo|Foo>a",
+      "~Foo|Foo/bar1:Bar>in[0]"
+    ).map(Target.deserialize(_) match {
+            case r: ReferenceTarget => println(r); DontTouchAnnotation(r)
+            case _ => ???
+          })
+    val expectedTrees: Seq[PartialFunction[Any, Boolean]] = Seq(
+      { case ir.DefWire(_, "a", ir.VectorType(ir.UIntType(ir.IntWidth(w)), s)) => w == 1 && s == 1 },
+      { case ir.Module(_, "Bar", Seq(ir.Port(_, "in", _, ir.VectorType(ir.UIntType(ir.IntWidth(w)), s))), _) => w == 1 && s == 1 },
+      { case ir.Module(_, "Foo", Seq(ir.Port(_, "in", _, ir.VectorType(ir.UIntType(ir.IntWidth(w)), s))), _) => w == 1 && s == 1 }
+    )
+    test(input, Seq.empty, expectedTrees, annotations)
+  }
+
+}


### PR DESCRIPTION
This adds a `CollapseVectors` transform that converts `UInt<1>[n]` into `UInt<n>`. This works on ports, wires, registers, nodes, and memories. It will not collapse top-level ports.

Roughly, this is running the following algorithm:

1. Any declaration (wire, register, node, memory) is converted from `UInt<1>[n]` to `UInt<n>`
1. Anytime a bit in a collapsed vector is assigned to (`Connect` or `IsInvalid`), this statement is dropped and the RHS is stored in a bit assignment data structure
1. When the last bit in a collapsed vector is assigned to, the full assignment is done in one of four possible ways with the following priority:
    1. If every bit is invalidated, then the collapsed vector (now a `UInt`) is invalidated
    1. If every bit is assigned to a literal, then the collapsed vector gets assigned to the collapsed literal
    1. If every bit is assigned (in order) to every bit in another collapsed vector, then the two collapsed vectors are connected directly
    1. Temporary wires/nodes are generated for every bit, each bit is assigned to, and the collapsed vector is assigned to via a concatenation.
1. Any RHS references to subindices are replaced with bit extract primops.

### Async Reset Problems

**This fails asynchronous reset checks due to the way that collapsed vectors are bit-assigned to.** 

Specifically, when collapsing a complex literal of another complex literal, this fails as the assignment is handled with a concatenation.

**This likely motivates allowing resets to propagate across `cat`, `bits`, and `pad`.** I.e., this needs the reduced version of https://github.com/freechipsproject/firrtl/pull/1201#issuecomment-549638878.

As an example, take the following circuit from `AsyncResetSpec` which has a register initialized to a complex literal composed of other complex literals:
```
circuit Test:
  module Test:
    input clock : Clock
    input reset : AsyncReset
    input x : UInt<1>[4]
    output z : UInt<1>[4]
    wire literal : UInt<1>[2]
    literal[0] <= UInt<1>("h01")
    literal[1] <= UInt<1>("h01")
    wire complex_literal : UInt<1>[4]
    complex_literal[0] <= literal[0]
    complex_literal[1] <= literal[1]
    complex_literal[2] <= UInt<1>("h00")
    complex_literal[3] <= UInt<1>("h00")
    reg r : UInt<1>[4], clock with : (reset => (reset, complex_literal))
    r <= x
    z <= r
```

This produces the following which fails `CheckResets` due to the concatenation:
```
circuit Test :
  module Test :
    input clock : Clock
    input reset : AsyncReset
    input x : UInt<1>[4]
    output z : UInt<1>[4]stOnly 4s
  
    wire bundle : { a : UInt<1>, b : UInt<1>}
    wire complex_literal : UInt<4>
    reg r : UInt<4>, clock with :
      reset => (reset, complex_literal)
    z[0] <= bits(r, 0, 0)
    z[1] <= bits(r, 1, 1)
    z[2] <= bits(r, 2, 2)
    z[3] <= bits(r, 3, 3)
    bundle.a <= UInt<1>("h1")
    bundle.b <= UInt<1>("h1")
    node _complex_literal_0 = bundle.a
    node _complex_literal_1 = bundle.b
    node _complex_literal_2 = UInt<1>("h0")
    node _complex_literal_3 = UInt<1>("h0")
    complex_literal <= cat(cat(_complex_literal_3, _complex_literal_2), cat(_complex_literal_1, _complex_literal_0))
    node _r_0 = x[0]
    node _r_1 = x[1]
    node _r_2 = x[2]
    node _r_3 = x[3]
    r <= cat(cat(_r_3, _r_2), cat(_r_1, _r_0))
```

### Todo
- [ ] Relax constraints on asynchronous reset checks
- [ ] Support `DontTouchAnnotation`
- [ ] Don't collapse `ExtModule` ports

### Metadata

Fixes #99

### Performance

This should be `O(n)` as it's walking the AST twice (once to build an instance graph and once to process it).

Running this on Rocket Chip master is "not too bad":

```
======== Starting Transform CollapseVectors ========
----------------------------------------------------

Time: 790.0 ms
Form: UnknownForm
======== Finished Transform CollapseVectors ========
```

### QOR

Here's a small example of what this is doing in Rocket Chip:

```
  module IntXbar : 
    input clock : Clock
    input reset : UInt<1>
    output auto : {flip int_in : UInt<1>[2], int_out : UInt<1>[2]}
    
    clock is invalid
    reset is invalid
    auto is invalid
    wire _T : UInt<1>[2] @[Nodes.scala 369:76]
    _T is invalid @[Nodes.scala 369:76]
    wire _T_1 : UInt<1>[2] @[Nodes.scala 368:76]
    _T_1 is invalid @[Nodes.scala 368:76]
    auto.int_out <- _T_1 @[LazyModule.scala 173:49]
    _T <- auto.int_in @[LazyModule.scala 173:31]
    _T_1[0] <= _T[0] @[Xbar.scala 21:44]
    _T_1[1] <= _T[1] @[Xbar.scala 21:44]
```

Without this PR, you get:

```verilog
module IntXbar( // @[:freechips.rocketchip.system.DefaultConfig.fir@3.2]
  input   auto_int_in_0, // @[:freechips.rocketchip.system.DefaultConfig.fir@6.4]
  input   auto_int_in_1, // @[:freechips.rocketchip.system.DefaultConfig.fir@6.4]
  output  auto_int_out_0, // @[:freechips.rocketchip.system.DefaultConfig.fir@6.4]
  output  auto_int_out_1 // @[:freechips.rocketchip.system.DefaultConfig.fir@6.4]
 );
  assign auto_int_out_0 = auto_int_in_0; // @[LazyModule.scala 173:49:freechips.rocketchip.system.DefaultConfig.fir@15.4]
  assign auto_int_out_1 = auto_int_in_1; // @[LazyModule.scala 173:49:freechips.rocketchip.system.DefaultConfig.fir@15.4]
endmodule
```

With this PR you get:
```verilog
module IntXbar( // @[:freechips.rocketchip.system.DefaultConfig.fir@3.2]                                                                                                                                                                                           
  input  [1:0] auto_int_in, // @[:freechips.rocketchip.system.DefaultConfig.fir@6.4]                                                                                                                                                                               
  output [1:0] auto_int_out // @[:freechips.rocketchip.system.DefaultConfig.fir@6.4]                                                                                                                                                                               
);                                                                                                                                                                                                                                                                 
  assign auto_int_out = auto_int_in;                                                                                                                                                                                                                               
endmodule 
```

Overall Verilog line count changes are about flat. No discernible change in Verilator simulation time.

```
# git diff --no-index --stat freechips.rocketchip.system.DefaultConfig.orig.v freechips.rocketchip.system.DefaultConfig.v
 ... => freechips.rocketchip.system.DefaultConfig.v | 31658 +++++++++----------
 1 file changed, 15608 insertions(+), 16050 deletions(-)
```