### PR TITLE
Add CheckTransforms wrapper

### DIFF
--- a/src/main/scala/firrtl/stage/transforms/CheckTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/CheckTransforms.scala
@@ -1,0 +1,68 @@
+// See LICENSE for license details.
+
+package firrtl.stage.transforms
+
+import firrtl.{CircuitState, Transform, Utils}
+import firrtl.options.Dependency
+import firrtl.stage.Forms
+
+class CheckTransforms(val underlying: Transform) extends Transform with WrappedTransform {
+
+  val checks = Forms.Checks ++ Seq(
+    Dependency(firrtl.passes.ResolveKinds),
+    Dependency(firrtl.passes.InferTypes),
+    Dependency(firrtl.passes.Uniquify),
+    Dependency(firrtl.passes.ResolveFlows),
+    Dependency[firrtl.passes.InferBinaryPoints],
+    Dependency[firrtl.passes.TrimIntervals],
+    Dependency[firrtl.passes.InferWidths],
+    Dependency[firrtl.transforms.InferResets] )
+
+  lazy val checksSet = checks.toSet
+
+  override def execute(state: CircuitState): CircuitState = {
+
+    println(s"Running transform: ${underlying.name}")
+
+    val statex = underlying.transform(state)
+
+    val statedState = statex.annotations.collectFirst {
+      case TransformHistoryAnnotation(_, state) => state
+    }.getOrElse(Utils.throwInternalError("You need to run CheckTransforms with TrackTransforms enabled"))
+
+    // println("  Stated State:")
+    // println(statedState.mkString("    - ", "\n    - ", ""))
+
+    val (targets, currentState) = statedState.map(Dependency.fromTransform).partition(checksSet.contains(_))
+
+    // println("  The following transforms should NOT have been invalidated:")
+    // println(targets.map(_.getObject.name).mkString("    - ", "\n    - ", ""))
+
+    val checkingCompiler = new Compiler(
+      targets = targets.toSeq,
+      currentState = currentState.toSeq)
+
+    try {
+      checkingCompiler.flattenedTransformOrder.foldLeft(statex) {
+        case (acc, tx) =>
+          val accx = tx.transform(acc)
+          if (acc.circuit != accx.circuit && !underlying.invalidates(tx)) {
+            println(s"    Circuit mismatch in ${tx.name}!")
+          }
+          accx
+      }
+    }
+    // catch {
+    //   case t: Throwable => println(s"    Caught exception ${t}. Will try to continue...")
+    // }
+
+    statex
+  }
+
+}
+
+object CheckTransforms {
+
+  def apply(a: Transform): CheckTransforms = new CheckTransforms(a)
+
+}

--- a/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
+++ b/src/main/scala/firrtl/stage/transforms/TrackTransforms.scala
@@ -8,11 +8,18 @@ import firrtl.options.{Dependency, DependencyManagerException}
 
 case class TransformHistoryAnnotation(history: Seq[Transform], state: Set[Transform]) extends NoTargetAnnotation {
 
+  @deprecated("Use add(transform: Transform) where invalidates are set from the transform argument", "FIRRTL 1.4")
   def add(transform: Transform,
           invalidates: (Transform) => Boolean = (a: Transform) => false): TransformHistoryAnnotation =
     this.copy(
       history = transform +: this.history,
       state = (this.state + transform).filterNot(invalidates)
+    )
+
+  def add(transform: Transform): TransformHistoryAnnotation =
+    this.copy(
+      history = transform +: this.history,
+      state = (this.state + transform).filterNot(transform.invalidates)
     )
 
 }
@@ -64,6 +71,6 @@ class TrackTransforms(val underlying: Transform) extends Transform with WrappedT
 
 object TrackTransforms {
 
-  def apply(a: Transform): Transform = new TrackTransforms(a)
+  def apply(a: Transform): TrackTransforms = new TrackTransforms(a)
 
 }

--- a/src/test/scala/firrtlTests/CheckTransformsSpec.scala
+++ b/src/test/scala/firrtlTests/CheckTransformsSpec.scala
@@ -1,0 +1,44 @@
+// See LICENSE for license details.
+
+package firrtlTests
+
+import firrtl.{Compiler => _, _}
+import firrtl.stage.Forms
+import firrtl.stage.transforms.Compiler
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class CheckTransformsSpec extends FlatSpec with Matchers {
+
+  behavior of "All transforms making up the Verilog compiler"
+
+  they should "properly declare their invalidates" in {
+
+    val input =
+"""
+circuit Foo:
+  module Foo:
+    input in: UInt<1>
+    output out: UInt<1>
+    wire tmp: UInt<1>
+    tmp <= not(not(in))
+    out <= tmp
+"""
+
+    val c = new Compiler(targets = Forms.VerilogOptimized) {
+      override val wrappers = Seq(
+        (a: Transform) => firrtl.stage.transforms.ExpandPrepares(a),
+        (a: Transform) => firrtl.stage.transforms.CatchCustomTransformExceptions(a),
+        (a: Transform) => firrtl.stage.transforms.TrackTransforms(a),
+        (a: Transform) => firrtl.stage.transforms.CheckTransforms(a),
+        (a: Transform) => firrtl.stage.transforms.UpdateAnnotations(a)
+      )
+    }
+
+    val state = CircuitState(Parser.parse(input), Seq.empty)
+
+    c.transform(state)
+
+  }
+
+}


### PR DESCRIPTION
Work-in-progress to add a `CheckTransforms` wrapper that runs some checks that transform dependencies make sense. I'm intending to replace `LoweringCompilersSpec` with a test that uses `CheckTransforms` to verify that transform dependencies make sense as opposed to enforcing a hard order with patches.

The `CheckTransforms` wrapper is trying to validate the following property after every transform:

*If a transform doesn't claim to invalidate certain transforms, then running those transforms should have no effect on the circuit.*

E.g., if a transform adds an expression with `ir.UnknownType`, but doesn't invalidate `InferTypes`, that should be an error.

Other checks to consider:

- [ ] A transform, when run under `-ll none` should not write to stdout or stderr.
- [ ] A transform should neither read nor write files.
- [ ] If a transform is run missing a prerequisite, there exists a circuit for which the transform will error or produce different output if the prerequisite is run or not.

The wapper that this PR provides should be available via a command line option so that users can run with additional safety checks in place.

Example output:

```
Running transform: firrtl.passes.CheckChirrtl$
Running transform: firrtl.passes.CInferTypes$
Running transform: firrtl.passes.CInferMDir$
Running transform: firrtl.passes.RemoveCHIRRTL$
Running transform: firrtl.passes.ToWorkingIR$
Running transform: firrtl.passes.CheckHighForm$
Running transform: firrtl.passes.ResolveKinds$
Running transform: firrtl.passes.InferTypes$
Running transform: firrtl.passes.CheckTypes$
Running transform: firrtl.passes.Uniquify$
Running transform: firrtl.passes.ResolveKinds$
Running transform: firrtl.passes.InferTypes$
Running transform: firrtl.passes.ResolveFlows$
Running transform: firrtl.passes.CheckFlows$
Running transform: firrtl.passes.InferBinaryPoints
Running transform: firrtl.passes.TrimIntervals
Running transform: firrtl.passes.InferWidths
Running transform: firrtl.passes.CheckWidths$
Running transform: firrtl.transforms.InferResets
Running transform: firrtl.passes.CheckTypes$
Running transform: firrtl.transforms.DedupModules
Running transform: firrtl.passes.PullMuxes$
Running transform: firrtl.passes.ReplaceAccesses$
Running transform: firrtl.passes.ExpandConnects$
    Circuit mismatch in firrtl.passes.ResolveKinds$!
Running transform: firrtl.passes.ZeroLengthVecs$
Running transform: firrtl.passes.ResolveFlows$
Running transform: firrtl.passes.RemoveAccesses$
Running transform: firrtl.passes.ResolveKinds$
Running transform: firrtl.passes.Uniquify$
Running transform: firrtl.passes.ResolveKinds$
Running transform: firrtl.passes.InferTypes$
Running transform: firrtl.passes.ResolveFlows$
Running transform: firrtl.passes.ExpandWhensAndCheck
Running transform: firrtl.passes.ResolveKinds$
    Circuit mismatch in firrtl.passes.ResolveFlows$!
Running transform: firrtl.passes.InferTypes$
    Circuit mismatch in firrtl.passes.ResolveFlows$!
Running transform: firrtl.passes.ResolveFlows$
Running transform: firrtl.passes.InferWidths
Running transform: firrtl.passes.RemoveIntervals
Running transform: firrtl.passes.ResolveKinds$
Running transform: firrtl.passes.InferTypes$
Running transform: firrtl.passes.ConvertFixedToSInt$
Running transform: firrtl.passes.ZeroWidth$
Running transform: firrtl.transforms.formal.AssertSubmoduleAssumptions
Running transform: firrtl.passes.InferTypes$
Running transform: firrtl.passes.LowerTypes$
Running transform: firrtl.passes.ResolveKinds$
Running transform: firrtl.passes.InferTypes$
Running transform: firrtl.passes.ResolveFlows$
Running transform: firrtl.passes.InferWidths
Running transform: firrtl.passes.Legalize$
Running transform: firrtl.transforms.RemoveReset$
Running transform: firrtl.passes.ResolveFlows$
Running transform: firrtl.transforms.CheckCombLoops
Running transform: firrtl.checks.CheckResets
Running transform: firrtl.transforms.RemoveWires
Running transform: firrtl.passes.RemoveValidIf$
Running transform: firrtl.transforms.ConstantPropagation
Running transform: firrtl.passes.PadWidths$
Running transform: firrtl.transforms.ConstantPropagation
Running transform: firrtl.passes.Legalize$
Running transform: firrtl.passes.memlib.VerilogMemDelays$
    Circuit mismatch in firrtl.passes.ResolveKinds$!
Running transform: firrtl.passes.ResolveFlows$
Running transform: firrtl.transforms.ConstantPropagation
Running transform: firrtl.passes.Legalize$
Running transform: firrtl.passes.SplitExpressions$
Running transform: firrtl.passes.ResolveKinds$
Running transform: firrtl.transforms.CombineCats
Running transform: firrtl.passes.CommonSubexpressionElimination$
Running transform: firrtl.transforms.DeadCodeElimination
    Circuit mismatch in firrtl.passes.ResolveKinds$!
Running transform: firrtl.transforms.BlackBoxSourceHelper
    Circuit mismatch in firrtl.passes.ResolveKinds$!
Running transform: firrtl.transforms.FixAddingNegativeLiterals
Running transform: firrtl.transforms.ReplaceTruncatingArithmetic
Running transform: firrtl.transforms.InlineBitExtractionsTransform
Running transform: firrtl.transforms.PropagatePresetAnnotations
Running transform: firrtl.transforms.InlineCastsTransform
Running transform: firrtl.transforms.LegalizeClocksTransform
Running transform: firrtl.transforms.FlattenRegUpdate
    Circuit mismatch in firrtl.passes.ResolveKinds$!
Running transform: firrtl.transforms.DeadCodeElimination
Running transform: firrtl.passes.VerilogModulusCleanup$
Running transform: firrtl.transforms.VerilogRename
Running transform: firrtl.passes.VerilogPrep$
Running transform: firrtl.AddDescriptionNodes
```

PR https://github.com/freechipsproject/firrtl/pull/1760 fixes the mismatches above.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
