### PR TITLE
Make EmittedAnnotation a SingleTargetAnnotation

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -54,7 +54,7 @@ case class CircuitState(
 
   /** Helper function for extracting emitted components from annotations */
   def emittedComponents: Seq[EmittedComponent] =
-    annotations.collect { case emitted: EmittedAnnotation[_] => emitted.value }
+    annotations.collect { case emitted: EmittedAnnotation[_, _] => emitted.value }
   def deletedAnnotations: Seq[Annotation] =
     annotations.collect { case anno: DeletedAnnotation => anno }
 

--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -43,7 +43,7 @@ package object stage {
       with LazyLogging {
 
     def view(options: AnnotationSeq): FirrtlExecutionResult = {
-      val emittedRes = options.collect { case a: EmittedAnnotation[_] => a.value.value }
+      val emittedRes = options.collect { case a: EmittedAnnotation[_, _] => a.value.value }
         .mkString("\n")
 
       val emitters = options.collect { case RunFirrtlTransformAnnotation(e: Emitter) => e }

--- a/src/test/scala/firrtlTests/RegisterUpdateSpec.scala
+++ b/src/test/scala/firrtlTests/RegisterUpdateSpec.scala
@@ -5,7 +5,7 @@ package firrtlTests
 import firrtl._
 import firrtl.ir._
 import firrtl.transforms.FlattenRegUpdate
-import firrtl.annotations.NoTargetAnnotation
+import firrtl.annotations.{CircuitTarget, NoTargetAnnotation}
 import firrtl.stage.transforms.Compiler
 import firrtl.options.Dependency
 import firrtl.testutils._
@@ -22,7 +22,8 @@ object RegisterUpdateSpec {
     override def invalidates(a: Transform): Boolean = false
     def execute(state: CircuitState): CircuitState = {
       val emittedAnno = EmittedFirrtlCircuitAnnotation(
-        EmittedFirrtlCircuit(state.circuit.main, state.circuit.serialize, ".fir")
+        EmittedFirrtlCircuit(state.circuit.main, state.circuit.serialize, ".fir"),
+        CircuitTarget(state.circuit.main)
       )
       val capturedState = state.copy(annotations = emittedAnno +: state.annotations)
       state.copy(annotations = CaptureStateAnno(capturedState) +: state.annotations)

--- a/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/CompilerSpec.scala
@@ -126,7 +126,7 @@ class CompilerSpec extends AnyFlatSpec with Matchers {
     output.collect { case a: FirrtlCircuitAnnotation => a }.size should be(6)
 
     info("and all expected EmittedAnnotations should be generated")
-    output.collect { case a: EmittedAnnotation[_] => a }.size should be(20)
+    output.collect { case a: EmittedAnnotation[_, _] => a }.size should be(20)
   }
 
   it should "run transforms in sequential order" in new Fixture {

--- a/src/test/scala/firrtlTests/stage/phases/WriteEmittedSpec.scala
+++ b/src/test/scala/firrtlTests/stage/phases/WriteEmittedSpec.scala
@@ -6,6 +6,7 @@ import java.io.File
 
 import firrtl._
 
+import firrtl.annotations.CircuitTarget
 import firrtl.options.{Phase, TargetDirAnnotation}
 import firrtl.stage.OutputFileAnnotation
 import firrtl.stage.phases.WriteEmitted
@@ -15,7 +16,7 @@ import org.scalatest.matchers.should.Matchers
 class WriteEmittedSpec extends AnyFlatSpec with Matchers {
 
   def removeEmitted(a: AnnotationSeq): AnnotationSeq = a.flatMap {
-    case a: EmittedAnnotation[_] => None
+    case a: EmittedAnnotation[_, _] => None
     case a => Some(a)
   }
 
@@ -26,9 +27,9 @@ class WriteEmittedSpec extends AnyFlatSpec with Matchers {
   it should "write emitted circuits" in new Fixture {
     val annotations = Seq(
       TargetDirAnnotation("test_run_dir/WriteEmittedSpec"),
-      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("foo", "", ".foocircuit")),
-      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("bar", "", ".barcircuit")),
-      EmittedVerilogCircuitAnnotation(EmittedVerilogCircuit("baz", "", ".bazcircuit"))
+      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("foo", "", ".foocircuit"), CircuitTarget("foo")),
+      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("bar", "", ".barcircuit"), CircuitTarget("bar")),
+      EmittedVerilogCircuitAnnotation(EmittedVerilogCircuit("baz", "", ".bazcircuit"), CircuitTarget("baz"))
     )
     val expected = Seq("foo.foocircuit", "bar.barcircuit", "baz.bazcircuit")
       .map(a => new File(s"test_run_dir/WriteEmittedSpec/$a"))
@@ -47,7 +48,7 @@ class WriteEmittedSpec extends AnyFlatSpec with Matchers {
     val annotations = Seq(
       TargetDirAnnotation("test_run_dir/WriteEmittedSpec"),
       OutputFileAnnotation("quux"),
-      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("qux", "", ".quxcircuit"))
+      EmittedFirrtlCircuitAnnotation(EmittedFirrtlCircuit("qux", "", ".quxcircuit"), CircuitTarget("qux"))
     )
     val expected = new File("test_run_dir/WriteEmittedSpec/quux.quxcircuit")
 
@@ -62,9 +63,9 @@ class WriteEmittedSpec extends AnyFlatSpec with Matchers {
   it should "write emitted modules" in new Fixture {
     val annotations = Seq(
       TargetDirAnnotation("test_run_dir/WriteEmittedSpec"),
-      EmittedFirrtlModuleAnnotation(EmittedFirrtlModule("foo", "", ".foomodule")),
-      EmittedFirrtlModuleAnnotation(EmittedFirrtlModule("bar", "", ".barmodule")),
-      EmittedVerilogModuleAnnotation(EmittedVerilogModule("baz", "", ".bazmodule"))
+      EmittedFirrtlModuleAnnotation(EmittedFirrtlModule("foo", "", ".foomodule"), CircuitTarget("foo").module("foo")),
+      EmittedFirrtlModuleAnnotation(EmittedFirrtlModule("bar", "", ".barmodule"), CircuitTarget("foo").module("bar")),
+      EmittedVerilogModuleAnnotation(EmittedVerilogModule("baz", "", ".bazmodule"), CircuitTarget("foo").module("baz"))
     )
     val expected = Seq("foo.foomodule", "bar.barmodule", "baz.bazmodule")
       .map(a => new File(s"test_run_dir/WriteEmittedSpec/$a"))


### PR DESCRIPTION
Change EmittedAnnotation from a NoTargetAnnotation to a
SingleTargetAnnotation. Concretely, this means that some string that
the emitter produces, be it a Verilog or FIRRTL IR string, is now
associated with a specific circuit "thing". This has the benefit of
allowing for transforms that run after an emitter to know which
emitted annotation is associated with a specific component.

This is a concrete example of what I was talking about in the dev meeting. It seems like an emitted annotation is really a string associated with something in the circuit. You can recover this information by re-parsing the string contained in an emitted annotation, but it seems more natural to make the emitted annotation be associated with a single target.

There is a question on how duplication should work for these though...

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

This is an API modification as it adds parameters and type parameters.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
