### PR TITLE
Implement GraphML for DiGraph

### DIFF
--- a/src/main/scala/firrtl/graph/GraphML.scala
+++ b/src/main/scala/firrtl/graph/GraphML.scala
@@ -2,6 +2,9 @@
 
 package firrtl.graph
 
+import firrtl.analyses.ConnectionGraph
+import firrtl.annotations.{ReferenceTarget, Target}
+
 import scala.collection.Set
 
 trait GraphAttribute {
@@ -16,22 +19,27 @@ trait GraphAttribute {
 
   // @todo: in Scala 2.13 it will be cleaner with Type tricks...
   def toGraphML =
-    s"""<data key="$id">${attrType match {
-      case "string" => s""""$value""""
-      case _ => value
-    }}</data>""".stripMargin
+    s"""<data key="$id">${
+      attrType match {
+        case "string" => s""""$value""""
+        case _ => value
+      }
+    }</data>""".stripMargin
 }
 
 trait GraphMLEdge {
-  val id: Option[String] = None
-  val source: GraphMLVertex
-  val target: GraphMLVertex
-  val attributes: Set[GraphAttribute]
+  val gmId: Option[String] = None
+  val gmSource: GraphMLVertex
+  val gmTarget: GraphMLVertex
+  val gmAttributes: Set[GraphAttribute]
+
   def toGraphML =
-    s"""<edge${id match {
-      case Some(id) => s" $id "
-      case None => " "
-    }}source="${source.gmId}" target="${target.gmId}">${attributes.map(_.toGraphML).mkString("\n  ")}</edge>"""
+    s"""<edge${
+      gmId match {
+        case Some(id) => s" $id "
+        case None => " "
+      }
+    }source="${gmSource.gmId}" target="${gmTarget.gmId}">${gmAttributes.map(_.toGraphML).mkString("\n  ")}</edge>"""
 }
 
 trait GraphMLVertex {
@@ -49,23 +57,43 @@ trait GraphMLVertex {
 
 
 object GraphML {
-  implicit class WithGraphML[T <: GraphMLVertex](diGraph: DiGraph[T]) {
-    /* require ids to be unique. */
-    require(graphMLVertices.groupBy(_.gmId).values.forall(_.size == 1))
-    lazy val graphMLVertices: Set[T] = diGraph.getVertices
-    lazy val graphMLEdges: Set[GraphMLEdge] = diGraph.getEdgeMap.flatMap { case (e, es) => es.map(e.gmEdge(_)) }.toSet
-    lazy val graphMLAttributes: Set[GraphAttribute] = graphMLVertices.flatMap(_.gmAttributes) ++ graphMLEdges.flatMap(_.attributes)
-    lazy val graphML =
-      s"""<?xml version="1.0" encoding="UTF-8"?>
-         |<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
-         |${graphMLAttributes.map(_.toGraphMLHeader).mkString("\n")}
-         |<graph id="G" edgedefault="directed">
-         |  ${graphMLVertices.map(_.toGraphML).mkString("\n  ")}
-         |  ${graphMLEdges.map(_.toGraphML).mkString("\n  ")}
-         |</graph>
-         |</graphml>
-      """.stripMargin
+  def connectionGraph(connectionGraph: ConnectionGraph): String = apply(connectionGraph, referenceTargetHelper)
+
+
+  def apply[T <: GraphMLVertex](diGraph: DiGraph[T]): String = gml(
+    diGraph.getVertices,
+    diGraph.getEdgeMap.flatMap { case (source, targets) => targets.map(t => source.gmEdge(t)) }.toSet
+  )
+
+  def apply[T, G <: DiGraph[T]](diGraph: G, helper: (G, T) => GraphMLVertex): String = gml(
+    diGraph.getVertices.map(helper(diGraph, _)),
+    diGraph.getEdgeMap.flatMap { case (source, targets) => targets.map(t => helper(diGraph, source).gmEdge(helper(diGraph, t))) }.toSet
+  )
+
+  private def referenceTargetHelper(digraph: ConnectionGraph, rt: ReferenceTarget): GraphMLVertex = new GraphMLVertex {
+    gmlv =>
+    override def gmId: String = rt.toString
+
+    override def gmAttributes: Set[GraphAttribute] = Set.empty
+
+    override def gmEdge(target: GraphMLVertex): GraphMLEdge = new GraphMLEdge {
+      val gmSource: GraphMLVertex = gmlv
+      val gmTarget: GraphMLVertex = target
+      val gmAttributes: Set[GraphAttribute] = Set.empty
+    }
   }
 
-  def apply[T <: GraphMLVertex](diGraph: DiGraph[T]) = diGraph.graphML
+  private def gml[V <: GraphMLVertex, E <: GraphMLEdge](graphMLVertices: Set[V], graphMLEdges: Set[E]): String = {
+    require(graphMLVertices.groupBy(_.gmId).values.forall(_.size == 1))
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+       |<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+       |${(graphMLVertices.flatMap(_.gmAttributes) ++ graphMLEdges.flatMap(_.gmAttributes)).map(_.toGraphMLHeader).mkString("\n")}
+       |<graph id="G" edgedefault="directed">
+       |  ${graphMLVertices.map(_.toGraphML).mkString("\n  ")}
+       |  ${graphMLEdges.map(_.toGraphML).mkString("\n  ")}
+       |</graph>
+       |</graphml>
+      """.stripMargin
+  }
 }
+

--- a/src/main/scala/firrtl/graph/GraphML.scala
+++ b/src/main/scala/firrtl/graph/GraphML.scala
@@ -1,0 +1,72 @@
+// See LICENSE for license details.
+
+package firrtl.graph
+
+import scala.collection.Set
+
+trait GraphAttribute {
+  val id: String
+  val attrFor: String
+  val attrType: String
+  val attrName: String
+  val value: String
+
+  def toGraphMLHeader =
+    s"""<key id="$id" for="$attrFor" attr.name="$attrName" attr.type="$attrType"/>""".stripMargin
+
+  // @todo: in Scala 2.13 it will be cleaner with Type tricks...
+  def toGraphML =
+    s"""<data key="$id">${attrType match {
+      case "string" => s""""$value""""
+      case _ => value
+    }}</data>""".stripMargin
+}
+
+trait GraphMLEdge {
+  val id: Option[String] = None
+  val source: GraphMLVertex
+  val target: GraphMLVertex
+  val attributes: Set[GraphAttribute]
+  def toGraphML =
+    s"""<edge${id match {
+      case Some(id) => s" $id "
+      case None => " "
+    }}source="${source.id}" target="${target.id}">${attributes.map(_.toGraphML).mkString("\n  ")}</edge>"""
+}
+
+trait GraphMLVertex {
+  def id: String
+
+  def attributes: Set[GraphAttribute]
+
+  def source = this
+
+  def edge(target: GraphMLVertex): GraphMLEdge
+
+  def toGraphML =
+    s"""<node id="${id}">${attributes.map(_.toGraphML).mkString("\n  ")}</node>""".stripMargin
+}
+
+
+object GraphML {
+
+  implicit class WithGraphML[T <: GraphMLVertex](diGraph: DiGraph[T]) {
+    /* require ids to be unique. */
+    require(graphMLVertices.groupBy(_.id).values.forall(_.size == 1))
+    lazy val graphMLVertices: Set[T] = diGraph.getVertices
+    lazy val graphMLEdges: Set[GraphMLEdge] = diGraph.getEdgeMap.flatMap { case (e, es) => es.map(e.edge(_)) }.toSet
+    lazy val graphMLAttributes: Set[GraphAttribute] = graphMLVertices.flatMap(_.attributes) ++ graphMLEdges.flatMap(_.attributes)
+    lazy val graphML =
+      s"""<?xml version="1.0" encoding="UTF-8"?>
+         |<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+         |${graphMLAttributes.map(_.toGraphMLHeader).mkString("\n")}
+         |<graph id="G" edgedefault="directed">
+         |  ${graphMLVertices.map(_.toGraphML).mkString("\n  ")}
+         |  ${graphMLEdges.map(_.toGraphML).mkString("\n  ")}
+         |</graph>
+         |</graphml>
+      """.stripMargin
+  }
+
+  def apply[T <: GraphMLVertex](diGraph: DiGraph[T]) = diGraph.graphML
+}

--- a/src/main/scala/firrtl/graph/GraphML.scala
+++ b/src/main/scala/firrtl/graph/GraphML.scala
@@ -31,31 +31,30 @@ trait GraphMLEdge {
     s"""<edge${id match {
       case Some(id) => s" $id "
       case None => " "
-    }}source="${source.id}" target="${target.id}">${attributes.map(_.toGraphML).mkString("\n  ")}</edge>"""
+    }}source="${source.gmId}" target="${target.gmId}">${attributes.map(_.toGraphML).mkString("\n  ")}</edge>"""
 }
 
 trait GraphMLVertex {
-  def id: String
+  def gmId: String
 
-  def attributes: Set[GraphAttribute]
+  def gmAttributes: Set[GraphAttribute]
 
-  def source = this
+  final def gmSource = this
 
-  def edge(target: GraphMLVertex): GraphMLEdge
+  def gmEdge(target: GraphMLVertex): GraphMLEdge
 
   def toGraphML =
-    s"""<node id="${id}">${attributes.map(_.toGraphML).mkString("\n  ")}</node>""".stripMargin
+    s"""<node id="${gmId}">${gmAttributes.map(_.toGraphML).mkString("\n  ")}</node>""".stripMargin
 }
 
 
 object GraphML {
-
   implicit class WithGraphML[T <: GraphMLVertex](diGraph: DiGraph[T]) {
     /* require ids to be unique. */
-    require(graphMLVertices.groupBy(_.id).values.forall(_.size == 1))
+    require(graphMLVertices.groupBy(_.gmId).values.forall(_.size == 1))
     lazy val graphMLVertices: Set[T] = diGraph.getVertices
-    lazy val graphMLEdges: Set[GraphMLEdge] = diGraph.getEdgeMap.flatMap { case (e, es) => es.map(e.edge(_)) }.toSet
-    lazy val graphMLAttributes: Set[GraphAttribute] = graphMLVertices.flatMap(_.attributes) ++ graphMLEdges.flatMap(_.attributes)
+    lazy val graphMLEdges: Set[GraphMLEdge] = diGraph.getEdgeMap.flatMap { case (e, es) => es.map(e.gmEdge(_)) }.toSet
+    lazy val graphMLAttributes: Set[GraphAttribute] = graphMLVertices.flatMap(_.gmAttributes) ++ graphMLEdges.flatMap(_.attributes)
     lazy val graphML =
       s"""<?xml version="1.0" encoding="UTF-8"?>
          |<graphml xmlns="http://graphml.graphdrawing.org/xmlns">

--- a/src/test/scala/firrtlTests/graph/GraphMLTests.scala
+++ b/src/test/scala/firrtlTests/graph/GraphMLTests.scala
@@ -2,22 +2,27 @@
 
 package firrtlTests.graph
 
+import firrtl.{CircuitState, FileUtils, UnknownForm}
+import firrtl.analyses.ConnectionGraph
 import firrtl.graph._
+import firrtl.options.Dependency
+import firrtl.passes.ExpandWhensAndCheck
 import firrtl.testutils._
 
 
 class GraphMLTests extends FirrtlFlatSpec {
+
   case class SimpleNode(name: String, gmAttributes: Set[GraphAttribute] = Set.empty) extends GraphMLVertex {
     override def gmId: String = name
 
     override def gmEdge(target: GraphMLVertex): GraphMLEdge = SimpleEdge(this, target, {
-      if(gmSource.gmId == "n1" & target.gmId == "n3") Set(WeightAttr("2.0"))
-      else if(gmSource.gmId == "n5" & target.gmId == "n4") Set(WeightAttr("2.0"))
+      if (gmSource.gmId == "n1" & target.gmId == "n3") Set(WeightAttr("2.0"))
+      else if (gmSource.gmId == "n5" & target.gmId == "n4") Set(WeightAttr("2.0"))
       else Set.empty
     })
   }
 
-  case class SimpleEdge(source: GraphMLVertex, target: GraphMLVertex, attributes: collection.Set[GraphAttribute]) extends GraphMLEdge
+  case class SimpleEdge(gmSource: GraphMLVertex, gmTarget: GraphMLVertex, gmAttributes: collection.Set[GraphAttribute]) extends GraphMLEdge
 
   case class ColorAttr(val value: String) extends GraphAttribute {
     override val id: String = "d0"
@@ -40,29 +45,41 @@ class GraphMLTests extends FirrtlFlatSpec {
   val n4 = SimpleNode("n4", Set(ColorAttr("green")))
   val n5 = SimpleNode("n5", Set(ColorAttr("turquoise")))
 
-  val simpleGraph = DiGraph(Map(
+  val simpleGraph: DiGraph[SimpleNode] = DiGraph(Map(
     n0 -> Set(n1),
     n1 -> Set(n3),
     n2 -> Set(n4),
     n3 -> Set(n2, n5),
     n4 -> Set[SimpleNode](),
-    n5 -> Set(n4),
+    n5 -> Set(n4)
   ))
 
+  val rocketGraph = ConnectionGraph(
+    new firrtl.stage.transforms.Compiler(Seq(Dependency[ExpandWhensAndCheck]))
+      .runTransform(
+        CircuitState(parse(FileUtils.getTextResource("/regress/RocketCore.fir")), UnknownForm)
+      )
+      .circuit
+  )
+
   "A simple graph" should "emit graphml" in {
-    val graphml = GraphML(simpleGraph)
-    graphml should include("""<node id="n0"><data key="d0">"green"</data></node>""")
-    graphml should include("""<node id="n1"></node>""")
-    graphml should include("""<node id="n2"><data key="d0">"blue"</data></node>""")
-    graphml should include("""<node id="n3"><data key="d0">"red"</data></node>""")
-    graphml should include("""<node id="n4"><data key="d0">"green"</data></node>""")
-    graphml should include("""<node id="n5"><data key="d0">"turquoise"</data></node>""")
-    graphml should include("""<edge source="n0" target="n1"></edge>""")
-    graphml should include("""<edge source="n1" target="n3"><data key="d1">2.0</data></edge>""")
-    graphml should include("""<edge source="n2" target="n4"></edge>""")
-    graphml should include("""<edge source="n3" target="n2"></edge>""")
-    graphml should include("""<edge source="n3" target="n5"></edge>""")
-    graphml should include("""<edge source="n5" target="n4"><data key="d1">2.0</data></edge>""")
-    print(graphml)
+    val graphMl = GraphML(simpleGraph)
+    graphMl should include("""<node id="n0"><data key="d0">"green"</data></node>""")
+    graphMl should include("""<node id="n1"></node>""")
+    graphMl should include("""<node id="n2"><data key="d0">"blue"</data></node>""")
+    graphMl should include("""<node id="n3"><data key="d0">"red"</data></node>""")
+    graphMl should include("""<node id="n4"><data key="d0">"green"</data></node>""")
+    graphMl should include("""<node id="n5"><data key="d0">"turquoise"</data></node>""")
+    graphMl should include("""<edge source="n0" target="n1"></edge>""")
+    graphMl should include("""<edge source="n1" target="n3"><data key="d1">2.0</data></edge>""")
+    graphMl should include("""<edge source="n2" target="n4"></edge>""")
+    graphMl should include("""<edge source="n3" target="n2"></edge>""")
+    graphMl should include("""<edge source="n3" target="n5"></edge>""")
+    graphMl should include("""<edge source="n5" target="n4"><data key="d1">2.0</data></edge>""")
+  }
+
+  "rocket connection graph" should "built" in {
+    val graphMl = GraphML.connectionGraph(rocketGraph)
+    println(graphMl)
   }
 }

--- a/src/test/scala/firrtlTests/graph/GraphMLTests.scala
+++ b/src/test/scala/firrtlTests/graph/GraphMLTests.scala
@@ -1,0 +1,68 @@
+// See LICENSE for license details.
+
+package firrtlTests.graph
+
+import firrtl.graph._
+import firrtl.testutils._
+
+
+class GraphMLTests extends FirrtlFlatSpec {
+  case class SimpleNode(name: String, attributes: Set[GraphAttribute] = Set.empty) extends GraphMLVertex {
+    override def id: String = name
+
+    override def edge(target: GraphMLVertex): GraphMLEdge = SimpleEdge(this, target, {
+      if(source.id == "n1" & target.id == "n3") Set(WeightAttr("2.0"))
+      else if(source.id == "n5" & target.id == "n4") Set(WeightAttr("2.0"))
+      else Set.empty
+    })
+  }
+
+  case class SimpleEdge(source: GraphMLVertex, target: GraphMLVertex, attributes: collection.Set[GraphAttribute]) extends GraphMLEdge
+
+  case class ColorAttr(val value: String) extends GraphAttribute {
+    override val id: String = "d0"
+    override val attrFor: String = "node"
+    override val attrName: String = "color"
+    override val attrType: String = "string"
+  }
+
+  case class WeightAttr(val value: String) extends GraphAttribute {
+    override val id: String = "d1"
+    override val attrFor: String = "edge"
+    override val attrName: String = "weight"
+    override val attrType: String = "double"
+  }
+
+  val n0 = SimpleNode("n0", Set(ColorAttr("green")))
+  val n1 = SimpleNode("n1")
+  val n2 = SimpleNode("n2", Set(ColorAttr("blue")))
+  val n3 = SimpleNode("n3", Set(ColorAttr("red")))
+  val n4 = SimpleNode("n4", Set(ColorAttr("green")))
+  val n5 = SimpleNode("n5", Set(ColorAttr("turquoise")))
+
+  val simpleGraph = DiGraph(Map(
+    n0 -> Set(n1),
+    n1 -> Set(n3),
+    n2 -> Set(n4),
+    n3 -> Set(n2, n5),
+    n4 -> Set[SimpleNode](),
+    n5 -> Set(n4),
+  ))
+
+  "A simple graph" should "emit graphml" in {
+    val graphml = GraphML(simpleGraph)
+    graphml should include("""<node id="n0"><data key="d0">"green"</data></node>""")
+    graphml should include("""<node id="n1"></node>""")
+    graphml should include("""<node id="n2"><data key="d0">"blue"</data></node>""")
+    graphml should include("""<node id="n3"><data key="d0">"red"</data></node>""")
+    graphml should include("""<node id="n4"><data key="d0">"green"</data></node>""")
+    graphml should include("""<node id="n5"><data key="d0">"turquoise"</data></node>""")
+    graphml should include("""<edge source="n0" target="n1"></edge>""")
+    graphml should include("""<edge source="n1" target="n3"><data key="d1">2.0</data></edge>""")
+    graphml should include("""<edge source="n2" target="n4"></edge>""")
+    graphml should include("""<edge source="n3" target="n2"></edge>""")
+    graphml should include("""<edge source="n3" target="n5"></edge>""")
+    graphml should include("""<edge source="n5" target="n4"><data key="d1">2.0</data></edge>""")
+    print(graphml)
+  }
+}

--- a/src/test/scala/firrtlTests/graph/GraphMLTests.scala
+++ b/src/test/scala/firrtlTests/graph/GraphMLTests.scala
@@ -7,12 +7,12 @@ import firrtl.testutils._
 
 
 class GraphMLTests extends FirrtlFlatSpec {
-  case class SimpleNode(name: String, attributes: Set[GraphAttribute] = Set.empty) extends GraphMLVertex {
-    override def id: String = name
+  case class SimpleNode(name: String, gmAttributes: Set[GraphAttribute] = Set.empty) extends GraphMLVertex {
+    override def gmId: String = name
 
-    override def edge(target: GraphMLVertex): GraphMLEdge = SimpleEdge(this, target, {
-      if(source.id == "n1" & target.id == "n3") Set(WeightAttr("2.0"))
-      else if(source.id == "n5" & target.id == "n4") Set(WeightAttr("2.0"))
+    override def gmEdge(target: GraphMLVertex): GraphMLEdge = SimpleEdge(this, target, {
+      if(gmSource.gmId == "n1" & target.gmId == "n3") Set(WeightAttr("2.0"))
+      else if(gmSource.gmId == "n5" & target.gmId == "n4") Set(WeightAttr("2.0"))
       else Set.empty
     })
   }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- new feature/API 

#### API Impact

Extends API of DiGraph, if `T` implements trait of `GraphMLVertex`, it is can emit a GraphML string with `toGraphML`

#### Desired Merge Strategy

#### Release Notes
Add GraphML generation

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?