### PR TITLE
Reduce warnings, add scalafix for inputForm/outputForm

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,0 +1,54 @@
+lazy val V = _root_.scalafix.sbt.BuildInfo
+inThisBuild(
+  List(
+    organization := "com.example",
+    homepage := Some(url("https://github.com/com/example")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "example-username",
+        "Example Full Name",
+        "example@email.com",
+        url("https://example.com")
+      )
+    ),
+    scalaVersion := V.scala212,
+    addCompilerPlugin(scalafixSemanticdb),
+    scalacOptions ++= List(
+      "-Yrangepos",
+      "-P:semanticdb:synthetics:on"
+    ),
+    libraryDependencies += "edu.berkeley.cs" %% "firrtl" % "1.3+"
+  )
+)
+
+skip in publish := true
+
+lazy val rules = project.settings(
+  moduleName := "scalafix",
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+)
+
+lazy val input = project.settings(
+  skip in publish := true
+)
+
+lazy val output = project.settings(
+  skip in publish := true
+)
+
+lazy val tests = project
+  .settings(
+    skip in publish := true,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    compile.in(Compile) := 
+      compile.in(Compile).dependsOn(compile.in(input, Compile)).value,
+    scalafixTestkitOutputSourceDirectories :=
+      sourceDirectories.in(output, Compile).value,
+    scalafixTestkitInputSourceDirectories :=
+      sourceDirectories.in(input, Compile).value,
+    scalafixTestkitInputClasspath :=
+      fullClasspath.in(input, Compile).value,
+  )
+  .dependsOn(rules)
+  .enablePlugins(ScalafixTestkitPlugin)

--- a/scalafix/input/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/input/src/main/scala/fix/Firrtl.scala
@@ -28,3 +28,23 @@ class HasAllModifiers extends Transform {
   final override def outputForm = LowForm
   override def execute(state: CircuitState): CircuitState = state
 }
+
+class HasVals extends Transform {
+  val inputForm = LowForm
+  val outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+object ObjTransform extends Transform {
+  val inputForm = LowForm
+  val outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+abstract class SubClass extends Transform {
+  override def execute(state: CircuitState): CircuitState = state
+}
+class SubSubClass extends SubClass {
+  val inputForm = LowForm
+  val outputForm = LowForm
+}

--- a/scalafix/input/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/input/src/main/scala/fix/Firrtl.scala
@@ -47,4 +47,6 @@ abstract class SubClass extends Transform {
 class SubSubClass extends SubClass {
   val inputForm = LowForm
   val outputForm = LowForm
+  val otherVal = 10
+  def otherDef = 10
 }

--- a/scalafix/input/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/input/src/main/scala/fix/Firrtl.scala
@@ -1,0 +1,30 @@
+/*
+rule = Firrtl
+*/
+package fix
+
+import firrtl.{Transform, CircuitState, LowForm, UnknownForm}
+
+class NoOverrides extends Transform {
+  def inputForm = LowForm
+  def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+class HasOverrides extends Transform {
+  override def inputForm = LowForm
+  override def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+class HasOtherModifiers extends Transform {
+  final def inputForm = LowForm
+  final def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+class HasAllModifiers extends Transform {
+  override final def inputForm = LowForm
+  final override def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}

--- a/scalafix/output/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/output/src/main/scala/fix/Firrtl.scala
@@ -1,0 +1,27 @@
+package fix
+
+import firrtl.{Transform, CircuitState, LowForm, UnknownForm}
+
+class NoOverrides extends Transform {
+  override def inputForm = LowForm
+  override def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+class HasOverrides extends Transform {
+  override def inputForm = LowForm
+  override def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+class HasOtherModifiers extends Transform {
+  override final def inputForm = LowForm
+  override final def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+class HasAllModifiers extends Transform {
+  override final def inputForm = LowForm
+  final override def outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}

--- a/scalafix/output/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/output/src/main/scala/fix/Firrtl.scala
@@ -25,3 +25,23 @@ class HasAllModifiers extends Transform {
   final override def outputForm = LowForm
   override def execute(state: CircuitState): CircuitState = state
 }
+
+class HasVals extends Transform {
+  override val inputForm = LowForm
+  override val outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+object ObjTransform extends Transform {
+  override val inputForm = LowForm
+  override val outputForm = LowForm
+  override def execute(state: CircuitState): CircuitState = state
+}
+
+abstract class SubClass extends Transform {
+  override def execute(state: CircuitState): CircuitState = state
+}
+class SubSubClass extends SubClass {
+  override val inputForm = LowForm
+  override val outputForm = LowForm
+}

--- a/scalafix/output/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/output/src/main/scala/fix/Firrtl.scala
@@ -44,4 +44,6 @@ abstract class SubClass extends Transform {
 class SubSubClass extends SubClass {
   override val inputForm = LowForm
   override val outputForm = LowForm
+  val otherVal = 10
+  def otherDef = 10
 }

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.1

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("releases")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.12")

--- a/scalafix/readme.md
+++ b/scalafix/readme.md
@@ -1,0 +1,7 @@
+# Scalafix rules for firrtl
+
+To develop rule:
+```
+sbt ~tests/test
+# edit rules/src/main/scala/fix/Firrtl.scala
+```

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+fix.Firrtl

--- a/scalafix/rules/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/rules/src/main/scala/fix/Firrtl.scala
@@ -3,23 +3,29 @@ package fix
 import scalafix.v1._
 import scala.meta._
 
-class Firrtl extends SemanticRule("Firrtl") {
+class Firrtl extends SyntacticRule("Firrtl") {
 
   def hasOverrides(defn: Defn.Def): Boolean = {
     defn.mods.collectFirst {
       case x@mod"override" => "override"
     }.nonEmpty
   }
+  def hasOverrides(defn: Defn.Val): Boolean = {
+    defn.mods.collectFirst {
+      case x@mod"override" => "override"
+    }.nonEmpty
+  }
 
-  override def fix(implicit doc: SemanticDocument): Patch = {
-    //println("Tree.syntax: " + doc.tree.syntax)
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    println("Tree.syntax: " + doc.tree.syntax)
     //println("Tree.structure: " + doc.tree.structure)
     //println("Tree.structureLabeled: " + doc.tree.structureLabeled)
+    val nameMatcher = "(in|out)putForm".r
     doc.tree.collect {
-      case inputForm @ Defn.Def(_, Term.Name("inputForm"), List(), List(), _, _ ) if !hasOverrides(inputForm) =>
-        Patch.addLeft(inputForm, "override ")
-      case outputForm @ Defn.Def(_, Term.Name("outputForm"), List(), List(), _, _ ) if !hasOverrides(outputForm) =>
-        Patch.addLeft(outputForm, "override ")
+      case formDef @ Defn.Def(_, Term.Name(nameMatcher), List(), List(), _, _ ) if !hasOverrides(formDef) =>
+        Patch.addLeft(formDef, "override ")
+      case formVal @ Defn.Val(_, List(Pat.Var(Term.Name(nameMatcher))), _, rhs) if !hasOverrides(formVal) =>
+        Patch.addLeft(formVal, "override ")
     }.asPatch
   }
 }

--- a/scalafix/rules/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/rules/src/main/scala/fix/Firrtl.scala
@@ -15,16 +15,19 @@ class Firrtl extends SyntacticRule("Firrtl") {
       case x@mod"override" => "override"
     }.nonEmpty
   }
+  def isName(name: String): Boolean = {
+    name == "inputForm" || name == "outputForm"
+  }
 
   override def fix(implicit doc: SyntacticDocument): Patch = {
-    println("Tree.syntax: " + doc.tree.syntax)
+    //Note: Keep these printlns around, they are necessary to debug/develop scalafix patches
+    //println("Tree.syntax: " + doc.tree.syntax)
     //println("Tree.structure: " + doc.tree.structure)
     //println("Tree.structureLabeled: " + doc.tree.structureLabeled)
-    val nameMatcher = "(in|out)putForm".r
     doc.tree.collect {
-      case formDef @ Defn.Def(_, Term.Name(nameMatcher), List(), List(), _, _ ) if !hasOverrides(formDef) =>
+      case formDef @ Defn.Def(_, Term.Name(name), List(), List(), _, _ ) if !hasOverrides(formDef) && isName(name) =>
         Patch.addLeft(formDef, "override ")
-      case formVal @ Defn.Val(_, List(Pat.Var(Term.Name(nameMatcher))), _, rhs) if !hasOverrides(formVal) =>
+      case formVal @ Defn.Val(_, List(Pat.Var(Term.Name(name))), _, rhs) if !hasOverrides(formVal) && isName(name) =>
         Patch.addLeft(formVal, "override ")
     }.asPatch
   }

--- a/scalafix/rules/src/main/scala/fix/Firrtl.scala
+++ b/scalafix/rules/src/main/scala/fix/Firrtl.scala
@@ -1,0 +1,25 @@
+package fix
+
+import scalafix.v1._
+import scala.meta._
+
+class Firrtl extends SemanticRule("Firrtl") {
+
+  def hasOverrides(defn: Defn.Def): Boolean = {
+    defn.mods.collectFirst {
+      case x@mod"override" => "override"
+    }.nonEmpty
+  }
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    //println("Tree.syntax: " + doc.tree.syntax)
+    //println("Tree.structure: " + doc.tree.structure)
+    //println("Tree.structureLabeled: " + doc.tree.structureLabeled)
+    doc.tree.collect {
+      case inputForm @ Defn.Def(_, Term.Name("inputForm"), List(), List(), _, _ ) if !hasOverrides(inputForm) =>
+        Patch.addLeft(inputForm, "override ")
+      case outputForm @ Defn.Def(_, Term.Name("outputForm"), List(), List(), _, _ ) if !hasOverrides(outputForm) =>
+        Patch.addLeft(outputForm, "override ")
+    }.asPatch
+  }
+}

--- a/scalafix/tests/src/test/scala/fix/RuleSuite.scala
+++ b/scalafix/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,0 +1,7 @@
+package fix
+
+import scalafix.testkit.SemanticRuleSuite
+
+class RuleSuite extends SemanticRuleSuite() {
+  runAllTests()
+}

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -194,6 +194,8 @@ Although this is discouraged, if this transform requires being run after LowForm
   - override def inputForm = LowForm
   + override def prerequisites: Seq[Dependency[Transform]] = firrtl.stage.Forms.LowFormOptimized
 Note that this will always require optimization passes to be run, which is highly undesireable.
+
+Your code:
 """, "1.2")
   def inputForm: CircuitForm = UnknownForm
 

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -197,7 +197,7 @@ Note that this will always require optimization passes to be run, which is highl
 
 Your code:
 """, "1.2")
-  def inputForm: CircuitForm = UnknownForm
+  def inputForm: CircuitForm
 
   /** The [[firrtl.CircuitForm]] that this transform outputs */
   @deprecatedOverriding(

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -185,59 +185,17 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
   def name: String = this.getClass.getName
   /** The [[firrtl.CircuitForm]] that this transform requires to operate on */
   @deprecatedOverriding(
-"""inputForm will be removed in 1.3. Use DependencyAPI method prerequisites, dependents, invalidates)
-Please delete your overriding of inputForm and instead override prerequisites:"
-  - override def inputForm = [[[LowForm|MidForm|HighForm|ChirrtlForm]]]
-  + override def prerequisites: Seq[Dependency[Transform]] = firrtl.stage.Forms.[[[LowForm|MidForm|Deduped|Nil]]]
-
-Although this is discouraged, if this transform requires being run after LowForm optimizations, use the following:
-  - override def inputForm = LowForm
-  + override def prerequisites: Seq[Dependency[Transform]] = firrtl.stage.Forms.LowFormOptimized
-Note that this will always require optimization passes to be run, which is highly undesireable.
-
-Your code:
-""", "1.2")
-  def inputForm: CircuitForm
+    "inputForm will be removed in 1.4, please follow migration instructions: https://gist.github.com/azidar/2595584157adb2228ef40d1e643e8ffd",
+    "1.2"
+  )
+  def inputForm: CircuitForm = UnknownForm
 
   /** The [[firrtl.CircuitForm]] that this transform outputs */
   @deprecatedOverriding(
-    """outputForm will be removed in 1.3. Use DependencyAPI method prerequisites, dependents, invalidates)
-Please delete your overriding of outputForm:
-  - override def outputForm = [[[LowForm|MidForm|HighForm|ChirrtlForm]]]
-
-Then, you will need to override 'def invalidates' depending on your transform.
-  + override def invalidates(a: Transform): Boolean = ...
-
-First we listed the most conservative options to replicate existing behavior. However, we recommend not doing these
-solutions, but instead understanding your transform and trying to minimize the number of transforms you invalidate.
-This can significantly reduce your execution runtime through not unnecessarily rerunning many transforms.
-
-Conservative solutions:
-
-If inputForm == outputForm == UnknownForm:
-  + override def invalidates(a: Transform): Boolean = true
-
-If inputForm == outputForm != UnknownForm:
-  + override def invalidates(a: Transform): Boolean = false
-
-If inputForm != outputForm and outputForm is HighForm:
-  + override def invalidates(a: Transform): Boolean =
-     (Forms.VerilogOptimized -- Forms.MinimalHighForm).contains(Dependency.fromTransform(a))
-
-If inputForm != outputForm and outputForm is MidForm:
-  + override def invalidates(a: Transform): Boolean =
-     (Forms.VerilogOptimized -- Forms.MidForm).contains(Dependency.fromTransform(a))
-
-Recommended Solutions:
-
-For faster and less conservative invalidation, consider if you know more about what this transform does. If so, you can
-selectively invalidate the transforms you know need to be rerun. For example if you invalidate deduplication (and want
-it to be rerun) you can do the following:
-  + override def invalidates(a: Transform): Boolean = Dependency.is[firrtl.transforms.DedupModules](a)
-
-Your code:
-""", "1.2")
-  def outputForm: CircuitForm
+    "outputForm will be removed in 1.4, please follow migration instructions: https://gist.github.com/azidar/2595584157adb2228ef40d1e643e8ffd",
+    "1.2"
+  )
+  def outputForm: CircuitForm = UnknownForm
 
   /** Perform the transform, encode renaming with RenameMap, and can
     *   delete annotations

--- a/src/main/scala/firrtl/FirrtlException.scala
+++ b/src/main/scala/firrtl/FirrtlException.scala
@@ -41,3 +41,10 @@ case class CustomTransformException(cause: Throwable) extends Exception("", caus
   */
 private[firrtl] class FirrtlInternalException(message: String, cause: Throwable = null)
   extends Exception(message, cause)
+
+/** A useful exception for an unexpected match within FIRRTL
+  * @param other The value which is not matched
+  * @param cause Cause of exception, usually left blank
+  */
+private[firrtl] class FirrtlUnexpectedMatch(other: Any, cause: Throwable = null)
+  extends FirrtlInternalException(s"Unexpected match: $other", cause)

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -156,11 +156,13 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
                 case (_, "?") => UnknownBound
                 case ("(", v) => Open(string2BigDecimal(v))
                 case ("[", v) => Closed(string2BigDecimal(v))
+                case other => throw new FirrtlUnexpectedMatch(other)
               }
               val upper = (ctx.upperBound.getText, ctx.boundValue(1).getText) match {
                 case (_, "?") => UnknownBound
                 case (")", v) => Open(string2BigDecimal(v))
                 case ("]", v) => Closed(string2BigDecimal(v))
+                case other => throw new FirrtlUnexpectedMatch(other)
               }
               val point = ctx.intLit.size match {
                 case 0 => UnknownWidth

--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -72,6 +72,7 @@ trait SingleTargetAnnotation[T <: Named] extends Annotation {
                   s"cannot be renamed to ${newTarget.getClass}"
                 throw AnnotationException(msg)
             }
+          case other => throw new FirrtlUnexpectedMatch(other)
         })).getOrElse(List(this))
     }
   }

--- a/src/main/scala/firrtl/annotations/Target.scala
+++ b/src/main/scala/firrtl/annotations/Target.scala
@@ -231,6 +231,7 @@ case class GenericTarget(circuitOpt: Option[String],
           (getRef, getInstanceOf) match {
             case (Some((r, comps)), _) => ReferenceTarget(c, m, path, r, comps)
             case (None, Some((i, o)))  => InstanceTarget(c, m, path, i, o)
+            case other => throw new FirrtlUnexpectedMatch(other)
           }
       }
       Some(target)
@@ -458,6 +459,7 @@ trait IsComponent extends IsMember {
             case ("", Ref(name)) => name
             case (string, Field(value)) => s"$string.$value"
             case (string, Index(value)) => s"$string[$value]"
+            case other => throw new FirrtlUnexpectedMatch(other)
           }
           ComponentName(name, mn)
         case Seq(Instance(name), OfModule(o)) => ComponentName(name, mn)
@@ -595,6 +597,7 @@ case class ReferenceTarget(circuit: String,
         case Index(idx) => sub_type(baseType)
         case Field(field) => field_type(baseType, field)
         case _: Ref => baseType
+        case other => throw new FirrtlUnexpectedMatch(other)
       }
       componentType(headType, tokens.tail)
     }

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -727,6 +727,7 @@ case class IntervalType(lower: Bound, upper: Bound, point: Width) extends Ground
       case x => Some(x.setScale(0, FLOOR) * prec)
     }
     case (Closed(a), Some(prec)) => Some((a / prec).setScale(0, FLOOR) * prec)
+    case other => throw new FirrtlUnexpectedMatch(other)
   }
 
   def minAdjusted: Option[BigInt] = min.map(_ * BigDecimal(BigInt(1) << bp) match {

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -42,8 +42,8 @@ object Dependency {
     * @tparam A type of Dependency
     * @return Whether they are equivalent
     */
-  def is[A <: DependencyAPI[_] : ClassTag](t: DependencyAPI[_]): Boolean =
-    fromTransform(t) == Dependency[A]
+  //def is[A <: DependencyAPI[_] : ClassTag](t: DependencyAPI[_]): Boolean =
+  //  fromTransform(t) == Dependency[A]
 }
 
 case class Dependency[+A <: DependencyAPI[_]](id: Either[Class[_ <: A], A with Singleton]) {

--- a/src/main/scala/firrtl/options/Phase.scala
+++ b/src/main/scala/firrtl/options/Phase.scala
@@ -36,6 +36,14 @@ object Dependency {
   private def isSingleton(obj: AnyRef): Boolean = {
     reflect.runtime.currentMirror.reflect(obj).symbol.isModuleClass
   }
+
+  /** Determines whether a given concrete DependencyAPI[_] is the same as a given Dependency[_]
+    * @param t concrete value
+    * @tparam A type of Dependency
+    * @return Whether they are equivalent
+    */
+  def is[A <: DependencyAPI[_] : ClassTag](t: DependencyAPI[_]): Boolean =
+    fromTransform(t) == Dependency[A]
 }
 
 case class Dependency[+A <: DependencyAPI[_]](id: Either[Class[_ <: A], A with Singleton]) {

--- a/src/main/scala/firrtl/passes/InferWidths.scala
+++ b/src/main/scala/firrtl/passes/InferWidths.scala
@@ -103,6 +103,7 @@ class InferWidths extends Transform with ResolvedAnnotationPaths with PreservesA
     case (AsyncResetType, AsyncResetType) => Nil
     case (ResetType, _) => Nil
     case (_, ResetType) => Nil
+    case other => throw new FirrtlUnexpectedMatch(other)
   }
 
   private def addExpConstraints(e: Expression): Expression = e map addExpConstraints match {

--- a/src/main/scala/firrtl/passes/RemoveIntervals.scala
+++ b/src/main/scala/firrtl/passes/RemoveIntervals.scala
@@ -173,7 +173,7 @@ class RemoveIntervals extends Pass with PreservesAll[Transform] {
     case DefNode(info, name, value) => value.tpe match {
       case IntervalType(l, u, p) =>
         val newType = IntervalType(l, u, p)
-        Block(Seq(DefWire(info, name, newType), Connect(info, WRef(name, newType, WireKind, FEMALE), value)))
+        Block(Seq(DefWire(info, name, newType), Connect(info, WRef(name, newType, WireKind, SinkFlow), value)))
       case other => s
     }
     case other => other map makeWireStmt

--- a/src/main/scala/firrtl/passes/Resolves.scala
+++ b/src/main/scala/firrtl/passes/Resolves.scala
@@ -126,6 +126,7 @@ object CInferMDir extends Pass with PreservesAll[Transform] {
           case (MReadWrite, MWrite) => MReadWrite
           case (MReadWrite, MRead) => MReadWrite
           case (MReadWrite, MReadWrite) => MReadWrite
+          case other => throw new FirrtlUnexpectedMatch(other)
         }
       }
       e

--- a/src/main/scala/firrtl/proto/FromProto.scala
+++ b/src/main/scala/firrtl/proto/FromProto.scala
@@ -138,6 +138,7 @@ object FromProto {
     case ReadUnderWrite.UNDEFINED => ir.ReadUnderWrite.Undefined
     case ReadUnderWrite.OLD => ir.ReadUnderWrite.Old
     case ReadUnderWrite.NEW => ir.ReadUnderWrite.New
+    case other => throw new FirrtlUnexpectedMatch(other)
   }
 
   def convert(dt: Firrtl.Statement.CMemory.TypeAndDepth): (ir.Type, BigInt) =
@@ -161,6 +162,7 @@ object FromProto {
     case MEMORY_PORT_DIRECTION_READ => MRead
     case MEMORY_PORT_DIRECTION_WRITE => MWrite
     case MEMORY_PORT_DIRECTION_READ_WRITE => MReadWrite
+    case other => throw new FirrtlUnexpectedMatch(other)
   }
 
   def convert(port: Firrtl.Statement.MemoryPort, info: Firrtl.SourceInfo): CDefMPort = {
@@ -275,6 +277,7 @@ object FromProto {
     dir match {
       case Firrtl.Port.Direction.PORT_DIRECTION_IN => ir.Input
       case Firrtl.Port.Direction.PORT_DIRECTION_OUT => ir.Output
+      case other => throw new FirrtlUnexpectedMatch(other)
     }
   }
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -51,6 +51,7 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform {
       case Some(cir: CircuitName)   => ModuleName(name, cir)
       case Some(mod: ModuleName)    => ComponentName(name, mod)
       case Some(com: ComponentName) => ComponentName(s"${com.name}.$name", com.module)
+      case other => throw new FirrtlUnexpectedMatch(other)
     }
 
     val named = wrap(n, scope)

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -52,6 +52,7 @@ class SimplifyMems extends Transform {
             case Field(name, _, _) => // etc
               Connect(mem.info, WSubField(memPort, name), WSubField(adapterPort, name))
           }
+        case other => throw new FirrtlUnexpectedMatch(other)
       }
       memAdapters(mem.name) = adapterDecl
       renames.record(oldRT, oldRT.copy(ref = simpleMemDecl.name))

--- a/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
+++ b/src/main/scala/tutorial/lesson2-working-ir/AnalyzeCircuit.scala
@@ -4,7 +4,9 @@ package tutorial
 package lesson2
 
 // Compiler Infrastructure
-import firrtl.{Transform, LowForm, CircuitState, Utils}
+import firrtl.options.Dependency
+import firrtl.{CircuitState, Transform, Utils}
+import firrtl.stage.Forms.LowForm
 // Firrtl IR classes
 import firrtl.ir.{DefModule, Statement, DefInstance, Expression, Mux}
 // Firrtl compiler's working IR classes (WIR)
@@ -95,8 +97,8 @@ class Ledger {
   *   - TODO(izraelevitz)
   */
 class AnalyzeCircuit extends Transform {
-  def inputForm = LowForm
-  def outputForm = LowForm
+  override def prerequisites: Seq[Dependency[Transform]] = LowForm
+  override def invalidates(xform: Transform) = false
 
   // Called by [[Compiler]] to run your pass.
   def execute(state: CircuitState): CircuitState = {


### PR DESCRIPTION
My attempt to remove warnings and provide a migration path to use the dependency API, as well as experiment with scalafix.

To add `override` to all `def inputForm = ...` and `def outputForm = ...`, you can run in your project's sbt shell:
```sbt
> scalafix --rules=https://raw.githubusercontent.com/freechipsproject/firrtl/reduce-warnings/scalafix/rules/src/main/scala/fix/Firrtl.scala
```

### TODO Checklist
- [ ] Add case to scalafix for `val inputForm = ...` and `val outputForm`
- [ ] Consider switching from SemanticRule to a syntax rule so user code does not need to compile to use it
- [ ] Figure out publishing mechanism for scalafix patches
- [ ] Figure out how to advertise their existence
- [ ] Get feedback on MASSIVE deprecation instructions of those methods
- [ ] Fix Dependency.is method
- [ ] Add default value for inputForm/outputForm

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?

### Type of Improvement

- code cleanup
- new feature/API

### API Impact

Requires all subclasses of `Transform` to add the override keyword to their `def inputForm` and `def outputForm` functions. Adds verbose deprecation descriptions to help users migrate their code.

### Backend Code Generation Impact

None

### Desired Merge Strategy

Squash

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you mark as `Please Merge`?
