### PR TITLE
Deprecate Uniquify and move its useful utilities

### DIFF
--- a/src/main/scala/firrtl/Namespace.scala
+++ b/src/main/scala/firrtl/Namespace.scala
@@ -3,6 +3,7 @@
 package firrtl
 
 import scala.collection.mutable
+import scala.annotation.tailrec
 import firrtl.ir._
 
 class Namespace private {
@@ -79,5 +80,21 @@ object Namespace {
     val namespace = new Namespace
     namespace.namespace ++= names
     namespace
+  }
+
+  /** Appends delim to prefix until no collisions of prefix + elts in names We don't add an _ in the collision check
+    * because elts could be Seq("") In this case, we're just really checking if prefix itself collides
+    */
+  def findValidPrefix(
+    prefix:    String,
+    elts:      Iterable[String],
+    namespace: String => Boolean
+  ): String = {
+    @tailrec
+    def rec(p: String): String = {
+      val found = elts.exists(elt => namespace(p + elt))
+      if (found) rec(p + "_") else p
+    }
+    rec(prefix)
   }
 }

--- a/src/main/scala/firrtl/annotations/analysis/DuplicationHelper.scala
+++ b/src/main/scala/firrtl/annotations/analysis/DuplicationHelper.scala
@@ -72,7 +72,7 @@ case class DuplicationHelper(existingModules: Set[String]) {
         val prefix = path.last._2.value + "___"
         val postfix = top + "_" + path.map { case (i, m) => i.value }.mkString("_")
         val ns = mutable.HashSet(allModules.toSeq: _*)
-        val finalName = firrtl.passes.Uniquify.findValidPrefix(prefix, Seq(postfix), ns) + postfix
+        val finalName = firrtl.Namespace.findValidPrefix(prefix, Seq(postfix), ns) + postfix
         allModules += finalName
         cachedNames((top, path)) = finalName
         finalName

--- a/src/main/scala/firrtl/passes/RemoveAccesses.scala
+++ b/src/main/scala/firrtl/passes/RemoveAccesses.scala
@@ -25,8 +25,8 @@ object RemoveAccesses extends Pass {
     ) ++ firrtl.stage.Forms.Deduped
 
   override def invalidates(a: Transform): Boolean = a match {
-    case Uniquify | ResolveKinds | ResolveFlows => true
-    case _                                      => false
+    case ResolveKinds | ResolveFlows => true
+    case _                           => false
   }
 
   private def AND(e1: Expression, e2: Expression) =

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -6,7 +6,6 @@ import firrtl._
 
 import firrtl.Utils.v_keywords
 import firrtl.options.Dependency
-import firrtl.passes.Uniquify
 
 /** Transform that removes collisions with reserved keywords
   * @param keywords a set of reserved words
@@ -23,7 +22,7 @@ class RemoveKeywordCollisions(keywords: Set[String]) extends ManipulateNames {
     */
   override def manipulate = (n: String, ns: Namespace) =>
     keywords.contains(n) match {
-      case true  => Some(Uniquify.findValidPrefix(n + inlineDelim, Seq(""), ns.cloneUnderlying ++ keywords))
+      case true  => Some(Namespace.findValidPrefix(n + inlineDelim, Seq(""), ns.cloneUnderlying ++ keywords))
       case false => None
     }
 


### PR DESCRIPTION
Since https://github.com/freechipsproject/firrtl/pull/1784 effectively deprecated it, we ought to actually do so.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
  - code refactoring  
  - code cleanup   


#### API Impact

This deprecates APIs for removal

#### Backend Code Generation Impact

No change

#### Desired Merge Strategy

-   - Squash

#### Release Notes

Deprecate Uniquify and its utilities

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
