### PR TITLE
Create PartitionCircuit transform for minimizing test cases

### DIFF
--- a/src/main/resources/META-INF/services/firrtl.options.RegisteredTransform
+++ b/src/main/resources/META-INF/services/firrtl.options.RegisteredTransform
@@ -1,4 +1,5 @@
 firrtl.transforms.DeadCodeElimination
+firrtl.transforms.PartitionCircuit
 firrtl.transforms.CheckCombLoops
 firrtl.passes.InlineInstances
 firrtl.passes.clocklist.ClockListTransform

--- a/src/main/scala/firrtl/transforms/PartitionCircuit.scala
+++ b/src/main/scala/firrtl/transforms/PartitionCircuit.scala
@@ -1,0 +1,95 @@
+
+package firrtl.transforms
+
+import firrtl._
+import firrtl.ir._
+import firrtl.annotations._
+import firrtl.graph._
+import firrtl.traversals.Foreachers._
+import firrtl.options.{RegisteredTransform, ShellOption}
+import firrtl.stage.RunFirrtlTransformAnnotation
+
+import collection.mutable
+
+case class PartitionCircuitAnnotation(target: ModuleTarget) extends SingleTargetAnnotation[ModuleTarget] {
+  def duplicate(n: ModuleTarget): PartitionCircuitAnnotation = this.copy(n)
+}
+
+/** Partition a Circuit by keeping only marked modules
+  *
+  * This transform enables minimization of test-cases by removing all Modules but the marked ones
+  * (and blackboxing all submodules of the marked modules)
+  *
+  * @note It does **not** do renaming
+  */
+class PartitionCircuit extends Transform with RegisteredTransform {
+  def inputForm = ChirrtlForm
+  def outputForm = ChirrtlForm
+
+  val options = Seq(
+    new ShellOption[Seq[String]](
+      longOption = "partition-circuit",
+      toAnnotationSeq = (a: Seq[String]) => a.map { mod =>
+        PartitionCircuitAnnotation(ModuleTarget("DontCare", mod))
+      } :+ RunFirrtlTransformAnnotation(new PartitionCircuit),
+      helpText = "Partition the circuit keeping the marked modules",
+      helpValueName = Some("<module name>[,...]")
+    )
+  )
+
+  // Return DiGraph where edges are from Module to child Modules
+  private def buildModuleGraph(circuit: Circuit): DiGraph[String] = {
+    val graph = new MutableDiGraph[String]
+    def onMod(mod: DefModule): Unit = {
+      val children = mutable.ArrayBuffer.empty[String]
+      def onStmt(stmt: Statement): Unit = {
+        stmt.foreach(onStmt)
+        stmt match {
+          case DefInstance(_, _, mod) => children += mod
+          case _ =>
+        }
+      }
+      graph.addVertex(mod.name)
+      mod.foreach(onStmt)
+      for (c <- children) {
+        graph.addPairWithEdge(mod.name, c)
+      }
+    }
+    circuit.modules.foreach(onMod)
+    DiGraph(graph)
+  }
+
+  // Returns (Modules to keep, Modules to BlackBox)
+  private def classifyModules(keep: Set[String], graph: DiGraph[String]): (Set[String], Set[String]) = {
+    val revGraph = graph.reverse
+    val allKeep: Set[String] = keep.flatMap(revGraph.reachableFrom) ++ keep
+    val blackbox: Set[String] = allKeep.flatMap(graph.getEdges) -- allKeep
+    (allKeep, blackbox)
+  }
+
+  private def blackboxify(mod: DefModule): ExtModule = mod match {
+    case ext: ExtModule => ext
+    case Module(info, name, ports, _) => ExtModule(info, name, ports, name, Nil)
+  }
+
+  def execute(state: CircuitState): CircuitState = {
+
+    val marked = state.annotations.collect {
+      case PartitionCircuitAnnotation(ModuleTarget(_, mod)) => mod
+    }
+
+    if (marked.nonEmpty) {
+      val graph = buildModuleGraph(state.circuit)
+      val (keep, blackbox) = classifyModules(marked.toSet, graph)
+      val modulesx = state.circuit.modules.flatMap {
+        case mod if keep(mod.name)     => Some(mod)
+        case mod if blackbox(mod.name) => Some(blackboxify(mod))
+        case other                     => None
+      }
+      state.copy(circuit = state.circuit.copy(modules = modulesx))
+    } else {
+      logger.warn("PartitionCircuit run but no PartitionCircuitAnnotation found! Skipping...")
+      state
+    }
+  }
+}


### PR DESCRIPTION
This doesn't necessarily need to be merged, but it's a debugging utility I cranked out to minimize test cases. It lets you mark the Modules you care about which it will keep (all the way up to the top), otherwise it deletes all modules and blackboxes those that are needed because they are instantiated by a module that needs to be kept.

It's intended to be used with the `none` compiler

TODO
- [ ] Write Tests
- [ ] Support renaming

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

### Type of Improvement


- new feature/API                  

### API Impact

API expansion

### Backend Code Generation Impact

None

### Desired Merge Strategy

Dont Care

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
