### PR TITLE
RenameMap: add associatedTransform field

### DIFF
--- a/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
+++ b/src/main/scala/firrtl/annotations/transforms/EliminateTargetPaths.scala
@@ -100,7 +100,7 @@ class EliminateTargetPaths extends Transform with DependencyAPIMigration with Pr
     lazy val finalModuleSet = finalModuleList.map{ case a: DefModule => a.name }.toSet
 
     // Records how targets have been renamed
-    val renameMap = RenameMap()
+    val renameMap = RenameMap(this)
 
     /* Foreach target, calculate the pathless version and only rename targets that are instantiated. Additionally, rename
      * module targets
@@ -162,7 +162,7 @@ class EliminateTargetPaths extends Transform with DependencyAPIMigration with Pr
       val cache = mutable.Map.empty[String, Boolean]
       mod => cache.getOrElseUpdate(mod, iGraph.findInstancesInHierarchy(mod).size == 1)
     }
-    val firstRenameMap = RenameMap()
+    val firstRenameMap = RenameMap(this)
     val nonSingletonTargets = targets.foldLeft(Seq.empty[IsMember]) {
       case (acc, t: IsComponent) if t.asPath.nonEmpty =>
         val origPath = t.asPath

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -220,7 +220,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
       }
 
       val maxIdx = indexMap.values.max
-      val resultSeq = Seq.fill(maxIdx + 1)(RenameMap())
+      val resultSeq = Seq.fill(maxIdx + 1)(RenameMap(this))
       val resultMap = indexMap.mapValues(idx => resultSeq(maxIdx - idx))
       (resultMap, resultSeq)
     }

--- a/src/main/scala/firrtl/passes/LowerTypes.scala
+++ b/src/main/scala/firrtl/passes/LowerTypes.scala
@@ -286,7 +286,7 @@ object LowerTypes extends Transform with DependencyAPIMigration {
 
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
-    val renames = RenameMap()
+    val renames = RenameMap(this)
     renames.setCircuit(c.main)
     val result = c copy (modules = c.modules map lowerTypes(renames))
     CircuitState(result, outputForm, state.annotations, Some(renames))

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -269,7 +269,7 @@ object RemoveCHIRRTL extends Transform with DependencyAPIMigration with Preserve
 
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
-    val renames = RenameMap()
+    val renames = RenameMap(this)
     renames.setCircuit(c.main)
     val result = c copy (modules = c.modules map remove_chirrtl_m(renames))
     state.copy(circuit = result, renames = Some(renames))

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -246,7 +246,7 @@ object Uniquify extends Transform with DependencyAPIMigration {
   // Everything wrapped in run so that it's thread safe
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
-    val renames = RenameMap()
+    val renames = RenameMap(this)
     renames.setCircuit(c.main)
     // Debug state
     implicit var mname: String = ""

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -188,7 +188,7 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
     // run executeEmptyMemStmt first to remove zero-width memories
     // then run InferTypes to update widths for addr, en, clk, etc
     val c = InferTypes.run(executeEmptyMemStmt(state).circuit)
-    val renames = RenameMap()
+    val renames = RenameMap(this)
     renames.setCircuit(c.main)
     val result = c.copy(modules = c.modules map onModule(renames))
     CircuitState(result, outputForm, state.annotations, Some(renames))

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -65,7 +65,7 @@ class UpdateAnnotations(val underlying: Transform) extends Transform with Wrappe
     }
 
     // For each annotation, rename all annotations.
-    val renames = renameOpt.getOrElse(RenameMap())
+    val renames = renameOpt.getOrElse(RenameMap(this))
     val remapped2original = mutable.LinkedHashMap[Annotation, mutable.LinkedHashSet[Annotation]]()
     val keysOfNote = mutable.LinkedHashSet[Annotation]()
     val finalAnnotations = newAnnotations.flatMap { anno =>

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -334,7 +334,7 @@ class DeadCodeElimination extends Transform
 
     val liveNodes = depGraph.reachableFrom(circuitSink) + circuitSink
     val deadNodes = depGraph.getVertices -- liveNodes
-    val renames = RenameMap()
+    val renames = RenameMap(this)
     renames.setCircuit(c.main)
 
     // As we delete deadCode, we will delete ports from Modules and somtimes complete modules

--- a/src/main/scala/firrtl/transforms/Dedup.scala
+++ b/src/main/scala/firrtl/transforms/Dedup.scala
@@ -67,7 +67,7 @@ class DedupModules extends Transform with DependencyAPIMigration with PreservesA
   def run(c: Circuit, noDedups: Seq[String], annos: Seq[Annotation]): (Circuit, RenameMap) = {
 
     // RenameMap
-    val renameMap = RenameMap()
+    val renameMap = RenameMap(this)
     renameMap.setCircuit(c.main)
 
     // Maps module name to corresponding dedup module
@@ -336,9 +336,6 @@ object DedupModules {
     val agnosticRename = RenameMap()
 
     moduleLinearization.foreach { originalModule =>
-      // Replace instance references to new deduped modules
-      val dontcare = RenameMap()
-      dontcare.setCircuit("dontcare")
 
       if (noDedups.contains(originalModule.name)) {
         // Don't dedup. Set dedup module to be the same as fixed module

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -187,7 +187,7 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform with Depe
     * @param renames a [[RenameMap]] to update. If you don't want to propagate renames, this can be ignored.
     * @return a [[firrtl.ir Circuit]] without keyword conflicts
     */
-  def run(c: ir.Circuit, renames: RenameMap = RenameMap()): ir.Circuit = {
+  def run(c: ir.Circuit, renames: RenameMap = RenameMap(this)): ir.Circuit = {
     implicit val circuitNamespace: Namespace = Namespace(c)
     implicit val scope: Option[CircuitName] = Some(CircuitName(c.main))
     val modType: ModuleType = new ModuleType()
@@ -224,7 +224,7 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends Transform with Depe
     * @return a [[CircuitState]] without name collisions
     */
   def execute(state: CircuitState): CircuitState = {
-    val renames = RenameMap()
+    val renames = RenameMap(this)
     renames.setCircuit(state.circuit.main)
     state.copy(circuit = run(state.circuit, renames), renames = Some(renames))
   }

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -79,7 +79,7 @@ class SimplifyMems extends Transform with DependencyAPIMigration with PreservesA
 
   override def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
-    val renames = RenameMap()
+    val renames = RenameMap(this)
     state.copy(circuit = c.map(onModule(c, renames)), renames = Some(renames))
   }
 }


### PR DESCRIPTION
Adds `associatedTransform` and updates constructor call sites to pass in a transform. These are @azidar changes from https://github.com/freechipsproject/firrtl/pull/1539.


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
This adds a `val associatedTransform: Transform` field to `RenameMap` and adds a new constructor `def apply(associatedTransform: Transform)` to create a `RenameMap` with an associated transform.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
add `associatedTransform` field to `RenameMap`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
