### PR TITLE
smt: add support for uninterpreted ext modules

### DIFF
--- a/src/main/scala/firrtl/backends/experimental/smt/SMTExpr.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/SMTExpr.scala
@@ -138,6 +138,17 @@ private case class BVIte(cond: BVExpr, tru: BVExpr, fals: BVExpr) extends BVExpr
   override def children: List[BVExpr] = List(cond, tru, fals)
 }
 
+/** apply bv arguments to a function which returns a result of bit vector type */
+private case class BVFunctionCall(name: String, args: List[BVExpr], width: Int) extends BVExpr {
+  override def children = args
+  def toSymbol:          BVFunctionSymbol = BVFunctionSymbol(name, args.map(_.width), width)
+  override def toString: String = args.mkString(name + "(", ", ", ")")
+}
+
+private case class BVFunctionSymbol(name: String, argWidths: List[Int], width: Int) {
+  override def toString: String = s"$name : " + (argWidths :+ width).map(w => s"bv<$w>").mkString(" -> ")
+}
+
 private sealed trait ArrayExpr extends SMTExpr { val indexWidth: Int; val dataWidth: Int }
 private case class ArraySymbol(name: String, indexWidth: Int, dataWidth: Int) extends ArrayExpr with SMTSymbol {
   assert(!name.contains("|"), s"Invalid id $name contains escape character `|`")

--- a/src/main/scala/firrtl/backends/experimental/smt/SMTExprVisitor.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/SMTExprVisitor.scala
@@ -54,6 +54,11 @@ private object SMTExprVisitor {
     case old @ BVIte(a, b, c) =>
       val (nA, nB, nC) = (map(a, bv, ar), map(b, bv, ar), map(c, bv, ar))
       bv(if (nA.eq(a) && nB.eq(b) && nC.eq(c)) old else BVIte(nA, nB, nC))
+    // n-ary
+    case old @ BVFunctionCall(name, args, width) =>
+      val nArgs = args.map(a => map(a, bv, ar))
+      val noneNew = nArgs.zip(args).forall { case (n, o) => n.eq(o) }
+      bv(if (noneNew) old else BVFunctionCall(name, nArgs, width))
   }
 
   private def map(e: ArrayExpr, bv: BVFun, ar: ArrayFun): ArrayExpr = e match {

--- a/src/main/scala/firrtl/backends/experimental/smt/SMTLibSerializer.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/SMTLibSerializer.scala
@@ -24,6 +24,11 @@ private object SMTLibSerializer {
     case a: ArrayExpr => serializeArrayType(a.indexWidth, a.dataWidth)
   }
 
+  def declareFunction(foo: BVFunctionSymbol): SMTCommand = {
+    val args = foo.argWidths.map(serializeBitVectorType)
+    DeclareFunction(BVSymbol(foo.name, foo.width), args)
+  }
+
   private def serialize(e: BVExpr): String = e match {
     case BVLiteral(value, width) =>
       val mask = (BigInt(1) << width) - 1
@@ -74,6 +79,7 @@ private object SMTLibSerializer {
     case BVConcat(a, b)                     => s"(concat ${asBitVector(a)} ${asBitVector(b)})"
     case ArrayRead(array, index)            => s"(select ${serialize(array)} ${asBitVector(index)})"
     case BVIte(cond, tru, fals)             => s"(ite ${serialize(cond)} ${serialize(tru)} ${serialize(fals)})"
+    case BVFunctionCall(name, args, _)      => args.map(serialize).mkString(s"($name ", " ", ")")
     case BVRawExpr(serialized, _)           => serialized
   }
 

--- a/src/main/scala/firrtl/backends/experimental/smt/SMTTransitionSystemEncoder.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/SMTTransitionSystemEncoder.scala
@@ -20,6 +20,9 @@ private object SMTTransitionSystemEncoder {
     // emit header as comments
     cmds ++= sys.header.map(Comment)
 
+    // declare uninterpreted functions used in model
+    cmds ++= sys.ufs.map(SMTLibSerializer.declareFunction)
+
     // declare state type
     val stateType = id(name + "_s")
     cmds += DeclareUninterpretedSort(stateType)

--- a/src/main/scala/firrtl/backends/experimental/smt/UninterpretedModuleAnnotation.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/UninterpretedModuleAnnotation.scala
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
+
+package firrtl.backends.experimental.smt
+
+import firrtl.annotations._
+import firrtl.ir
+import firrtl.passes.PassException
+
+/** ExtModules annotated as UninterpretedModule will be modelled as
+  * UninterpretedFunction (SMTLib) or constant arrays (btor2).
+  * This can be useful when trying to abstract over a function that the
+  * SMT solver or model checker is struggling with.
+  *
+  * E.g., one could declare an abstract 64bit multiplier like this:
+  * ```
+  * extmodule Mul64 :
+  *   input a : UInt<64>
+  *   input b : UInt<64>
+  *   output r : UInt<64>
+  * ```
+  * Now instead of using Chisel to actually implement a multiplication circuit
+  * we can instantiate this Mul64 module twice: Once in our implementation
+  * and once for our correctness property that might specify how the
+  * multiply instruction is supposed to be executed on our CPU.
+  * Now instead of having to prove equivalence of multiplication circuits, the
+  * solver only has to make sure that the connections to the multiplier are correct,
+  * since if `a` and `b` are the same on both instances of `Mul64`, then the `r` output
+  * will also be the same. This is a much easier problem and will result in much faster
+  * solving due to manual abstraction.
+  *
+  * When [[stateBits]] is 0, we model the module as purely combinatorial circuit and
+  * thus expect there to be no clock wire going into the module.
+  * Every output is thus a function of all inputs of the module.
+  *
+  * When [[stateBits]] is an N greater than zero, we will model the module as having an abstract state of width N.
+  * Thus on every clock transition the abstract state is updated and all outputs will take the state
+  * as well as the current inputs as arguments.
+  * TODO: Support for stateful circuits is work in progress.
+  *
+  * All output functions well be prefixed with [[prefix]] and end in the name of the output pin.
+  * It is the users responsibility to ensure that all function names will be unique by choosing apropriate
+  * prefixes.
+  *
+  * The annotation is consumed by the [[FirrtlToTransitionSystem]] pass.
+  */
+case class UninterpretedModuleAnnotation(target: ModuleTarget, prefix: String, stateBits: Int = 0)
+    extends SingleTargetAnnotation[ModuleTarget] {
+  require(stateBits >= 0, "negative number of bits is forbidden")
+  if (stateBits > 0) throw new NotImplementedError("TODO: support for stateful circuits is not implemented yet!")
+  override def duplicate(n: ModuleTarget) = copy(n)
+}
+
+object UninterpretedModuleAnnotation {
+
+  /** checks to see whether the annotation module can actually be abstracted. Use *after* LowerTypes! */
+  def checkModule(m: ir.DefModule, anno: UninterpretedModuleAnnotation): Unit = m match {
+    case _: ir.Module =>
+      throw new UninterpretedModuleException(s"UninterpretedModuleAnnotation can only be used with extmodule! $anno")
+    case m: ir.ExtModule =>
+      val clockInputs = m.ports.collect { case p @ ir.Port(_, _, ir.Input, ir.ClockType) => p.name }
+      val clockOutput = m.ports.collect { case p @ ir.Port(_, _, ir.Output, ir.ClockType) => p.name }
+      val asyncResets = m.ports.collect { case p @ ir.Port(_, _, _, ir.AsyncResetType) => p.name }
+      if (clockOutput.nonEmpty) {
+        throw new UninterpretedModuleException(
+          s"We do not support clock outputs for uninterpreted modules! $clockOutput"
+        )
+      }
+      if (asyncResets.nonEmpty) {
+        throw new UninterpretedModuleException(
+          s"We do not support async reset I/O for uninterpreted modules! $asyncResets"
+        )
+      }
+      if (anno.stateBits == 0) {
+        if (clockInputs.nonEmpty) {
+          throw new UninterpretedModuleException(s"A combinatorial module may not have any clock inputs! $clockInputs")
+        }
+      } else {
+        if (clockInputs.size != 1) {
+          throw new UninterpretedModuleException(s"A stateful module must have exactly one clock input! $clockInputs")
+        }
+      }
+  }
+}
+
+private class UninterpretedModuleException(s: String) extends PassException(s)

--- a/src/test/scala/firrtl/backends/experimental/smt/end2end/UninterpretedModulesSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/end2end/UninterpretedModulesSpec.scala
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.backends.experimental.smt.end2end
+
+import firrtl.annotations.CircuitTarget
+import firrtl.backends.experimental.smt.UninterpretedModuleAnnotation
+
+class UninterpretedModulesSpec extends EndToEndSMTBaseSpec {
+
+  private def testCircuit(assumption: String = ""): String = {
+    s"""circuit UF00:
+       |  module UF00:
+       |    input clk: Clock
+       |    input a: UInt<128>
+       |    input b: UInt<128>
+       |    input c: UInt<128>
+       |
+       |    inst m0 of Magic
+       |    m0.a <= a
+       |    m0.b <= b
+       |
+       |    inst m1 of Magic
+       |    m1.a <= a
+       |    m1.b <= c
+       |
+       |    assert(clk, eq(m0.r, m1.r), UInt(1), "m0.r == m1.r")
+       |    $assumption
+       |  extmodule Magic:
+       |    input a: UInt<128>
+       |    input b: UInt<128>
+       |    output r: UInt<128>
+       |""".stripMargin
+  }
+  private val magicAnno = UninterpretedModuleAnnotation(CircuitTarget("UF00").module("Magic"), "magic", 0)
+
+  "two instances of the same uninterpreted module" should "give the same result when given the same inputs" taggedAs (RequiresZ3) in {
+    val assumeTheSame = """assume(clk, eq(b,c), UInt(1), "b == c")"""
+    test(testCircuit(assumeTheSame), MCSuccess, 1, "inputs are the same ==> outputs are the same", Seq(magicAnno))
+  }
+  "two instances of the same uninterpreted module" should "not always give the same result when given potentially different inputs" taggedAs (RequiresZ3) in {
+    test(
+      testCircuit(),
+      MCFail(0),
+      1,
+      "inputs are not necessarily the same ==> outputs can be different",
+      Seq(magicAnno)
+    )
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- n/a Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- new feature/API

#### API Impact

- adds a new UninterpretedModuleAnnotation which is consumed by the SMT backend to model ExtModules with uninterpreted functions / constant arrays

#### Backend Code Generation Impact
- uses UninterpretedFunctions in the SMTLib backend
- uses constant arrays for the btor2 backend

#### Desired Merge Strategy
- squash

#### Release Notes
The SMT backend now has support for modelling with uninterpreted functions using the `UninterpretedModuleAnnotation`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
