### PR TITLE
add TransformBatch for back-to-back Transforms

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -217,6 +217,9 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
     case U => Nil
   }
 
+  /** get prerequisites recursively. */
+  def recursivePrerequisites: Seq[Dependency[Transform]] = prerequisites.flatMap(_.getObject().prerequisites.flatMap(_.getObject().recursivePrerequisites)) ++ prerequisites
+
   override def optionalPrerequisites: Seq[Dependency[Transform]] = inputForm match {
     case L => Forms.LowFormOptimized
     case _ => Seq.empty
@@ -354,6 +357,7 @@ trait SeqTransformBased {
 }
 
 /** For transformations that are simply a sequence of transforms */
+@deprecated("use TransformBatch will be deprecated in 1.3", "1.2")
 abstract class SeqTransform extends Transform with SeqTransformBased {
   def execute(state: CircuitState): CircuitState = {
     /*

--- a/src/main/scala/firrtl/stage/transforms/Compiler.scala
+++ b/src/main/scala/firrtl/stage/transforms/Compiler.scala
@@ -4,7 +4,7 @@ package firrtl.stage.transforms
 
 import firrtl.options.DependencyManagerUtils.CharSet
 import firrtl.stage.TransformManager
-import firrtl.{Transform, VerilogEmitter}
+import firrtl.{SeqTransform, Transform}
 
 class Compiler(
   targets: Seq[TransformManager.TransformDependency],
@@ -25,20 +25,24 @@ class Compiler(
     val last = size - 1
 
     val f: PartialFunction[(Transform, Int), Seq[String]] = {
-      {
-        case (a: VerilogEmitter, `last`) =>
-          val firstTransforms = a.transforms.dropRight(1)
-          val lastTransform = a.transforms.last
-          Seq(s"$tab$l ${a.name}") ++
-            firstTransforms.map(t => s"""$tab${" " * c.size} $n ${t.name}""") :+
-            s"""$tab${" " * c.size} $l ${lastTransform.name}"""
-        case (a: VerilogEmitter, _) =>
-          val firstTransforms = a.transforms.dropRight(1)
-          val lastTransform = a.transforms.last
-          Seq(s"$tab$n ${a.name}") ++
-            firstTransforms.map(t => s"""$tab$c $n ${t.name}""") :+
-            s"""$tab$c $l ${lastTransform.name}"""
-      }
+      case (a: SeqTransform, `last`) =>
+        val firstTransforms = a.transforms.dropRight(1)
+        val lastTransform = a.transforms.last
+        Seq(s"$tab$l ${a.name}") ++
+          firstTransforms.map(t => s"""$tab${" " * c.size} $n ${t.name}""") :+
+          s"""$tab${" " * c.size} $l ${lastTransform.name}"""
+      case (a: SeqTransform, _) =>
+        val firstTransforms = a.transforms.dropRight(1)
+        val lastTransform = a.transforms.last
+        Seq(s"$tab$n ${a.name}") ++
+          firstTransforms.map(t => s"""$tab$c $n ${t.name}""") :+
+          s"""$tab$c $l ${lastTransform.name}"""
+      case (a: TransformBatch, _) =>
+        val firstTransforms = a.transformManager.flattenedTransformOrder.dropRight(1)
+        val lastTransform = a.transformManager.flattenedTransformOrder.last
+        Seq(s"$tab$n ${a.name}") ++
+          firstTransforms.map(t => s"""$tab$c $n ${t.name}""") :+
+          s"""$tab$c $l ${lastTransform.name}"""
     }
 
     Some(f)

--- a/src/main/scala/firrtl/stage/transforms/TransformBatch.scala
+++ b/src/main/scala/firrtl/stage/transforms/TransformBatch.scala
@@ -1,0 +1,36 @@
+package firrtl.stage.transforms
+
+import firrtl._
+import firrtl.options._
+import firrtl.stage.TransformManager
+
+trait TransformBatch extends Transform {
+  def inputForm: CircuitForm = UnknownForm
+
+  def outputForm: CircuitForm = UnknownForm
+
+  def transforms: Seq[Transform]
+
+  final override def prerequisites: Seq[Dependency[Transform]] = transforms.flatMap(_.recursivePrerequisites).distinct
+
+  final def allTransforms: Seq[Dependency[Transform]] = (transforms.map(t => Dependency.fromTransform(t)) ++
+    prerequisites.filter { prerequisite =>
+      transforms.map {
+        transform =>
+          transform.invalidates(prerequisite.getObject())
+      }.reduce(_ | _)
+    } ++
+    transforms.flatMap {
+      _.dependents.flatMap(_.getObject().recursivePrerequisites)
+    }
+    ).distinct
+
+  val transformManager = new TransformManager(allTransforms, prerequisites)
+
+  protected def runTransforms(state: CircuitState): CircuitState = transformManager.flattenedTransformOrder.foldLeft(state) { (in, xform) => xform.runTransform(in) }
+
+  def execute(state: CircuitState): CircuitState = {
+    val ret = runTransforms(state)
+    CircuitState(ret.circuit, outputForm, ret.annotations, ret.renames)
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - new feature/API                    

#### API Impact

  - deprecate `SeqTransfrom`
  - add `TransformBatch`

#### Backend Code Generation Impact

  No impact

#### Desired Merge Strategy

  - Squash: The PR will be squashed and merged (choose this if you have no preference. 

#### Release Notes
  
   It support add multi transforms wrapped in a single Transform like `SeqTransform` does, but:
     - Automatically generate prerequisites(The sum of all transforms)
     - Automatically adding necessary dependents and prerequisite to allTransforms.

   With this implementation, back-to-back transform can be easily implemented like this:
```
class SomeTransform extends TransformBatch {
  def transforms = Seq(
    new TransformA,
    new TransformC,
    new TransformD
  )
}
```

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?