### PR TITLE
Mangle target dir

### DIFF
--- a/scripts/formal_equiv.sh
+++ b/scripts/formal_equiv.sh
@@ -27,7 +27,7 @@ make_verilog () {
 
     sbt clean
     sbt "runMain firrtl.Driver -i $DUT.fir -o $filename -X verilog"
-    RET=$filename
+    RET="firrtl/$filename"
 }
 
 # Generate Verilog to compare

--- a/src/main/scala/firrtl/options/Stage.scala
+++ b/src/main/scala/firrtl/options/Stage.scala
@@ -35,13 +35,16 @@ abstract class Stage extends Phase {
       Seq( new phases.GetIncludes,
            new phases.ConvertLegacyAnnotations )
         .map(phases.DeletedWrapper(_))
-        .foldLeft(annotations)((a, p) => p.transform(a))
+        .foldLeft(phases.TargetDirectoryEnterAnnotation(shell.applicationName) +: annotations)((a, p) => p.transform(a))
 
     Logger.makeScope(annotationsx) {
       Seq( new phases.AddDefaults,
            new phases.Checks,
+           new phases.TargetDirectoryManipulator,
            new Phase { def transform(a: AnnotationSeq) = run(a) },
-           new phases.WriteOutputAnnotations )
+           new phases.WriteOutputAnnotations,
+           new phases.TargetDirectoryExit,
+           new phases.TargetDirectoryManipulator )
         .map(phases.DeletedWrapper(_))
         .foldLeft(annotationsx)((a, p) => p.transform(a))
     }

--- a/src/main/scala/firrtl/options/phases/TargetDirectoryManipulator.scala
+++ b/src/main/scala/firrtl/options/phases/TargetDirectoryManipulator.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package firrtl.options.phases
+
+import firrtl.AnnotationSeq
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.options.{Phase, StageOptions, TargetDirAnnotation}
+import firrtl.options.Viewer._
+
+import java.io.File
+
+private[options] sealed trait TargetDirectoryManipulatorAnnotation extends NoTargetAnnotation
+
+private[options] case class TargetDirectoryEnterAnnotation(dir: String) extends TargetDirectoryManipulatorAnnotation
+
+private[options] case object TargetDirectoryExitAnnotation extends TargetDirectoryManipulatorAnnotation
+
+class TargetDirectoryManipulator extends Phase {
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val targetDir = new File(view[StageOptions](annotations).targetDir)
+    val targetDirx = annotations.foldLeft(targetDir){ (dir, anno) =>
+      anno match {
+        case TargetDirectoryEnterAnnotation(dir) => new File(targetDir, dir)
+        case TargetDirectoryExitAnnotation       => dir.getParentFile
+        case _                                   => dir
+      }
+    }
+    annotations.flatMap {
+      case _: TargetDirectoryEnterAnnotation => None
+      case TargetDirectoryExitAnnotation     => None
+      case _: TargetDirAnnotation            => Some(TargetDirAnnotation(targetDirx.toString))
+      case a                                 => Some(a)
+    }
+  }
+
+}
+
+class TargetDirectoryExit extends Phase {
+
+  def transform(a: AnnotationSeq) = TargetDirectoryExitAnnotation +: a
+
+}

--- a/src/test/scala/firrtlTests/DriverSpec.scala
+++ b/src/test/scala/firrtlTests/DriverSpec.scala
@@ -387,13 +387,13 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
 
     "To a single file with file extension depending on the compiler by default" in {
       Seq(
-        "none" -> "./Foo.fir",
-        "low" -> "./Foo.lo.fir",
-        "high" -> "./Foo.hi.fir",
-        "middle" -> "./Foo.mid.fir",
-        "verilog" -> "./Foo.v",
-        "mverilog" -> "./Foo.v",
-        "sverilog" -> "./Foo.sv"
+        "none" -> "./firrtl/Foo.fir",
+        "low" -> "./firrtl/Foo.lo.fir",
+        "high" -> "./firrtl/Foo.hi.fir",
+        "middle" -> "./firrtl/Foo.mid.fir",
+        "verilog" -> "./firrtl/Foo.v",
+        "mverilog" -> "./firrtl/Foo.v",
+        "sverilog" -> "./firrtl/Foo.sv"
       ).foreach { case (compilerName, expectedOutputFileName) =>
         info(s"$compilerName -> $expectedOutputFileName")
         val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {
@@ -418,13 +418,13 @@ class DriverSpec extends FreeSpec with Matchers with BackendCompilationUtilities
     }
     "To a single file per module if OneFilePerModule is specified" in {
       Seq(
-        "none" -> Seq("./Top.fir", "./Child.fir"),
-        "low" -> Seq("./Top.lo.fir", "./Child.lo.fir"),
-        "high" -> Seq("./Top.hi.fir", "./Child.hi.fir"),
-        "middle" -> Seq("./Top.mid.fir", "./Child.mid.fir"),
-        "verilog" -> Seq("./Top.v", "./Child.v"),
-        "mverilog" -> Seq("./Top.v", "./Child.v"),
-        "sverilog" -> Seq("./Top.sv", "./Child.sv")
+        "none" -> Seq("./firrtl/Top.fir", "./firrtl/Child.fir"),
+        "low" -> Seq("./firrtl/Top.lo.fir", "./firrtl/Child.lo.fir"),
+        "high" -> Seq("./firrtl/Top.hi.fir", "./firrtl/Child.hi.fir"),
+        "middle" -> Seq("./firrtl/Top.mid.fir", "./firrtl/Child.mid.fir"),
+        "verilog" -> Seq("./firrtl/Top.v", "./firrtl/Child.v"),
+        "mverilog" -> Seq("./firrtl/Top.v", "./firrtl/Child.v"),
+        "sverilog" -> Seq("./firrtl/Top.sv", "./firrtl/Child.sv")
       ).foreach { case (compilerName, expectedOutputFileNames) =>
         info(s"$compilerName -> $expectedOutputFileNames")
         val manager = new ExecutionOptionsManager("test") with HasFirrtlOptions {

--- a/src/test/scala/firrtlTests/FirrtlSpec.scala
+++ b/src/test/scala/firrtlTests/FirrtlSpec.scala
@@ -120,7 +120,7 @@ trait FirrtlRunners extends BackendCompilationUtilities {
     }
     firrtl.Driver.execute(optionsManager)
 
-    testDir
+    new File(testDir, "firrtl")
   }
   /** Execute a Firrtl Test
     *

--- a/src/test/scala/firrtlTests/IntegrationSpec.scala
+++ b/src/test/scala/firrtlTests/IntegrationSpec.scala
@@ -19,6 +19,7 @@ class GCDSplitEmissionExecutionTest extends FirrtlFlatSpec {
     val top = "GCDTester"
     val testDir = createTestDirectory("GCDTesterSplitEmission")
     val sourceFile = new File(testDir, s"$top.fir")
+    val outputDir = new File(testDir, "firrtl")
     copyResourceToFile(s"/integration/$top.fir", sourceFile)
 
     val optionsManager = new ExecutionOptionsManager("GCDTesterSplitEmission") with HasFirrtlOptions {
@@ -32,19 +33,19 @@ class GCDSplitEmissionExecutionTest extends FirrtlFlatSpec {
     firrtl.Driver.execute(optionsManager)
 
     // expected filenames
-    val dutFile = new File(testDir, "DecoupledGCD.v")
-    val topFile = new File(testDir, s"$top.v")
+    val dutFile = new File(outputDir, "DecoupledGCD.v")
+    val topFile = new File(outputDir, s"$top.v")
     dutFile should exist
     topFile should exist
 
     // Copy harness over
-    val harness = new File(testDir, s"testTop.cpp")
+    val harness = new File(outputDir, s"testTop.cpp")
     copyResourceToFile(cppHarnessResourceName, harness)
 
     // topFile will be compiled by Verilator command by default but we need to also include dutFile
-    verilogToCpp(top, testDir, Seq(dutFile), harness).!
-    cppToExe(top, testDir).!
-    assert(executeExpectingSuccess(top, testDir))
+    verilogToCpp(top, outputDir, Seq(dutFile), harness).!
+    cppToExe(top, outputDir).!
+    assert(executeExpectingSuccess(top, outputDir))
   }
 }
 

--- a/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
@@ -98,7 +98,7 @@ class FirrtlMainSpec extends FeatureSpec with GivenWhenThen with Matchers with f
 
       p.files.foreach { f =>
         And(s"file '$f' should be emitted in the target directory")
-        val out = new File(td.buildDir + s"/$f")
+        val out = new File(td.stageDir + s"/$f")
         out should (exist)
       }
     }
@@ -119,6 +119,7 @@ class FirrtlMainSpec extends FeatureSpec with GivenWhenThen with Matchers with f
   class TargetDirectoryFixture(dirName: String) {
     val dir = new File(s"test_run_dir/FirrtlMainSpec/$dirName")
     val buildDir = new File(dir + "/build")
+    val stageDir = new File(buildDir, "firrtl")
     dir.mkdirs()
   }
 
@@ -227,7 +228,7 @@ class FirrtlMainSpec extends FeatureSpec with GivenWhenThen with Matchers with f
 
       When("the user doesn't specify a target directory")
       val outName = "FirrtlMainSpecNoTargetDirectory"
-      val out = new File(s"$outName.hi.fir")
+      val out = new File("firrtl", s"$outName.hi.fir")
       out.delete()
       val result = catchStatus {
         f.stage.main(Array("-i", "src/test/resources/integration/GCDTester.fir", "-o", outName, "-X", "high",
@@ -254,7 +255,7 @@ class FirrtlMainSpec extends FeatureSpec with GivenWhenThen with Matchers with f
                          "-o", "Foo"))
 
       Then("the output should be the same as using FIRRTL input")
-      new File(td.buildDir + "/Foo.hi.fir") should (exist)
+      new File(td.stageDir + "/Foo.hi.fir") should (exist)
     }
 
   }
@@ -304,14 +305,14 @@ class FirrtlMainSpec extends FeatureSpec with GivenWhenThen with Matchers with f
       val pw = new PrintWriter(in)
       pw.write(circuit.input)
       pw.close()
-      val (out, _, result) = grabStdOutErr{ catchStatus { f.stage.main(Array("-td", td.dir.toString,
+      val (out, _, result) = grabStdOutErr{ catchStatus { f.stage.main(Array("-td", td.buildDir.toString,
                                                                              "-i", in.toString,
                                                                              "-foaf", "Top.out",
                                                                              "-X", "high",
                                                                              "-E", "high")) } }
 
       Then("the implicit annotation file should NOT be read")
-      val annoFileOut = new File(td.dir + "/Top.out.anno.json")
+      val annoFileOut = new File(td.stageDir + "/Top.out.anno.json")
       val annotationJson = FileUtils.getText(annoFileOut)
       annotationJson should not include ("InlineInstances")
 


### PR DESCRIPTION
The makes each stage change the `TargetDirAnnotation` to a subdirectory derived from the stage's name before running the meat of a stage. The end result of this is that the outputs of Chisel wind up in `chisel` and the outputs of FIRRTL wind up in `firrtl`. 

This fixes a problem where each stage will generate an output annotation file, but their names may conflict.

### Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### TODO

- [ ] Companion Chisel3 PR

### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No impact on code generation, but the location of generated code and output files changes. This has the effect of potentially breaking downstream tooling with hard-code paths.

### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.
