### PR TITLE
Improve DependencyManager Scheduling

### DIFF
--- a/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
+++ b/src/test/scala/firrtlTests/options/PhaseManagerSpec.scala
@@ -386,6 +386,28 @@ object OrderingFixture {
 
 }
 
+object ChiselProxy {
+
+  class A extends IdentityPhase with PreservesAll {
+    override lazy val name = "A"
+  }
+
+  class B extends IdentityPhase {
+    override lazy val name = "B"
+    override def prerequisites = Seq(Dependency[A])
+    override def invalidates(phase: Phase): Boolean = phase match {
+      case _: A => true
+      case _    => false
+    }
+  }
+
+  class C extends IdentityPhase with PreservesAll {
+    override lazy val name = "C"
+    override def prerequisites = Seq(Dependency[A])
+  }
+
+}
+
 class PhaseManagerSpec extends AnyFlatSpec with Matchers {
 
   def writeGraphviz(pm: PhaseManager, dir: String): Unit = {
@@ -686,6 +708,29 @@ class PhaseManagerSpec extends AnyFlatSpec with Matchers {
       val order = Seq(classOf[f.B], classOf[f.A], classOf[f.Cx], classOf[f.B], classOf[f.A])
       (new PhaseManager(targets)).flattenedTransformOrder.map(_.getClass) should be (order)
     }
+  }
+
+  it should "work for the Chisel proxy case" in {
+    val f = ChiselProxy
+
+    {
+      val targets = Seq(Dependency[f.C], Dependency[f.B], Dependency[f.A])
+      val pm = new PhaseManager(targets)
+      writeGraphviz(pm, "test_run_dir/foor")
+      info(pm.prettyPrint())
+      val order = pm.flattenedTransformOrder.map(Dependency.fromTransform)
+      exactly (1, order) should be (Dependency[f.A])
+    }
+
+    {
+      val targets = Seq(Dependency[f.B], Dependency[f.C], Dependency[f.A])
+      val pm = new PhaseManager(targets)
+      writeGraphviz(pm, "test_run_dir/bar")
+      info(pm.prettyPrint())
+      val order = pm.flattenedTransformOrder.map(Dependency.fromTransform)
+      exactly (1, order) should be (Dependency[f.A])
+    }
+
   }
 
 }


### PR DESCRIPTION
This is intended to be a performance improvement for the `DependencyManager`.

For the case where multiple valid `invalidationGraph` orderings exist, the `DependencyManager` should choose the one which minimizes re-lowerings. A minimal test case is provided.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
