### PR TITLE
Enable Passing Objects to --custom-transforms/-fct

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -5,7 +5,7 @@ package firrtl.stage
 import firrtl._
 import firrtl.ir.Circuit
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{HasShellOptions, OptionsException, ShellOption, Unserializable}
+import firrtl.options.{Dependency, HasShellOptions, OptionsException, ShellOption, Unserializable}
 
 
 import java.io.FileNotFoundException
@@ -168,14 +168,19 @@ object CompilerAnnotation extends HasShellOptions {
 
 }
 
-/** Holds the unambiguous class name of a [[Transform]] to run
-  *  - will be append to [[FirrtlExecutionOptions.customTransforms]]
-  *  - set with `-fct/--custom-transforms`
-  * @param transform the full class name of the transform
+/** Add a [[Transform]] to be run by the FIRRTL compiler.
+  *
+  * Either this annotation can be included directly, or a transform can be added with `-fct`/`--custom-transforms`
+  *
+  * @param transform a [[firrtl.options.Dependency Dependency]] wrapped [[Transform]]
   */
-case class RunFirrtlTransformAnnotation(transform: Transform) extends NoTargetAnnotation
+case class RunFirrtlTransformAnnotation(transform: Dependency[Transform]) extends NoTargetAnnotation
 
 object RunFirrtlTransformAnnotation extends HasShellOptions {
+
+  @deprecated("Use RunFirrtlTransformAnnotation(Dependency(transform)).", "FIRRTL 1.4")
+  def apply(transform: Transform): RunFirrtlTransformAnnotation =
+    RunFirrtlTransformAnnotation(Dependency.fromTransform(transform))
 
   val options = Seq(
     new ShellOption[Seq[String]](

--- a/src/main/scala/firrtl/stage/phases/Compiler.scala
+++ b/src/main/scala/firrtl/stage/phases/Compiler.scala
@@ -13,13 +13,13 @@ import scala.collection.mutable
 private [stage] case class CompilerRun(
   stateIn: CircuitState,
   stateOut: Option[CircuitState],
-  transforms: Seq[Transform],
+  transforms: Seq[Dependency[Transform]],
   compiler: Option[FirrtlCompiler] )
 
 /** An encoding of possible defaults for a [[CompilerRun]] */
 private [stage] case class Defaults(
   annotations: AnnotationSeq = Seq.empty,
-  transforms: Seq[Transform] = Seq.empty,
+  transforms: Seq[Dependency[Transform]] = Seq.empty,
   compiler: Option[FirrtlCompiler] = None)
 
 /** Runs the FIRRTL compilers on an [[AnnotationSeq]]. If the input [[AnnotationSeq]] contains more than one circuit
@@ -95,7 +95,7 @@ class Compiler extends Phase with Translator[AnnotationSeq, Seq[CompilerRun]] wi
   protected def internalTransform(b: Seq[CompilerRun]): Seq[CompilerRun] = {
     def f(c: CompilerRun): CompilerRun = {
       val targets = c.compiler match {
-        case Some(d) => c.transforms.reverse.map(Dependency.fromTransform(_)) ++ compilerToTransforms(d)
+        case Some(d) => c.transforms.reverse ++ compilerToTransforms(d)
         case None    => throw new PhasePrerequisiteException("No compiler specified!") }
       val tm = new firrtl.stage.transforms.Compiler(targets)
       /* Transform order is lazily evaluated. Force it here to remove its resolution time from actual compilation. */

--- a/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
@@ -4,7 +4,7 @@ package firrtlTests.stage
 
 
 import firrtl.stage.RunFirrtlTransformAnnotation
-import firrtl.options.Shell
+import firrtl.options.{Dependency, Shell}
 import firrtl.stage.FirrtlCli
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -20,16 +20,16 @@ class FirrtlCliSpec extends AnyFlatSpec with Matchers {
       "--custom-transforms", "firrtl.transforms.CombineCats",
       "--custom-transforms", "firrtl.transforms.ConstantPropagation" )
     val expected = Seq(
-      classOf[firrtl.transforms.BlackBoxSourceHelper],
-      classOf[firrtl.transforms.CheckCombLoops],
-      classOf[firrtl.transforms.CombineCats],
-      classOf[firrtl.transforms.ConstantPropagation] )
+      Dependency[firrtl.transforms.BlackBoxSourceHelper],
+      Dependency[firrtl.transforms.CheckCombLoops],
+      Dependency[firrtl.transforms.CombineCats],
+      Dependency[firrtl.transforms.ConstantPropagation] )
 
     shell
       .parse(args)
       .collect{ case a: RunFirrtlTransformAnnotation => a }
       .zip(expected)
-      .map{ case (RunFirrtlTransformAnnotation(a), b) => a.getClass should be (b) }
+      .map{ case (RunFirrtlTransformAnnotation(a), b) => a should be (b) }
   }
 
 }

--- a/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlCliSpec.scala
@@ -18,12 +18,14 @@ class FirrtlCliSpec extends AnyFlatSpec with Matchers {
     val args = Array(
       "--custom-transforms", "firrtl.transforms.BlackBoxSourceHelper,firrtl.transforms.CheckCombLoops",
       "--custom-transforms", "firrtl.transforms.CombineCats",
-      "--custom-transforms", "firrtl.transforms.ConstantPropagation" )
+      "--custom-transforms", "firrtl.transforms.ConstantPropagation",
+      "--custom-transforms", "firrtl.passes.InferTypes$")
     val expected = Seq(
       Dependency[firrtl.transforms.BlackBoxSourceHelper],
       Dependency[firrtl.transforms.CheckCombLoops],
       Dependency[firrtl.transforms.CombineCats],
-      Dependency[firrtl.transforms.ConstantPropagation] )
+      Dependency[firrtl.transforms.ConstantPropagation],
+      Dependency(firrtl.passes.InferTypes))
 
     shell
       .parse(args)


### PR DESCRIPTION
This lets a user pass an object (with a trailing `$`) as a command line custom transform, e.g., this lets a user do the following:

```
firrtl -i Foo.fir -fct firrtl.passes.InferTypes$
```

### Dependencies

- prerequisites: [https://github.com/freechipsproject/chisel3/pull/1475, https://github.com/freechipsproject/firrtl/pull/1697]

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Pure API expansion of the FIRRTL command line interface.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
