### PR TITLE
Restore publish settings to before sbt-ci-release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val antlrSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
-  // publishMavenStyle and publishTo handled by sbt-ci-release
+  publishMavenStyle := true,
   publishArtifact in Test := false,
   pomIncludeRepository := { x => false },
   // Don't add 'scm' elements if we have a git.remoteRepo definition,
@@ -114,6 +114,15 @@ lazy val publishSettings = Seq(
         <url>http://www.eecs.berkeley.edu/~jrb/</url>
       </developer>
     </developers>,
+  publishTo := {
+    val v = version.value
+    val nexus = "https://oss.sonatype.org/"
+    if (v.trim.endsWith("SNAPSHOT")) {
+      Some("snapshots" at nexus + "content/repositories/snapshots")
+    } else {
+      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    }
+  }
 )
 
 


### PR DESCRIPTION
sbt-ci-release changes the commands required to publish to Sonatype.
While this may be a desirable change at some point, it is inconsistent
with other repos. Reverting for the time being.

I was able to show that the SNAPSHOT publishing in CI still works in the companion Treadle PR: https://github.com/chipsalliance/treadle/pull/277

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [NA] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix   

#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

   - Squash
#### Release Notes

Fix release flow

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
