### PR TITLE
Parallelize Identity Transforms

### DIFF
--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -256,6 +256,10 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
 
     txs.foldRight(Seq.empty[TransformLike[A]]){
       case (a, acc) => a match {
+        case aa: firrtl.stage.transforms.WrappedTransform => aa.trueUnderlying match {
+          case _: IdentityLike[A] => Seq(new Speculative(aa, acc))
+          case _ => aa +: acc
+        }
         case aa: IdentityLike[A] => Seq(new Speculative(aa, acc))
         case aa => aa +: acc
       }

--- a/src/main/scala/firrtl/options/Speculative.scala
+++ b/src/main/scala/firrtl/options/Speculative.scala
@@ -1,0 +1,37 @@
+// See LICENSE for license details.
+
+package firrtl.options
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
+
+class Speculative[A](
+  identity: TransformLike[A] with IdentityLike[A],
+  speculative: Seq[TransformLike[A]]) extends TransformLike[A] {
+
+  override val name = s"speculating past ${identity.name}"
+
+  final override def transform(a: A): A = {
+
+    val aIdentity: Future[A] = Future {
+      identity.transform(a)
+    }
+
+    aIdentity.onComplete{
+      f => f match {
+        case Success(a) => a
+        case Failure(a) => throw a
+      }
+    }
+
+    try {
+      speculative.foldLeft(a: A){ case (acc, tx) => tx.transform(acc) }
+    } catch {
+      case t: Throwable => Await.result(aIdentity, Duration.Inf)
+    }
+
+  }
+
+}

--- a/src/main/scala/firrtl/options/Speculative.scala
+++ b/src/main/scala/firrtl/options/Speculative.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 
 class Speculative[A](
-  identity: TransformLike[A] with IdentityLike[A],
+  identity: TransformLike[A],
   speculative: Seq[TransformLike[A]]) extends TransformLike[A] {
 
   override val name = s"speculating past ${identity.name}"

--- a/src/main/scala/firrtl/passes/CheckChirrtl.scala
+++ b/src/main/scala/firrtl/passes/CheckChirrtl.scala
@@ -2,11 +2,14 @@
 
 package firrtl.passes
 
-import firrtl.Transform
+import firrtl.{CircuitState, Transform}
 import firrtl.ir._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.{Dependency, IdentityLike, PreservesAll}
 
-object CheckChirrtl extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+object CheckChirrtl extends Pass
+    with CheckHighFormLike
+    with PreservesAll[Transform]
+    with IdentityLike[CircuitState] {
 
   override val optionalPrerequisiteOf = firrtl.stage.Forms.ChirrtlForm ++
     Seq( Dependency(CInferTypes),

--- a/src/main/scala/firrtl/passes/CheckFlows.scala
+++ b/src/main/scala/firrtl/passes/CheckFlows.scala
@@ -6,9 +6,9 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.{Dependency, IdentityLike, PreservesAll}
 
-object CheckFlows extends Pass with PreservesAll[Transform] {
+object CheckFlows extends Pass with PreservesAll[Transform] with IdentityLike[CircuitState] {
 
   override def prerequisites = Dependency(passes.ResolveFlows) +: firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -7,7 +7,7 @@ import firrtl.ir._
 import firrtl.PrimOps._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.{Dependency, IdentityLike, PreservesAll}
 
 trait CheckHighFormLike { this: Pass =>
   type NameSet = collection.mutable.HashSet[String]
@@ -280,7 +280,7 @@ trait CheckHighFormLike { this: Pass =>
   }
 }
 
-object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Transform] {
+object CheckHighForm extends Pass with CheckHighFormLike with PreservesAll[Transform] with IdentityLike[CircuitState] {
 
   override def prerequisites = firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/passes/CheckInitialization.scala
+++ b/src/main/scala/firrtl/passes/CheckInitialization.scala
@@ -6,7 +6,7 @@ import firrtl._
 import firrtl.ir._
 import firrtl.Utils._
 import firrtl.traversals.Foreachers._
-import firrtl.options.PreservesAll
+import firrtl.options.{IdentityLike, PreservesAll}
 
 import annotation.tailrec
 
@@ -15,7 +15,7 @@ import annotation.tailrec
   * @note This pass looks for [[firrtl.WVoid]]s left behind by [[ExpandWhens]]
   * @note Assumes single connection (ie. no last connect semantics)
   */
-object CheckInitialization extends Pass with PreservesAll[Transform] {
+object CheckInitialization extends Pass with PreservesAll[Transform] with IdentityLike[CircuitState] {
 
   override def prerequisites = firrtl.stage.Forms.Resolved
 

--- a/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -9,9 +9,9 @@ import firrtl.Utils._
 import firrtl.traversals.Foreachers._
 import firrtl.WrappedType._
 import firrtl.constraint.{Constraint, IsKnown}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.{Dependency, IdentityLike, PreservesAll}
 
-object CheckTypes extends Pass with PreservesAll[Transform] {
+object CheckTypes extends Pass with PreservesAll[Transform] with IdentityLike[CircuitState] {
 
   override def prerequisites = Dependency(InferTypes) +: firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/passes/CheckWidths.scala
+++ b/src/main/scala/firrtl/passes/CheckWidths.scala
@@ -9,9 +9,9 @@ import firrtl.traversals.Foreachers._
 import firrtl.Utils._
 import firrtl.constraint.IsKnown
 import firrtl.annotations.{CircuitTarget, ModuleTarget, Target, TargetToken}
-import firrtl.options.{Dependency, PreservesAll}
+import firrtl.options.{Dependency, IdentityLike, PreservesAll}
 
-object CheckWidths extends Pass with PreservesAll[Transform] {
+object CheckWidths extends Pass with PreservesAll[Transform] with IdentityLike[CircuitState] {
 
   override def prerequisites = Dependency[passes.InferWidths] +: firrtl.stage.Forms.WorkingIR
 

--- a/src/main/scala/firrtl/transforms/CheckCombLoops.scala
+++ b/src/main/scala/firrtl/transforms/CheckCombLoops.scala
@@ -12,7 +12,7 @@ import firrtl.annotations._
 import firrtl.Utils.throwInternalError
 import firrtl.graph._
 import firrtl.analyses.InstanceGraph
-import firrtl.options.{Dependency, PreservesAll, RegisteredTransform, ShellOption}
+import firrtl.options.{Dependency, IdentityLike, PreservesAll, RegisteredTransform, ShellOption}
 
 /**
   * A case class that represents a net in the circuit. This is necessary since combinational loop
@@ -101,7 +101,8 @@ case class CombinationalPath(sink: ReferenceTarget, sources: Seq[ReferenceTarget
 class CheckCombLoops extends Transform
     with RegisteredTransform
     with DependencyAPIMigration
-    with PreservesAll[Transform] {
+    with PreservesAll[Transform]
+    with IdentityLike[CircuitState] {
 
   override def prerequisites = firrtl.stage.Forms.MidForm ++
     Seq( Dependency(passes.LowerTypes),

--- a/src/test/scala/firrtlTests/options/SpeculativeSpec.scala
+++ b/src/test/scala/firrtlTests/options/SpeculativeSpec.scala
@@ -1,0 +1,65 @@
+// See LICENSE for license details.
+
+package firrtlTests.options
+
+import firrtl.AnnotationSeq
+import firrtl.options.{
+  Dependency,
+  IdentityLike,
+  Phase,
+  PhaseManager
+}
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+object SpeculativeSpec {
+
+  class Foo extends Phase with IdentityLike[AnnotationSeq] {
+
+    override def prerequisites = Seq.empty
+    override def optionalPrerequisites = Seq.empty
+    override def optionalPrerequisiteOf = Seq.empty
+    override def invalidates(a: Phase) = false
+
+    override def internalTransform(a: AnnotationSeq) = {
+      println("Starting Foo")
+      Thread.sleep(1000)
+      println("Foo done!")
+    }
+
+  }
+
+  class Bar extends Phase {
+
+    override def prerequisites = Seq(Dependency[Foo])
+    override def optionalPrerequisites = Seq.empty
+    override def optionalPrerequisiteOf = Seq.empty
+    override def invalidates(a: Phase) = false
+
+    override def transform(a: AnnotationSeq) = {
+      println("Starting Bar")
+      Thread.sleep(1000)
+      println("Bar done!")
+      a
+    }
+
+  }
+
+}
+
+class SpeculativeSpec extends AnyFlatSpec with Matchers {
+
+  import SpeculativeSpec._
+
+  behavior of "Speculative TransformLikes"
+
+  it should "run in parallel" in {
+
+    val pm = new PhaseManager(Seq(Dependency[Foo], Dependency[Bar]))
+
+    pm.transform(Seq.empty)
+
+  }
+
+}


### PR DESCRIPTION
This enables transforms which are known to be identity functions (like `CheckTypes`) to be forked to separate processes. The mainline transforms then continue. Proper attribution of where an exception was thrown is still maintained.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
