### PR TITLE
Add --dump-on-crash to StageOptions and Shell

### DIFF
--- a/src/main/scala/firrtl/options/Shell.scala
+++ b/src/main/scala/firrtl/options/Shell.scala
@@ -62,7 +62,7 @@ class Shell(val applicationName: String) {
 
   parser.note("Shell Options")
   ProgramArgsAnnotation.addOptions(parser)
-  Seq(TargetDirAnnotation, InputAnnotationFileAnnotation, OutputAnnotationFileAnnotation)
+  Seq(TargetDirAnnotation, InputAnnotationFileAnnotation, OutputAnnotationFileAnnotation, DumpOnCrashAnnotation)
     .foreach(_.addOptions(parser))
 
   parser

--- a/src/main/scala/firrtl/options/StageAnnotations.scala
+++ b/src/main/scala/firrtl/options/StageAnnotations.scala
@@ -168,3 +168,17 @@ case object WriteDeletedAnnotation extends NoTargetAnnotation with StageOption w
   )
 
 }
+
+/** If this [[firrtl.annotations.Annotation Annotation]] exists in an [[firrtl.AnnotationSeq AnnotationSeq]], then
+  * Dump the raw [[firrtl.AnnotationSeq AnnotationSeq]] to a file on an error
+  */
+case object DumpOnCrashAnnotation extends NoTargetAnnotation with StageOption with HasShellOptions {
+
+  val options = Seq(
+    new ShellOption[Unit](
+      longOption =  "dump-on-crash",
+      toAnnotationSeq = { _ => Seq(this) },
+      helpText = "Dump raw Annotations to error.anno.json on error"
+    )
+  )
+}

--- a/src/main/scala/firrtl/options/StageOptions.scala
+++ b/src/main/scala/firrtl/options/StageOptions.scala
@@ -5,24 +5,27 @@ package firrtl.options
 import java.io.File
 
 /** Options that every stage shares
-  * @param targetDirName a target (build) directory
-  * @param an input annotation file
+  * @param targetDir a target (build) directory
+  * @param annotationFilesIn input annotation file
   * @param programArgs explicit program arguments
-  * @param outputAnnotationFileName an output annotation filename
+  * @param annotationFileOut an output annotation filename
+  * @param dumpOnCrash on error, dump raw AnnotationSeq to a file
   */
 class StageOptions private[firrtl] (
   val targetDir:         String = TargetDirAnnotation().directory,
   val annotationFilesIn: Seq[String] = Seq.empty,
   val annotationFileOut: Option[String] = None,
   val programArgs:       Seq[String] = Seq.empty,
-  val writeDeleted:      Boolean = false) {
+  val writeDeleted:      Boolean = false,
+  val dumpOnCrash:       Boolean = false) {
 
   private[options] def copy(
     targetDir:         String = targetDir,
     annotationFilesIn: Seq[String] = annotationFilesIn,
     annotationFileOut: Option[String] = annotationFileOut,
     programArgs:       Seq[String] = programArgs,
-    writeDeleted:      Boolean = writeDeleted
+    writeDeleted:      Boolean = writeDeleted,
+    dumpOnCrash:       Boolean = dumpOnCrash
   ): StageOptions = {
 
     new StageOptions(
@@ -30,7 +33,8 @@ class StageOptions private[firrtl] (
       annotationFilesIn = annotationFilesIn,
       annotationFileOut = annotationFileOut,
       programArgs = programArgs,
-      writeDeleted = writeDeleted
+      writeDeleted = writeDeleted,
+      dumpOnCrash = dumpOnCrash
     )
 
   }

--- a/src/main/scala/firrtl/options/package.scala
+++ b/src/main/scala/firrtl/options/package.scala
@@ -15,6 +15,7 @@ package object options {
           /* Do NOT reorder program args. The order may matter. */
           case ProgramArgsAnnotation(a) => c.copy(programArgs = c.programArgs :+ a)
           case WriteDeletedAnnotation   => c.copy(writeDeleted = true)
+          case DumpOnCrashAnnotation   => c.copy(dumpOnCrash = true)
         }
       )
   }

--- a/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -22,7 +22,7 @@ class WriteOutputAnnotations extends Phase {
 
   override def invalidates(a: Phase) = false
 
-  /** Write the input [[AnnotationSeq]] to a fie. */
+  /** Write the input [[AnnotationSeq]] to a file. */
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val sopts = Viewer[StageOptions].view(annotations)
     val filesWritten = mutable.HashMap.empty[String, Annotation]

--- a/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
+++ b/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
@@ -46,7 +46,7 @@ class CatchExceptions(val underlying: Phase) extends Phase {
       Utils.throwInternalError(exception = Some(e))}
   }
 
-  private[CatchExceptions] def dumpOnError(underlying: Phase, a: AnnotationSeq) = {
+  private def dumpOnError(underlying: Phase, a: AnnotationSeq) = {
     val sopts = Viewer[StageOptions].view(a)
 
     if (sopts.dumpOnCrash) {

--- a/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
+++ b/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
@@ -51,7 +51,7 @@ class CatchExceptions(val underlying: Phase) extends Phase {
 
     if (sopts.dumpOnCrash) {
       val dumpfile = sopts.getBuildFileName("error", Some(".anno.json"))
-      println(s"Dumping AnnotationSeq to ${dumpfile}")
+      logger.warn(s"Dumping annotations to ${dumpfile}")
       val pw = new PrintWriter(dumpfile)
       pw.write(a.serialize)
       pw.close()


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
 - code refactoring
Moves the code for the annotationSeq trace logger into an AnnotationSeq.serialize method
 - code cleanup
I did a little code gardening to fix a typo in a comment and update a couple of outdated scaladoc blocks.  Not sure how you guys feel about having that stuff mixed in.
<!--   - backend code generation            -->
- new feature/API 
Adds `--dump-on-crash` see below.

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Adds a new `--dump-on-crash` to `StageOptions` that writes the raw compiler annotations to error.anno.json when an exception is caught in `CatchExceptions`

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None known.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

squashing is fine.

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

#### Future Work
- split the FirrtlCircuitAnnotation out into a .fir file
- add support for encapsulating a CircuitState with a caught exception. For example,
  one could catch in firrtl.Transform#remapAnnotations, augmenting the exception
  with the 'before' and 'after' CircuitState.  Then, CatchExceptions can unpack the
  additional debug info and rethrow original exception.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
