### PR TITLE
Expand RHS Sinks into Wires

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -660,7 +660,7 @@ object Utils extends LazyLogging {
     *   Given:   SubField(SubIndex(Ref("b"), 2), "c")
     *   Returns: (Ref("b"), SubField(SubIndex(EmptyExpression, 2), "c"))
     *   b[2].c -> (b, EMPTY[2].c)
-    * @note This function only supports WRef, WSubField, and WSubIndex
+    * @note This function only supports WRef, WSubField, WSubIndex, and SubAccess
     */
   def splitRef(e: Expression): (WRef, Expression) = e match {
     case e: WRef => (e, EmptyExpression)
@@ -673,6 +673,9 @@ object Utils extends LazyLogging {
         case EmptyExpression => (root, WRef(e.name, e.tpe, root.kind, e.flow))
         case exp             => (root, WSubField(tail, e.name, e.tpe, e.flow))
       }
+    case e: SubAccess =>
+      val (root, tail) = splitRef(e.expr)
+      (root, SubAccess(tail, e.index, e.tpe, e.flow))
   }
 
   /** Adds a root reference to some SubField/SubIndex chain */

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -660,18 +660,20 @@ object Utils extends LazyLogging {
     *   Given:   SubField(SubIndex(Ref("b"), 2), "c")
     *   Returns: (Ref("b"), SubField(SubIndex(EmptyExpression, 2), "c"))
     *   b[2].c -> (b, EMPTY[2].c)
-    * @note This function only supports WRef, WSubField, WSubIndex, and SubAccess
+    * @note This function only supports [[firrtl.ir.RefLikeExpression RefLikeExpression]]s: [[firrtl.ir.Reference
+    * Reference]], [[firrtl.ir.SubField SubField]], [[firrtl.ir.SubIndex SubIndex]], and [[firrtl.ir.SubAccess
+    * SubAccess]]
     */
   def splitRef(e: Expression): (WRef, Expression) = e match {
-    case e: WRef => (e, EmptyExpression)
-    case e: WSubIndex =>
+    case e: Reference => (e, EmptyExpression)
+    case e: SubIndex =>
       val (root, tail) = splitRef(e.expr)
-      (root, WSubIndex(tail, e.value, e.tpe, e.flow))
-    case e: WSubField =>
+      (root, SubIndex(tail, e.value, e.tpe, e.flow))
+    case e: SubField =>
       val (root, tail) = splitRef(e.expr)
       tail match {
-        case EmptyExpression => (root, WRef(e.name, e.tpe, root.kind, e.flow))
-        case exp             => (root, WSubField(tail, e.name, e.tpe, e.flow))
+        case EmptyExpression => (root, Reference(e.name, e.tpe, root.kind, e.flow))
+        case exp             => (root, SubField(tail, e.name, e.tpe, e.flow))
       }
     case e: SubAccess =>
       val (root, tail) = splitRef(e.expr)

--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -688,6 +688,8 @@ object Utils extends LazyLogging {
       WSubIndex(mergeRef(root, e.expr), e.value, e.tpe, e.flow)
     case e: WSubField =>
       WSubField(mergeRef(root, e.expr), e.name, e.tpe, e.flow)
+    case e: SubAccess =>
+      SubAccess(mergeRef(root, e.expr), e.index, e.tpe, e.flow)
     case EmptyExpression => root
   }
 

--- a/src/main/scala/firrtl/ir/UnifiedTypes.scala
+++ b/src/main/scala/firrtl/ir/UnifiedTypes.scala
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.ir
+
+import firrtl.{ir => fir}
+
+import scala.collection.mutable
+
+object UnifiedTypes {
+
+  sealed trait Type {
+    def passive: Boolean
+    protected def passiveString = passive match {
+      case true => "(p)"
+      case false => ""
+    }
+
+    protected def canonicalize: Type
+
+    protected def flip: Type
+  }
+
+  case class Flip(wrapped: Type) extends Type {
+    val passive = false
+
+    override def toString = s"$$flip<$wrapped>"
+
+    override protected def canonicalize: Type = wrapped match {
+      /* flip(flip(a)) -> a */
+      case Flip(a) => a
+      case _       => Flip(wrapped)
+    }
+
+    override protected def flip = wrapped
+
+  }
+
+  object Flip {
+
+    def get(a: Type): Type = Flip(a).canonicalize
+
+  }
+
+  case object Ground extends Type {
+    override def passive = true
+
+    override def toString = "$ground"
+
+    override protected def canonicalize = this
+
+    override protected def flip = Flip(this)
+  }
+
+  case class Bundle(elements: scala.collection.Map[String, Type]) extends Type {
+    override def passive = elements.forall{ case (_, a) => a.passive }
+
+    override def toString = elements.map{ case (a, b) => s"$a: $b" }.mkString("$bundle<",", ",">")
+
+    override protected def canonicalize = elements.forall {
+      case (_, _: Flip) => true
+      case _            => false
+    } match {
+      /* All elements are flip, so flip them and wrap in a flip */
+      case true  => flip
+      case false => this
+    }
+
+    override protected def flip = Flip(Bundle(elements.mapValues(Flip.get(_))))
+  }
+
+  object Bundle {
+
+    def get(elements: scala.collection.Map[String, Type]): Type = {
+      Bundle(elements).canonicalize
+    }
+
+  }
+
+  implicit class TypeHelpers(tpe: fir.Type) {
+
+    def asUnified: Type = tpe match {
+      case _: fir.GroundType => Ground
+      case fir.BundleType(fields) =>
+        val fieldsx =
+          mutable.LinkedHashMap.empty[String, Type] ++
+            fields.map {
+              case fir.Field(n, fir.Flip, t) => (n -> Flip.get(t.asUnified))
+              case fir.Field(n, _, t)       => (n -> t.asUnified)
+            }
+        Bundle.get(fieldsx)
+      /* Squash aggregates since they cannot flip */
+      case a: fir.VectorType => a.tpe.asUnified
+    }
+
+  }
+
+}

--- a/src/main/scala/firrtl/passes/CheckFlows.scala
+++ b/src/main/scala/firrtl/passes/CheckFlows.scala
@@ -64,14 +64,8 @@ object CheckFlows extends Pass {
     def check_flow(info: Info, mname: String, flows: FlowMap, desired: Flow)(e: Expression): Unit = {
       val flow = get_flow(e, flows)
       (flow, desired) match {
-        case (SourceFlow, SinkFlow) =>
+        case (SourceFlow, SinkFlow) | (SinkFlow, SourceFlow) =>
           errors.append(new WrongFlow(info, mname, e.serialize, desired, flow))
-        case (SinkFlow, SourceFlow) =>
-          kind(e) match {
-            case PortKind | InstanceKind if !flip_q(e.tpe) => // OK!
-            case _ =>
-              errors.append(new WrongFlow(info, mname, e.serialize, desired, flow))
-          }
         case _ =>
       }
     }

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -22,7 +22,8 @@ object Forms {
       Dependency(passes.CInferTypes),
       Dependency(passes.CInferMDir),
       Dependency(passes.RemoveCHIRRTL),
-      Dependency[annotations.transforms.CleanupNamedTargets]
+      Dependency[annotations.transforms.CleanupNamedTargets],
+      Dependency(firrtl.transforms.ExpandChiselRValues)
     )
 
   val WorkingIR: Seq[TransformDependency] = MinimalHighForm :+ Dependency(passes.ToWorkingIR)

--- a/src/main/scala/firrtl/transforms/ExpandChiselRValues.scala
+++ b/src/main/scala/firrtl/transforms/ExpandChiselRValues.scala
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.transforms
+
+import firrtl.{
+  ir,
+  CircuitState,
+  DependencyAPIMigration,
+  DuplexFlow,
+  Flow,
+  Namespace,
+  RenameMap,
+  SinkFlow,
+  SourceFlow,
+  Transform,
+  UnknownFlow,
+  Utils,
+  WrappedExpression
+}
+import firrtl.annotations.{
+  CircuitTarget,
+  ModuleTarget,
+  Target
+}
+import firrtl.options.Dependency
+import firrtl.passes.ResolveFlows
+import firrtl.stage.Forms
+import firrtl.traversals.Foreachers._
+import firrtl.Mappers._
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+/** Expands right-hand-side usages of module outputs, instance inputs, and memory inputs into a synthetic wire. This
+  * avoids using sink flow as a source.
+  */
+object ExpandChiselRValues extends Transform with DependencyAPIMigration {
+
+  override def prerequisites = Seq(
+    Dependency(firrtl.passes.RemoveCHIRRTL)
+  )
+  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisiteOf = Forms.HighEmitters
+  override def invalidates(a: Transform) = false
+
+  implicit class ExpressionHelpers(expr: ir.RefLikeExpression) {
+
+    /** Convert a reference expression to a pruned bundle necessary to represent just that type. */
+    def toBundle: ir.BundleType = {
+
+      println(s"'${expr.serialize}'.toBundle")
+
+      def rec(tpe: ir.Type, e: ir.RefLikeExpression): ir.BundleType = e match {
+        /* Base case. All ref-likes end in a base reference */
+        case ir.Reference(name, _, _, _) =>
+          ir.BundleType(Seq(ir.Field(name, ir.Default, tpe)))
+        /* Prune the subfield to a bundle */
+        case ir.SubField(ex: ir.RefLikeExpression, name, _, _) =>
+          rec(ir.BundleType(Seq(ir.Field(name, ir.Default, tpe))), ex)
+        /* This could be pruned to a field, but it's complicated to merge and may collide */
+        case ir.SubIndex(ex: ir.RefLikeExpression, value, _, _) =>
+          // rec(ir.BundleType(Seq(ir.Field(value.toString, ir.Default, tpe))), ex)
+          rec(ex.tpe, ex)
+        /* This cannot be pruned */
+        case ir.SubAccess(ex: ir.RefLikeExpression, _, _, _) =>
+          rec(ex.tpe, ex)
+      }
+
+      val bundle = rec(expr.tpe, expr)
+      println(bundle.serialize)
+      bundle
+    }
+
+  }
+
+  implicit class BundleTypeHelpers(tpe: ir.BundleType) {
+
+    /** Merge two sorted bundles together. Assume that fields are sorted. */
+    def ++(that: ir.BundleType): ir.BundleType = {
+
+      @tailrec
+      def rec(a: Seq[ir.Field], b: Seq[ir.Field], acc: Seq[ir.Field]): Seq[ir.Field] = (a, b) match {
+        case (a, b) if a.isEmpty                  => acc ++ b
+        case (a, b) if b.isEmpty                  => acc ++ a
+        case (a, b) if a.head.name < b.head.name  => rec(a.tail, b,      acc :+ a.head)
+        case (a, b) if a.head.name > b.head.name  => rec(a,      b.tail, acc :+ b.head)
+        case (a, b) if a.head.name == b.head.name => (a.head.tpe, b.head.tpe) match {
+          case (at, bt) if at == bt                   => rec(a.tail, b.tail, acc :+ a.head)
+          case (at: ir.BundleType, bt: ir.BundleType) => rec(a.tail, b.tail, acc :+ a.head.copy(tpe=(at ++ bt)))
+          case _ => ???
+        }
+      }
+
+      ir.BundleType(rec(tpe.fields, that.fields, Seq.empty))
+    }
+
+  }
+
+  /** Determine if an expression is a sink port */
+  private def isSink(
+    rhs: ir.Expression,
+    portMap: Map[String, ir.Orientation]
+  ): Boolean = rhs match {
+    case _: ir.Literal => false
+    case _ => portMap.get(Utils.splitRef(rhs)._1.name) match {
+      /* The RHS is not a port. No modification necessary. */
+      case None => false
+      /* The RHS is a port. This is a sink if it is resolved as a SinkFlow.
+       *
+       * This uses flow resolution from the ResolveFlows pass, but seeded with the orientation of port.
+       */
+      case Some(orientation) =>
+        (Utils.to_dir(_: ir.Orientation))
+          .andThen(Utils.to_flow)
+          .andThen(ResolveFlows.resolve_e(_)(rhs))
+          .andThen{
+            _ match {
+              case b: ir.RefLikeExpression => b.flow == SinkFlow
+              case _ => ???
+            }
+          }.apply(orientation)
+    }
+  }
+
+  private def analyzeStatement(
+    statement: ir.Statement,
+    portMap: Map[String, ir.Orientation],
+    rhsSinks: scala.collection.mutable.Set[ir.RefLikeExpression]
+  ): Unit = {
+    statement match {
+      case a: ir.DefInstance =>
+        println(Utils.stmtToType(a))
+          ???
+      case a@ ir.Connect(_, _, rhs: ir.RefLikeExpression) if isSink(rhs, portMap)  =>
+        rhsSinks += rhs
+      case a@ ir.PartialConnect(_, _, rhs: ir.RefLikeExpression) if isSink(rhs, portMap) =>
+        rhsSinks += rhs
+      case a =>
+        a.foreach(analyzeStatement(_, portMap, rhsSinks))
+    }
+  }
+
+  private def onExpression(
+    expression: ir.Expression,
+    exps: Seq[WrappedExpression]
+  ): ir.Expression = {
+    expression match {
+      case a if {
+        println(s"onExpression: '${a.serialize}'")
+        println(s"  - $a")
+        false
+      } => ???
+      case a: ir.Reference =>
+        val synthetic = Utils.mergeRef(ir.Reference("_synthetic_output"), a)
+        exps.contains(WrappedExpression(synthetic)) match {
+          case true => synthetic
+          case false => a
+        }
+      case _ => expression.map(onExpression(_, exps))
+    }
+  }
+
+  private def onStatement(
+    statement: ir.Statement,
+    syntheticWire: ir.DefWire,
+    exps: Seq[WrappedExpression]
+  ): ir.Statement = {
+    val syntheticWireType = syntheticWire.tpe match {
+      case a: ir.BundleType => a
+      case _ => ???
+    }
+    statement.map(onStatement(_, syntheticWire, exps)) match {
+      case a if {
+        println(s"Examining: '${a.serialize}'")
+        println(s"  - $a")
+        false
+      } => ???
+      /* Connect the synthetic wire to the RHS */
+      case a@ ir.Connect(info, lhs: ir.RefLikeExpression, rhs) =>
+        lazy val rhsExps = Utils.create_exps(rhs)
+        lazy val refs = Utils.expandRef(ir.Reference(syntheticWire)).map(WrappedExpression(_))
+        ir.Block (
+          a.copy(expr = onExpression(rhs, refs)) +:
+            Utils.get_valid_points(syntheticWireType, lhs.toBundle, ir.Default, ir.Default)
+            .map { case (i, j) => (exps(i), rhsExps(j)) }
+            .map { case (x, y) => ir.Connect(info, x.e1, y) }
+        )
+      case a@ ir.PartialConnect(info, lhs: ir.RefLikeExpression, rhs) =>
+        lazy val rhsExps = Utils.create_exps(rhs)
+        lazy val refs = Utils.expandRef(ir.Reference(syntheticWire)).map(WrappedExpression(_))
+        ir.Block (
+          a.copy(expr = onExpression(rhs, refs)) +:
+            Utils.get_valid_points(syntheticWireType, lhs.toBundle, ir.Default, ir.Default)
+            .map { case (i, _) => (exps(i), rhsExps(i)) }
+            .map { case (x, y) => ir.Connect(info, x.e1, y) }
+        )
+      case a@ ir.IsInvalid(info, lhs: ir.RefLikeExpression) =>
+        ir.Block (
+          a +: Utils.get_valid_points(syntheticWireType, lhs.toBundle, ir.Default, ir.Default)
+            .map{ case (i, _) => exps(i) }
+            .map( b =>  ir.IsInvalid(info, b.e1) )
+        )
+      /* Replace connections to original wires */
+      case a@ ir.Connect(_, _, rhs) if ??? =>
+        ???
+      case a@ ir.PartialConnect(_, _, rhs) if ??? =>
+        ???
+      /* Skip other statements */
+      case a =>
+        println(s"  Skipping '${a.serialize}'")
+        a
+    }
+  }
+
+  private def onModule(module: ir.DefModule, circuitTarget: CircuitTarget): ir.DefModule = module match {
+    case a: ir.ExtModule => a
+    case a: ir.Module =>
+      val portMap: Map[String, ir.Orientation] =
+        Utils
+          .module_type(module)
+          .fields
+          .map { case ir.Field(name, flip, _) => name -> flip }
+          .toMap
+      val rhsSinks = mutable.LinkedHashSet.empty[ir.RefLikeExpression]
+      a.body.foreach(analyzeStatement(_, portMap, rhsSinks))
+      rhsSinks.map(_.serialize).foreach(println)
+      println("----------------------------------------")
+      rhsSinks.foreach(println)
+      println("----------------------------------------")
+      /* This is the synthetic wire that we will assign everything to. */
+      val synthetic: Option[ir.BundleType] = rhsSinks
+        .map(_.toBundle) match {
+          case b if b.isEmpty => None
+          case b              => Some(b.reduce(_ ++ _)) // This is an insertion sort...
+        }
+      println("----------------------------------------")
+      synthetic match {
+        case None => module
+        case Some(tpe) =>
+          val syntheticWire = ir.DefWire(ir.NoInfo, Namespace(a).newName("_synthetic_output"), tpe)
+          println("Synthetic wire: ")
+          println(s"  - ${syntheticWire.serialize}")
+          println(s"  - $syntheticWire")
+          val renames = mutable.HashMap.empty[WrappedExpression, ir.Expression]
+          val moduleTarget = circuitTarget.module(module.name)
+          val exps = Utils.create_exps(ir.Reference(syntheticWire)).map(WrappedExpression(_))
+          println(exps.mkString("Exprssions:\n  - ", "\n  - ", ""))
+          val bodyx = a.body.map(onStatement(_, syntheticWire, exps)) match {
+            case ir.Block(stmts) => ir.Block(syntheticWire +: stmts)
+            case stmt => ir.Block(Seq(syntheticWire, stmt))
+          }
+          println(renames)
+          a.copy(body = bodyx)
+      }
+  }
+
+  override def execute(state: CircuitState) = {
+    val circuitTarget = CircuitTarget(state.circuit.main)
+    val circuitx = state.circuit.map(onModule(_, circuitTarget))
+    state.copy(circuit = circuitx)
+  }
+
+}

--- a/src/main/scala/firrtl/transforms/ExpandChiselRValues.scala
+++ b/src/main/scala/firrtl/transforms/ExpandChiselRValues.scala
@@ -7,6 +7,7 @@ import firrtl.{
   CircuitState,
   DependencyAPIMigration,
   DuplexFlow,
+  EmptyExpression,
   Flow,
   Namespace,
   RenameMap,
@@ -21,8 +22,12 @@ import firrtl.analyses.InstanceKeyGraph
 import firrtl.annotations.{
   CircuitTarget,
   ModuleTarget,
-  Target
+  ReferenceTarget,
+  Target,
+  TargetToken
 }
+import firrtl.ir.UnifiedTypes
+import firrtl.ir.UnifiedTypes.TypeHelpers
 import firrtl.options.Dependency
 import firrtl.passes.ResolveFlows
 import firrtl.stage.Forms
@@ -52,7 +57,7 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
     /** Convert a reference expression to a pruned bundle necessary to represent just that type. */
     def toBundle: ir.BundleType = {
 
-      println(s"'${expr.serialize}'.toBundle")
+      // println(s"'${expr.serialize}'.toBundle")
 
       def rec(tpe: ir.Type, e: ir.RefLikeExpression): ir.BundleType = e match {
         /* Base case. All ref-likes end in a base reference */
@@ -63,7 +68,6 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
           rec(ir.BundleType(Seq(ir.Field(name, ir.Default, tpe))), ex)
         /* This could be pruned to a field, but it's complicated to merge and may collide */
         case ir.SubIndex(ex: ir.RefLikeExpression, value, _, _) =>
-          // rec(ir.BundleType(Seq(ir.Field(value.toString, ir.Default, tpe))), ex)
           rec(ex.tpe, ex)
         /* This cannot be pruned */
         case ir.SubAccess(ex: ir.RefLikeExpression, _, _, _) =>
@@ -71,7 +75,7 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
       }
 
       val bundle = rec(expr.tpe, expr)
-      println(bundle.serialize)
+      // println(bundle.serialize)
       bundle
     }
 
@@ -100,70 +104,139 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
 
   }
 
-  /** Determine if an expression is a sink port. Returns None if this is a non-sink instance reference indicating that
-    * this should not be recursively explored. Returns Some if this is a reference that is or is not a sink, but may
-    * contain sub-expressions that should be explored.
+  /** Determine the flow of an expression given auxiliary type information. Return None if the type does not match the
+    * expression, e.g., the expression includes a subfield not in the type.
+    */
+  private def toFlow(expression: ir.Expression, bundle: UnifiedTypes.Type): Option[Flow] = {
+
+    def rec(e: ir.Expression, b: UnifiedTypes.Type): Option[(ir.Orientation, UnifiedTypes.Type)] = {
+
+      e match {
+        /* Base case: All expressions end with a reference. Return the root orientation and strip the outermost type
+         * from the unified type. If the type doesn't match, return None.
+         */
+        case ir.Reference(name, _, _, _)  => b match {
+          case UnifiedTypes.Flip(UnifiedTypes.Bundle(elements)) => elements.get(name) match {
+            case Some(x) => Some((ir.Flip, elements(name)))
+            case None    => None
+          }
+          case UnifiedTypes.Bundle(elements) => elements.get(name) match {
+            case Some(x) => Some((ir.Default, elements(name)))
+            case None    => None
+          }
+          case _ => None
+        }
+        /* Post order recursion across subfields. The current orientation and type is returned. Use this to update the
+         * type and strip the outermost unified type. If not a bundle type, return None.
+         */
+        case ir.SubField(expr, name, _, _) => rec(expr, b) match {
+          case None => None
+          case Some((orientation, bx)) => bx match {
+            case UnifiedTypes.Flip(UnifiedTypes.Bundle(elements)) => elements.get(name) match {
+              case Some(x) => Some((Utils.swap(orientation), elements(name)))
+              case None    => None
+            }
+            case UnifiedTypes.Bundle(elements) =>
+              elements.get(name) match {
+              case Some(x) => Some(((orientation), elements(name)))
+              case None    => None
+            }
+            case _ => None
+          }
+        }
+        /* Skip over index and access as they don't affect the type. */
+        case a: ir.SubIndex  => rec(a.expr, b)
+        case a: ir.SubAccess => rec(a.expr, b)
+        /* Ignore EmptyExpression (if found) and literals. */
+        case EmptyExpression => None
+        case a: ir.Literal   => None
+        /* Anything else shouldn't be possible */
+        case _ =>
+          println(e.serialize)
+          ???
+      }
+
+    }
+
+    rec(expression, bundle).map {
+      /* Unwrap a swap on the returned type */
+      case (orientation, UnifiedTypes.Flip(tpe)) => (Utils.swap(orientation), tpe)
+      case other                                 => other
+    }.map {
+      case (_,          b) if !b.passive => DuplexFlow
+      case (ir.Default, _)               => SinkFlow
+      case (ir.Flip,    _)               => SourceFlow
+    }
+
+  }
+
+  private def isPort(a: UnifiedTypes.Type, b: String): Boolean = a match {
+    case UnifiedTypes.Flip(UnifiedTypes.Bundle(elements)) => elements.contains(b)
+    case UnifiedTypes.Bundle(elements)                    => elements.contains(b)
+    case _                                                => false
+  }
+
+  /** Determine if an expression is a sink. Returns None if this is a non-sink instance reference indicating that this
+    * should not be recursively explored. Returns Some if this is a reference that is or is not a sink, but may contain
+    * sub-expressions that should be explored.
     */
   private def isSink(
     rhs: ir.Expression,
-    portMap: scala.collection.Map[String, ir.Orientation],
-    modulePortMap: scala.collection.Map[String, immutable.Map[String, ir.Orientation]],
-    instanceMap: scala.collection.Map[String, String]
-  ): Option[Boolean] = rhs match {
-    case _: ir.Literal => Some(false)
-    case _ =>
-      val (car, cdr) = Utils.splitRef(rhs)
+    portMap: UnifiedTypes.Type,
+    modulePortMap: scala.collection.Map[String, UnifiedTypes.Type],
+    instanceMap: scala.collection.Map[String, String],
+  ): Option[Boolean] = {
 
-      car match {
-        /* This is a reference to a module port */
-        case _ if portMap.contains(car.name) =>
-          val orientation = portMap(car.name)
-          val sinkFlag =
-            (Utils.to_dir(_: ir.Orientation))
-              .andThen(Utils.to_flow)
-              .andThen(ResolveFlows.resolve_e(_)(rhs))
-              .andThen{
-                _ match {
-                  case b: ir.RefLikeExpression => b.flow == SinkFlow
-                  case _ => ???
-                }
-              }.apply(orientation)
-          Some(sinkFlag)
-        /* This is a reference to an instance port */
-        case _ if instanceMap.contains(car.name) =>
-          println(car.serialize, cdr.serialize)
-          val orientation = modulePortMap(instanceMap(car.name))(Utils.splitRef(cdr)._1.name)
-          (Utils.to_dir(_: ir.Orientation))
-            .andThen(Utils.swap)
-            .andThen(Utils.to_flow)
-            .andThen(ResolveFlows.resolve_e(_)(rhs))
-            .andThen{
-              _ match {
-                case b: ir.RefLikeExpression => b.flow == SinkFlow
-                case _ => ???
-              }
-            }.apply(orientation) match {
-              case false => None
-              case true => Some(true)
-            }
+    rhs match {
+      case _: ir.Literal => Some(false)
+      case _ =>
+        val (car, cdr) = Utils.splitRef(rhs)
 
-        case _ => Some(false)
-      }
+        car match {
+          /* This is a reference to a module port */
+          case _ if isPort(portMap, car.name) =>
+            toFlow(rhs, portMap).map(_ == SinkFlow)
+          /* This is a reference to an instance port. The logic is the same, but the comparison is against SourceFlow.
+           */
+          case _ if instanceMap.contains(car.name) =>
+            toFlow(cdr, modulePortMap(instanceMap(car.name))).map(_ == SourceFlow)
+          case _ =>
+            Some(false)
+        }
+    }
   }
 
   private def analyzeExpression(
     expression: ir.Expression,
-    portMap: scala.collection.Map[String, ir.Orientation],
-    modulePortMap: scala.collection.Map[String, immutable.Map[String, ir.Orientation]],
+    portMap: UnifiedTypes.Type,
+    modulePortMap: scala.collection.Map[String, UnifiedTypes.Type],
     instanceMap: scala.collection.Map[String, String],
-    rhsSinks: mutable.Set[ir.RefLikeExpression]
+    rhsSinks: mutable.Set[ir.RefLikeExpression],
   ): Unit = {
-
+    println(s"    analyzeExpression: ${expression.serialize}")
     expression match {
+      case e: ir.SubAccess => isSink(e, portMap, modulePortMap, instanceMap) match {
+        case None        =>
+          println("      - None")
+          e.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
+        case Some(true)  =>
+          println("      - Some(true)")
+          e.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
+          rhsSinks += e
+        case Some(false) =>
+          println("      - Some(false)")
+          e.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
+      }
       case e: ir.RefLikeExpression => isSink(e, portMap, modulePortMap, instanceMap) match {
-        case None        =>  e
-        case Some(true)  => rhsSinks += e
-        case Some(false) => e.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
+        case None        =>
+          println("      - None")
+          e
+        case Some(true)  =>
+          println("      - Some(true)")
+          rhsSinks += e
+        case Some(false) =>
+          println("      - Some(false)")
+          e.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
       }
       case e => e.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
     }
@@ -172,20 +245,103 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
 
   private def analyzeStatement(
     statement: ir.Statement,
-    portMap: scala.collection.Map[String, ir.Orientation],
+    portMap: UnifiedTypes.Type,
     rhsSinks: mutable.Set[ir.RefLikeExpression],
-    modulePortMap: scala.collection.Map[String, immutable.Map[String, ir.Orientation]],
-    instanceMap: mutable.Map[String, String]
+    modulePortMap: scala.collection.Map[String, UnifiedTypes.Type],
+    instanceMap: mutable.Map[String, String],
   ): Unit = {
+    println(s"  analyzeStatement: ${statement.serialize}")
     statement match {
       case a@ ir.DefInstance(_, instance, module, tpe) =>
+        println(s"    - instanceMap append '$instance -> $module'")
         instanceMap(instance) = module
-      case ir.Connect(_, _, rhs) =>
-        analyzeExpression(rhs, portMap, modulePortMap, instanceMap, rhsSinks)
-      case ir.PartialConnect(_, _, rhs: ir.RefLikeExpression) =>
-        analyzeExpression(rhs, portMap, modulePortMap, instanceMap, rhsSinks)
+      /* Find and analyze any RHS connections where the LHS and RHS are both sinks.
+       *
+       * For example, this would analyze the RHS "b" in "a <= b" below:
+       *
+       * circuit Baz:
+       *   module Baz:
+       *     output a: { a: UInt<1> }
+       *     output b: { a: UInt<1> }
+       *     b is invalid
+       *     a <= b
+       *
+       * Note that the same circuit with types and connections inverted is skipped. In the circuit below "b" will not be
+       * analyzed as this circuit is disallowed by CheckFlows.
+       *
+       * circuit Qux:
+       *   module Qux:
+       *     input a: { flip a: UInt<1> }
+       *     input b: { flip a: UInt<1> }
+       *     b is invalid
+       *     b <= a
+       *
+       */
+      case ir.Connect(_, lhs, rhs) =>
+        /* @todo This needs to compute the flow differently for different kinds. This should look at the modulePortMap for
+         * instances (and flip the output). This can look at the type of anything else (wire, register, or node) as that
+         * type should be correct.
+         */
+        val lhsFlow = toFlow(lhs, portMap)
+        val rhsFlow = toFlow(rhs, portMap)
+        println(s"   lhs: ${lhs.serialize}")
+        println(s"     raw: $lhs")
+        println(s"     flow: $lhsFlow")
+        println(s"   rhs: ${rhs.serialize}")
+        println(s"     raw: $rhs")
+        println(s"     flow: $rhsFlow")
+
+        val xhs = (lhsFlow, rhsFlow) match {
+          case (Some(SinkFlow),   Some(SinkFlow))   => Some(rhs)
+          case (Some(DuplexFlow), Some(SinkFlow))   => None
+          case (Some(SourceFlow), Some(SourceFlow)) => None
+          case _                                    => None
+        }
+        xhs.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
+        Seq(lhs, rhs).foreach {
+          case a: ir.SubAccess => analyzeExpression(a.index, portMap, modulePortMap, instanceMap, rhsSinks)
+          case _ =>
+        }
+      /* Partial connections are the same as connect, except the RHS also should be analyzed when the LHS is duplex.
+       *
+       * For example, this would analyze "b" in "a <- b":
+       *
+       * circuit Foo:
+       *   module Foo:
+       *     output a: { a: UInt<1>, flip b: UInt<1> }
+       *     output b: { a: UInt<1> }
+       *     b is invalid
+       *     a <- b
+       *
+       */
+      case ir.PartialConnect(_, lhs, rhs) =>
+        val lhsFlow = toFlow(lhs, portMap)
+        val rhsFlow = toFlow(rhs, portMap)
+        println(s"   lhs: ${lhs.serialize}")
+        println(s"     flow: $lhsFlow")
+        println(s"   rhs: ${rhs.serialize}")
+        println(s"     flow: $rhsFlow")
+
+        val xhs = (lhsFlow, rhsFlow) match {
+          case (Some(SinkFlow),   Some(SinkFlow))   => Some(rhs)
+          case (Some(DuplexFlow), Some(SinkFlow))   => Some(rhs)
+          case (Some(SourceFlow), Some(SourceFlow)) => None
+          case _                                    => None
+        }
+        xhs.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
+        Seq(lhs, rhs).foreach {
+          case a: ir.SubAccess => analyzeExpression(a.index, portMap, modulePortMap, instanceMap, rhsSinks)
+          case _ =>
+        }
+      /* Ignore invalid. This is a LHS usage of an expression. */
+      case _: ir.IsInvalid =>
+      /* Ignore attach. This is weird. */
+      case _: ir.Attach =>
+      /* Process other statements according to normal foreaching. */
       case a =>
+        // println("    - LHS and RHS recursion")
         a.foreach(analyzeStatement(_, portMap, rhsSinks, modulePortMap, instanceMap))
+        a.foreach(analyzeExpression(_, portMap, modulePortMap, instanceMap, rhsSinks))
     }
   }
 
@@ -195,17 +351,22 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
   ): ir.Expression = {
     expression match {
       case a if {
-        println(s"onExpression: '${a.serialize}'")
-        println(s"  - $a")
+        // println(s"onExpression: '${a.serialize}'")
+        // println(s"  - $a")
         false
       } => ???
-      case a: ir.Reference =>
+      /* SubAccess needs to be processed recursively */
+      case a: ir.SubAccess =>
+        expression.map(onExpression(_, exps))
+      /* Other reference-like expressions must match exactly. Do not recurse (into simpler statements). */
+      case a: ir.RefLikeExpression =>
         val synthetic = Utils.mergeRef(ir.Reference("_synthetic_output"), a)
         exps.contains(WrappedExpression(synthetic)) match {
           case true => synthetic
           case false => a
         }
-      case _ => expression.map(onExpression(_, exps))
+      /* Everything else should be handled recursively */
+      case e => expression.map(onExpression(_, exps))
     }
   }
 
@@ -220,8 +381,8 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
     }
     statement.map(onStatement(_, syntheticWire, exps)) match {
       case a if {
-        println(s"Examining: '${a.serialize}'")
-        println(s"  - $a")
+        // println(s"Examining: '${a.serialize}'")
+        // println(s"  - $a")
         false
       } => ???
       /* Handle connections. Replace RHS usages with the synthetic wire. Add statements that replicate assignments as
@@ -251,40 +412,35 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
             .map{ case (i, _) => exps(i) }
             .map( b =>  ir.IsInvalid(info, b.e1) )
         )
-      /* Skip other statements */
-      case a =>
-        println(s"  Skipping '${a.serialize}'")
-        a
+      case a => a.mapExpr{ rhs =>
+        lazy val refs = Utils.expandRef(ir.Reference(syntheticWire)).map(WrappedExpression(_))
+        onExpression(rhs, refs)
+      }
     }
   }
 
   private def onModule(
     module: ir.DefModule,
-    circuitTarget: CircuitTarget,
-    modulePortMap: mutable.Map[String, immutable.Map[String, ir.Orientation]]
+    modulePortMap: mutable.Map[String, UnifiedTypes.Type]
   ): ir.DefModule = {
 
     println(s"onModule: ${module.name}")
 
-    val portMap: Map[String, ir.Orientation] =
-      Utils
-        .module_type(module)
-        .fields
-        .map { case ir.Field(name, flip, _) => name -> flip }
-        .toMap
+    println(s"  - module_type: ${Utils.module_type(module).serialize}")
+    println(s"  - unified: ${Utils.module_type(module).asUnified}")
 
-    modulePortMap(module.name) = portMap
+    modulePortMap(module.name) = Utils.module_type(module).asUnified
+    val portMap = modulePortMap(module.name)
 
     module match {
       case a: ir.ExtModule => a
       case a: ir.Module =>
-        modulePortMap(module.name)
         val instanceMap = mutable.HashMap.empty[String, String]
         val rhsSinks = mutable.LinkedHashSet.empty[ir.RefLikeExpression]
         a.body.foreach(analyzeStatement(_, portMap, rhsSinks, modulePortMap, instanceMap))
-        rhsSinks.map(_.serialize).foreach(println)
+        // rhsSinks.map(_.serialize).foreach(println)
         println("----------------------------------------")
-        rhsSinks.foreach(println)
+        // rhsSinks.foreach(println)
         println("----------------------------------------")
         /* This is the synthetic wire that we will assign everything to. */
         val synthetic: Option[ir.BundleType] = rhsSinks
@@ -299,9 +455,8 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
             val syntheticWire = ir.DefWire(ir.NoInfo, Namespace(a).newName("_synthetic_output"), tpe)
             println("Synthetic wire: ")
             println(s"  - ${syntheticWire.serialize}")
-            println(s"  - $syntheticWire")
+            // println(s"  - $syntheticWire")
             val renames = mutable.HashMap.empty[WrappedExpression, ir.Expression]
-            val moduleTarget = circuitTarget.module(module.name)
             val exps = Utils.create_exps(ir.Reference(syntheticWire)).map(WrappedExpression(_))
             println(exps.mkString("Exprssions:\n  - ", "\n  - ", ""))
             val bodyx = a.body.map(onStatement(_, syntheticWire, exps)) match {
@@ -315,15 +470,14 @@ object ExpandChiselRValues extends Transform with DependencyAPIMigration {
   }
 
   override def execute(state: CircuitState) = {
-    val circuitTarget = CircuitTarget(state.circuit.main)
-    val modulePortMap = mutable.HashMap.empty[String, immutable.Map[String, ir.Orientation]]
+    val modulePortMap = mutable.HashMap.empty[String, UnifiedTypes.Type]
 
     /* Update all modules in reverse topological order. This ensures that modules are declared before instantiation. */
     val modulesx: immutable.Map[String, ir.DefModule] =
       InstanceKeyGraph(state.circuit)
         .moduleOrder
         .reverse
-        .map(onModule(_, circuitTarget, modulePortMap))
+        .map(onModule(_, modulePortMap))
         .groupBy(_.name)
         .mapValues(_.head)
 

--- a/src/test/scala/firrtlTests/FlattenTests.scala
+++ b/src/test/scala/firrtlTests/FlattenTests.scala
@@ -105,13 +105,13 @@ class FlattenTests extends LowTransformSpec {
         |    output b : UInt<32>
         |    inst i of Inline2
         |    i.a <= a
-        |    b <= i.a
+        |    b <= i.b
         |  module Inline1 :
         |    input a : UInt<32>
         |    output b : UInt<32>
         |    inst i of Inline2
         |    i.a <= a
-        |    b <= i.a
+        |    b <= i.b
         |  module Inline2 :
         |    input a : UInt<32>
         |    output b : UInt<32>
@@ -128,7 +128,7 @@ class FlattenTests extends LowTransformSpec {
         |    wire i_i_a : UInt<32>
         |    wire i_i_b : UInt<32>
         |    i_i_b <= i_i_a
-        |    i_b <= i_i_a
+        |    i_b <= i_i_b
         |    i_i_a <= i_a
         |    inst ni of NotInline1
         |    b <= i_b
@@ -139,13 +139,13 @@ class FlattenTests extends LowTransformSpec {
         |    input a : UInt<32>
         |    output b : UInt<32>
         |    inst i of Inline2
-        |    b <= i.a
+        |    b <= i.b
         |    i.a <= a
         |  module Inline1 :
         |    input a : UInt<32>
         |    output b : UInt<32>
         |    inst i of Inline2
-        |    b <= i.a
+        |    b <= i.b
         |    i.a <= a
         |  module Inline2 :
         |    input a : UInt<32>
@@ -172,13 +172,13 @@ class FlattenTests extends LowTransformSpec {
         |    output b : UInt<32>
         |    inst i of Inline2
         |    i.a <= a
-        |    b <= i.a
+        |    b <= i.b
         |  module Inline1 :
         |    input a : UInt<32>
         |    output b : UInt<32>
         |    inst i of Inline2
         |    i.a <= a
-        |    b <= i.a
+        |    b <= i.b
         |  module Inline2 :
         |    input a : UInt<32>
         |    output b : UInt<32>
@@ -200,7 +200,7 @@ class FlattenTests extends LowTransformSpec {
         |    input a : UInt<32>
         |    output b : UInt<32>
         |    inst i of Inline2
-        |    b <= i.a
+        |    b <= i.b
         |    i.a <= a
         |  module Inline1 :
         |    input a : UInt<32>
@@ -208,7 +208,7 @@ class FlattenTests extends LowTransformSpec {
         |    wire i_a : UInt<32>
         |    wire i_b : UInt<32>
         |    i_b <= i_a
-        |    b <= i_a
+        |    b <= i_b
         |    i_a <= a
         |  module Inline2 :
         |    input a : UInt<32>

--- a/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
+++ b/src/test/scala/firrtlTests/LoweringCompilersSpec.scala
@@ -146,7 +146,8 @@ class LoweringCompilersSpec extends AnyFlatSpec with Matchers {
   it should "replicate the old order" in {
     val tm = new TransformManager(Forms.MinimalHighForm, Forms.ChirrtlForm)
     val patches = Seq(
-      Add(5, Seq(Dependency[firrtl.annotations.transforms.CleanupNamedTargets]))
+      Add(5, Seq(Dependency[firrtl.annotations.transforms.CleanupNamedTargets],
+                 Dependency(firrtl.transforms.ExpandChiselRValues)))
     )
     compare(legacyTransforms(new firrtl.ChirrtlToHighFirrtl), tm, patches)
   }

--- a/src/test/scala/firrtlTests/formal/RemoveVerificationStatementsSpec.scala
+++ b/src/test/scala/firrtlTests/formal/RemoveVerificationStatementsSpec.scala
@@ -10,7 +10,7 @@ import firrtl.transforms.formal.RemoveVerificationStatements
 class RemoveVerificationStatementsSpec extends FirrtlFlatSpec {
   behavior.of("RemoveVerificationStatements")
 
-  val transforms = new TransformManager(Forms.HighForm, Forms.MinimalHighForm).flattenedTransformOrder ++ Seq(
+  val transforms = new TransformManager(Forms.ChirrtlForm, Forms.MinimalHighForm).flattenedTransformOrder ++ Seq(
     new RemoveVerificationStatements
   )
 

--- a/src/test/scala/firrtlTests/transforms/ExpandChiselRValuesSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/ExpandChiselRValuesSpec.scala
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests.transforms
+
+import firrtl.{
+  ir,
+  CircuitState,
+  Parser
+}
+import firrtl.options.Dependency
+import firrtl.stage.Forms
+import firrtl.testutils.FirrtlFlatSpec
+import firrtl.testutils.FirrtlCheckers._
+
+import org.scalatest.matchers.should._
+
+object ExpandChiselRValuesSpec {
+
+  def moduleCircuit = {
+    Parser.parse(
+      """|circuit Foo :
+         |  module Foo :
+         |    output element : UInt<1>
+         |    output aggregate : { a : UInt<1>, b: UInt<1>}
+         |    output vector : { b : { a : UInt<1> }[2] }
+         |    output a : UInt<1>
+         |    output b : { a : UInt<1>}
+         |    output c : { a : UInt<1>}
+         |    output d : { a : UInt<1>}
+         |    output e : { a : UInt<1>}
+         |    element is invalid
+         |    aggregate.a <= UInt<1>(0)
+         |    aggregate.b <= UInt<1>(0)
+         |    vector is invalid
+         |    a <= element
+         |    b.a <= aggregate.a
+         |    c.a <- aggregate.b
+         |    d <= vector.b[element]
+         |    e <= vector.b[1]
+         |""".stripMargin)
+  }
+
+  val instanceCircuit =
+    """|circuit Foo :
+       |  module Bar :
+       |    output a : { a : UInt<1>}
+       |    a.a is invalid
+       |  module Foo :
+       |    output a : { a : UInt<1>}
+       |    output b : { a : UInt<1>}
+       |    output c : { a : UInt<1>}
+       |    inst bar of Bar
+       |    a.a <= bar.a.a
+       |    b <- bar.a
+       |    c <= bar.a
+       |""".stripMargin
+
+  trait Fixture {
+    val stage = new firrtl.stage.transforms.Compiler(
+      targets = Seq(Dependency(firrtl.transforms.ExpandChiselRValues))
+    )
+
+    implicit class CircuitHelpers(circuit: ir.Circuit) {
+
+      def compile: CircuitState = stage.execute(CircuitState(circuit, Seq.empty))
+
+    }
+
+    implicit class StringHelpers(string: String) {
+
+      def parse: ir.Circuit = Parser.parse(string)
+
+    }
+
+  }
+
+}
+
+class ExpandChiselRValuesSpec extends FirrtlFlatSpec {
+
+  import ExpandChiselRValuesSpec._
+
+  behavior of "firrtl.transforms.ExpandChiselRValues"
+
+  it should "replace a RHS usage of an element that was invalidated" in new Fixture {
+     val output = """|circuit Foo:
+                     |  module Foo:
+                     |    output a: UInt<1>
+                     |    output b: UInt<1>
+                     |    a is invalid
+                     |    b <= a
+                     |"""
+       .stripMargin
+       .parse
+       .compile
+       .circuit
+       .serialize
+
+    output should include ("wire _synthetic_output : { a : UInt<1>}")
+    output should include ("_synthetic_output.a is invalid")
+    output should include ("b <= _synthetic_output.a")
+
+  }
+
+  it should "replace a RHS usage of an element that was connected" in new Fixture {
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: UInt<1>
+         |    output b: UInt<1>
+         |    a <= UInt<1>(0)
+         |    b <= a
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include ("wire _synthetic_output : { a : UInt<1>}")
+    output should include ("_synthetic_output.a <= UInt<1>(\"h0\")")
+    output should include ("b <= _synthetic_output.a")
+
+  }
+
+  it should "replace a RHS usage of an element that was partial connected" in new Fixture {
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: UInt<1>
+         |    output b: UInt<1>
+         |    input c: UInt<1>
+         |    a <- c
+         |    b <- a
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include ("wire _synthetic_output : { a : UInt<1>}")
+    output should include ("_synthetic_output.a <= c")
+    output should include ("b <- _synthetic_output.a")
+  }
+
+  it should "replace a RHS usage of an aggregate that was invalidated" in new Fixture {
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: { b: UInt<1>, c: UInt<1> }
+         |    output b: UInt<1>
+         |    a is invalid
+         |    b <= a.b
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include ("wire _synthetic_output : { a : { b : UInt<1>}}")
+    output should include ("_synthetic_output.a.b is invalid")
+    output should include ("b <= _synthetic_output.a.b")
+
+  }
+
+  it should "replace a RHS usage of an element assigned in an aggregate bi-directional connect" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    input a: { b: UInt<1>, flip c: UInt<1> }
+         |    output b: { b: UInt<1>, flip c: UInt<1> }
+         |    output c: UInt<1>
+         |    b <= a
+         |    c <= b.b
+         |"""
+      .stripMargin
+      .parse
+      .compile
+      .circuit
+      .serialize
+
+    output should include ("wire _synthetic_output : { b : { b : UInt<1>}}")
+    output should include ("_synthetic_output.b.b <= a.b")
+    output should include ("c <= _synthetic_output.b.b")
+
+  }
+
+  it should "assign to a synthetic wire in when statements" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    input cond: UInt<1>
+         |    output a: UInt<1>
+         |    output b: UInt<1>
+         |    when eq(cond, UInt<1>(0)):
+         |      a <= UInt<1>(0)
+         |    else:
+         |      when eq(cond, UInt<1>(1)):
+         |        a <= UInt<1>(1)
+         |      else:
+         |        a <= UInt<1>(0)
+         |    b <= a
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include ("wire _synthetic_output : { a : UInt<1>}")
+    output should include ("_synthetic_output.a <= UInt<1>(\"h0\")")
+    output should include ("_synthetic_output.a <= UInt<1>(\"h1\")")
+    output should include ("b <= _synthetic_output.a")
+  }
+
+  it should "replace a RHS usage of a module output" in {
+    // new firrtl.stage.transforms.Compiler(
+    //   targets = Seq(Dependency(firrtl.transforms.ExpandChiselRValues))
+    // ).execute(
+    //   CircuitState(moduleCircuit, Seq.empty)
+    // )
+
+    (new firrtl.stage.FirrtlStage)
+      .execute(
+        Array("-cll", "firrtl.transforms.ExpandChiselRValues$:trace"),
+        Seq(firrtl.stage.FirrtlCircuitAnnotation(moduleCircuit))
+      ).foreach {
+        case a: firrtl.EmittedVerilogCircuitAnnotation => println(a.value.value)
+        case _ =>
+      }
+  }
+
+  it should "replace a RHS usage of an instance input" in (pending)
+
+  it should "replace a RHS usage of a memory input (addr, etc.)" in (pending)
+
+}

--- a/src/test/scala/firrtlTests/transforms/ExpandChiselRValuesSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/ExpandChiselRValuesSpec.scala
@@ -190,6 +190,30 @@ class ExpandChiselRValuesSpec extends FirrtlFlatSpec {
 
   }
 
+  it should "replace a RHS usage of an aggregate that was partial connected" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: { a: UInt<1>, flip b: UInt<1> }
+         |    output b: { a: UInt<1> }
+         |    b is invalid
+         |    a <- b
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    info(output)
+
+    output should include (s"wire $syntheticName : { b : { a : UInt<1>}}")
+    output should include (s"$syntheticName.b.a is invalid")
+    output should include (s"a <- $syntheticName.b")
+
+  }
+
   it should "assign to a synthetic wire in when statements" in new Fixture {
 
     val output =
@@ -242,6 +266,177 @@ class ExpandChiselRValuesSpec extends FirrtlFlatSpec {
 
   }
 
+  it should "only include outputs in the synthetic wire" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    input decoupled: { flip ready: UInt<1>, valid: UInt<1>}
+         |    decoupled.ready <= UInt<1>(0)
+         |    node c = and(decoupled.ready, decoupled.valid)
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include (s"wire $syntheticName : { decoupled : { ready : UInt<1>}}")
+    output should include (s"""$syntheticName.decoupled.ready <= UInt<1>("h0")""")
+    output should include (s"node c = and($syntheticName.decoupled.ready, decoupled.valid)")
+  }
+
+  it should "replace a RHS sink assignment to a wire" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: { a: UInt<1> }
+         |    output b: { a: UInt<1> }
+         |    wire w : { a: UInt<1> }
+         |    b is invalid
+         |    w <= b
+         |    a <= w
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include (s"wire $syntheticName : { b : { a : UInt<1>}}")
+    output should include (s"$syntheticName.b.a is invalid")
+    output should include (s"w <= $syntheticName.b")
+
+  }
+
+  it should "replace a RHS sink assignment to a register" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: { a: UInt<1> }
+         |    output b: { a: UInt<1> }
+         |    input clk: Clock
+         |    reg r : { a: UInt<1> }, clk
+         |    b is invalid
+         |    r <= b
+         |    a <= r
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include (s"wire $syntheticName : { b : { a : UInt<1>}}")
+    output should include (s"$syntheticName.b.a is invalid")
+    output should include (s"r <= $syntheticName.b")
+
+  }
+
+  it should "replace a RHS sink assignment to a register clock" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: UInt<1>
+         |    input clkIn: Clock
+         |    output clkOut: Clock
+         |    reg r : UInt<1>, clkOut
+         |    clkOut <= clkIn
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include (s"reg r : UInt<1>, $syntheticName.clkOut")
+
+  }
+
+  it should "replace a RHS sink assignment to a register reset" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: UInt<1>
+         |    input clk: Clock
+         |    reg r : UInt<1>, clk with : (reset => (a, UInt<1>(0)))
+         |    a is invalid
+         |    r is invalid
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include (s"""reset => ($syntheticName.a, UInt<1>("h0"))""")
+
+  }
+
+  it should "replace a RHS sink assignment to a register init" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output a: UInt<1>
+         |    input clk: Clock
+         |    input rst: UInt<1>
+         |    reg r : UInt<1>, clk with : (reset => (rst, a))
+         |    a is invalid
+         |    r is invalid
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include (s"""reset => (rst, $syntheticName.a)""")
+
+  }
+
+  it should "ignore a bi-directional connect" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    input in: { flip ready: UInt<1>, valid: UInt<1>}
+         |    output out : { flip ready: UInt<1>, valid: UInt<1>}
+         |    out <= in
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    info(output)
+
+  }
+
+  it should "ignorea false RHS" in new Fixture {
+    val output =
+      """|circuit Foo :
+         |  module Foo :
+         |    output a : { flip a : UInt<1> }
+         |    input  b : { flip a : UInt<1> }
+         |    a <= b
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    info(output)
+    output should include ("a <= b")
+
+  }
+
   it should "replace a RHS usage of a module output" in {
     // new firrtl.stage.transforms.Compiler(
     //   targets = Seq(Dependency(firrtl.transforms.ExpandChiselRValues))
@@ -267,11 +462,15 @@ class ExpandChiselRValuesSpec extends FirrtlFlatSpec {
       """|circuit Foo:
          |  module Bar:
          |    input a: UInt<1>
+         |    output b: UInt<1>
+         |    b is invalid
          |  module Foo:
          |    output a: UInt<1>
+         |    output b: UInt<1>
          |    inst bar of Bar
          |    bar.a is invalid
          |    a <= bar.a
+         |    b <= bar.b
          |"""
         .stripMargin
         .parse
@@ -282,9 +481,49 @@ class ExpandChiselRValuesSpec extends FirrtlFlatSpec {
     output should include (s"wire $syntheticName : { bar : { a : UInt<1>}}")
     output should include (s"$syntheticName.bar.a is invalid")
     output should include (s"a <= $syntheticName.bar.a")
+    output should include (s"b <= bar.b")
 
   }
 
+  it should "ignore a bi-directional connect" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Bar:
+         |    input a: { flip b: UInt<1>, c: UInt<1>}
+         |  module Foo:
+         |    input a: { flip b: UInt<1>, c: UInt<1>}
+         |    inst bar of Bar
+         |    a <= bar.a
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    output should include (s"a <= bar.a")
+
+  }
+
+  /* This is low priority as Chisel cannot emit this. */
   it should "replace a RHS usage of a memory input (addr, etc.)" in (pending)
+
+  "module type canonicalization" should "work" in new Fixture {
+
+    val output =
+      """|circuit Foo:
+         |  module Foo:
+         |    output decoupled: { flip ready: UInt<1>, valid: UInt<1>, bits: UInt<1> }
+         |"""
+        .stripMargin
+        .parse
+        .compile
+        .circuit
+        .serialize
+
+    info(output)
+
+  }
 
 }


### PR DESCRIPTION
Replace right-hand-side usages of module port outputs or instance inputs with a synthetic wire. 

One synthetic wire is created per module or instance. This is _not_ a full enumeration of all ports. Only sinks used as sources will show up in a synthetic wire.

E.g., this will turn:

```
circuit Foo:
  module Foo:
    input cond: UInt<1>
    output a: UInt<1>
    output b: UInt<1>
    when eq(cond, UInt<1>(0)):
      a <= UInt<1>(0)
    else:
      when eq(cond, UInt<1>(1)):
        a <= UInt<1>(1)
      else:
        a <= UInt<1>(0)
    b <= a
```

Into:

```
circuit Foo :
  module Foo :
    input cond : UInt<1>
    output a : UInt<1>
    output b : UInt<1>

    wire _synthetic_output : { a : UInt<1>}
    when eq(cond, UInt<1>("h0")) :
      a <= UInt<1>("h0")
      _synthetic_output.a <= UInt<1>("h0")
    else :
      when eq(cond, UInt<1>("h1")) :
        a <= UInt<1>("h1")
        _synthetic_output.a <= UInt<1>("h1")
      else :
        a <= UInt<1>("h0")
        _synthetic_output.a <= UInt<1>("h0")
    b <= _synthetic_output.a
```

Fixes #2013 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
