### PR TITLE
add weak and strong to Utils.v_keywords

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -819,7 +819,7 @@ object Utils extends LazyLogging {
 
     "scalared", "sequence", "shortint", "shortreal", "showcancelled",
     "signed", "small", "solve", "specify", "specparam", "static",
-    "strength", "string", "strong0", "strong1", "struct", "super",
+    "strength", "string", "strong", "strong0", "strong1", "struct", "super",
     "supply0", "supply1",
 
     "table", "tagged", "task", "this", "throughout", "time", "timeprecision",
@@ -830,7 +830,7 @@ object Utils extends LazyLogging {
 
     "var", "vectored", "virtual", "void",
 
-    "wait", "wait_order", "wand", "weak0", "weak1", "while",
+    "wait", "wait_order", "wand", "weak", "weak0", "weak1", "while",
     "wildcard", "wire", "with", "within", "wor",
 
     "xnor", "xor",


### PR DESCRIPTION
Verilator 4.034 was complaining about wires being named weak and strong
because those are SV 2009 keywords.  Added them to the Utils.v_keywords list

fixes: #1975 

### Contributor Checklist

- [X] Did you add Scaladoc to every public function/method? *N/A*
- [X] Did you update the FIRRTL spec to include every new feature/behavior? *N/A*
- [ ] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?
- [X] Did you state the API impact?
- [X] Did you specify the code generation impact?
- [X] Did you request a desired merge strategy?
- [X] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

No impact on API surface.  Only adds missing values to firrtl.Utils.v_keywords

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Now that 'strong' and 'weak' are considered verilog keywords, the code generation names the offending signals with a trailing underscore.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

- Squash is fine

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- added 'strong' and 'weak' to list of Verilog keywords so that they aren't used as signal names

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
