### PR TITLE
Add missing ResolveKinds/ResolveFlows invalidates                                                                                                                                                    

### DIFF
--- a/src/main/scala/firrtl/passes/ExpandConnects.scala
+++ b/src/main/scala/firrtl/passes/ExpandConnects.scala
@@ -13,7 +13,7 @@ object ExpandConnects extends Pass {
          Dependency(ReplaceAccesses) ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform) = a match {
-    case ResolveFlows => true
+    case ResolveFlows | ResolveKinds => true
     case _            => false
   }
 

--- a/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
+++ b/src/main/scala/firrtl/passes/memlib/VerilogMemDelays.scala
@@ -175,7 +175,7 @@ object VerilogMemDelays extends Pass {
          Dependency[SystemVerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
-    case _: transforms.ConstantPropagation | ResolveFlows => true
+    case _: transforms.ConstantPropagation | ResolveFlows | ResolveKinds => true
     case _ => false
   }
 

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -116,7 +116,7 @@ class ConstantPropagation extends Transform with DependencyAPIMigration with Res
          Dependency[VerilogEmitter] )
 
   override def invalidates(a: Transform): Boolean = a match {
-    case firrtl.passes.Legalize => true
+    case firrtl.passes.Legalize | firrtl.passes.ResolveFlows => true
     case _ => false
   }
 

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -53,7 +53,7 @@ class DeadCodeElimination extends Transform
          Dependency(passes.VerilogPrep),
          Dependency[firrtl.AddDescriptionNodes] )
 
-  override def invalidates(a: Transform) = false
+  override def invalidates(a: Transform) = a == ResolveKinds
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -8,6 +8,7 @@ import firrtl.Mappers._
 import firrtl.Utils._
 import firrtl.options.Dependency
 import firrtl.InfoExpr.orElse
+import firrtl.passes.ResolveKinds
 
 import scala.collection.mutable
 
@@ -133,7 +134,7 @@ class FlattenRegUpdate extends Transform with DependencyAPIMigration {
   override def optionalPrerequisiteOf = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
-    case _: DeadCodeElimination => true
+    case _: DeadCodeElimination | ResolveKinds => true
     case _ => false
   }
 

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -157,6 +157,7 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
   it should "replicate the old order" in {
     val tm = new TransformManager(Forms.MidForm, Forms.Deduped)
     val patches = Seq(
+      Add(3, Seq(Dependency(firrtl.passes.ResolveKinds))),
       Add(4, Seq(Dependency(firrtl.passes.ResolveFlows))),
       Add(5, Seq(Dependency(firrtl.passes.ResolveKinds))),
       Add(6, Seq(Dependency(firrtl.passes.ResolveKinds),
@@ -191,7 +192,8 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
   it should "replicate the old order" in {
     val tm = new TransformManager(Forms.LowFormMinimumOptimized, Forms.LowForm)
     val patches = Seq(
-      Add(4, Seq(Dependency(firrtl.passes.ResolveFlows))),
+      Add(4, Seq(Dependency(firrtl.passes.ResolveKinds),
+                 Dependency(firrtl.passes.ResolveFlows))),
       Add(6, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform],
                  Dependency(firrtl.passes.ResolveKinds)))
     )
@@ -203,10 +205,15 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
   it should "replicate the old order" in {
     val tm = new TransformManager(Forms.LowFormOptimized, Forms.LowForm)
     val patches = Seq(
-      Add(6, Seq(Dependency(firrtl.passes.ResolveFlows))),
-      Add(7, Seq(Dependency(firrtl.passes.Legalize))),
+      Add(2, Seq(Dependency(firrtl.passes.ResolveFlows))),
+      Add(4, Seq(Dependency(firrtl.passes.ResolveFlows))),
+      Add(6, Seq(Dependency(firrtl.passes.ResolveKinds),
+                 Dependency(firrtl.passes.ResolveFlows))),
+      Add(7, Seq(Dependency(firrtl.passes.ResolveFlows),
+                 Dependency(firrtl.passes.Legalize))),
       Add(8, Seq(Dependency[firrtl.transforms.LegalizeAndReductionsTransform],
-                 Dependency(firrtl.passes.ResolveKinds)))
+                 Dependency(firrtl.passes.ResolveKinds))),
+      Add(11, Seq(Dependency(firrtl.passes.ResolveKinds)))
     )
     compare(legacyTransforms(new LowFirrtlOptimization), tm, patches)
   }
@@ -228,7 +235,10 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       firrtl.passes.VerilogPrep,
       new firrtl.AddDescriptionNodes)
     val tm = new TransformManager(Forms.VerilogMinimumOptimized, (new firrtl.VerilogEmitter).prerequisites)
-    compare(legacy, tm)
+    val patches = Seq(
+      Add(8, Seq(Dependency(firrtl.passes.ResolveKinds)))
+    )
+    compare(legacy, tm, patches)
   }
 
   behavior of "VerilogOptimized"
@@ -249,7 +259,11 @@ class LoweringCompilersSpec extends FlatSpec with Matchers {
       firrtl.passes.VerilogPrep,
       new firrtl.AddDescriptionNodes)
     val tm = new TransformManager(Forms.VerilogOptimized, Forms.LowFormOptimized)
-    compare(legacy, tm)
+    val patches = Seq(
+      Add(8, Seq(Dependency(firrtl.passes.ResolveKinds))),
+      Add(9, Seq(Dependency(firrtl.passes.ResolveKinds)))
+    )
+    compare(legacy, tm, patches)
   }
 
   behavior of "Legacy Custom Transforms"


### PR DESCRIPTION
Update the dependencies of transforms which empirically invalidate
ResolveKinds or ResolveFlows.
    
This was discovered with some to-be-committed work that automates
looking for incorrect transform dependencies. Specifically, the
deficient transforms were found to not invalidate ResolveKinds or
ResolveFlows, yet running ReslveKinds or ResolveFlows after these
transforms would result in modifications to the circuit.
    
The LoweringCompilersSpec was updated with patches to indicate the
location of these new transforms.

Depends on: [#1753, #1754]

This should be backported to 1.3.x, but will need to be done manually.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!-- - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
