### PR TITLE
Improve performance of LowerTypes renaming

### DIFF
--- a/src/main/scala/firrtl/annotations/TargetUtils.scala
+++ b/src/main/scala/firrtl/annotations/TargetUtils.scala
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.annotations
+
+import firrtl._
+import firrtl.analyses.InstanceKeyGraph
+import firrtl.analyses.InstanceKeyGraph.InstanceKey
+import firrtl.annotations.TargetToken._
+
+object TargetUtils {
+
+  /** Turns an instance path into a corresponding [[IsModule]]
+    *
+    * @note First InstanceKey is treated as the [[CircuitTarget]]
+    * @param path Instance path
+    * @param start Module in instance path to be starting [[ModuleTarget]]
+    * @return [[IsModule]] corresponding to Instance path
+    */
+  def instKeyPathToTarget(path: Seq[InstanceKey], start: Option[String] = None): IsModule = {
+    val head = path.head
+    val startx = start.getOrElse(head.module)
+    val top: IsModule = CircuitTarget(head.module).module(startx) // ~Top|Start
+    val pathx = path.dropWhile(_.module != startx)
+    if (pathx.isEmpty) top
+    else pathx.tail.foldLeft(top) { case (acc, key) => acc.instOf(key.name, key.module) }
+  }
+
+  /** Calculates all [[InstanceTarget]]s that refer to the given [[IsModule]]
+    *
+    * {{{
+    * ~Top|Top/a:A/b:B/c:C unfolds to:
+    * * ~Top|Top/a:A/b:B/c:C
+    * * ~Top|A/b:B/c:C
+    * * ~Top|B/c:C
+    * }}}
+    * @note [[ModuleTarget]] arguments return an empty Iterable
+    */
+  def unfoldInstanceTargets(ismod: IsModule): Iterable[InstanceTarget] = {
+    // concretely use List which is fast in practice
+    def rec(im: IsModule): List[InstanceTarget] = im match {
+      case inst: InstanceTarget => inst :: rec(inst.stripHierarchy(1))
+      case _ => Nil
+    }
+    rec(ismod)
+  }
+}

--- a/src/test/scala/firrtl/RenameMapPrivateSpec.scala
+++ b/src/test/scala/firrtl/RenameMapPrivateSpec.scala
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl
+
+import firrtl.annotations.Target
+import firrtl.annotations.TargetToken.{Instance, OfModule}
+import firrtl.analyses.InstanceKeyGraph
+import firrtl.testutils.FirrtlFlatSpec
+
+class RenameMapPrivateSpec extends FirrtlFlatSpec {
+  "RenameMap.fromInstanceRenames" should "handle instance renames" in {
+    def tar(str: String): Target = Target.deserialize(str)
+    val circuit = parse(
+      """circuit Top :
+        |  module Bar :
+        |    skip
+        |  module Foo :
+        |    inst bar of Bar
+        |  module Top :
+        |    inst foo1 of Foo
+        |    inst foo2 of Foo
+        |    inst bar of Bar
+        |""".stripMargin
+    )
+    val graph = InstanceKeyGraph(circuit)
+    val renames = Map(
+      OfModule("Foo") -> Map(Instance("bar") -> Instance("bbb")),
+      OfModule("Top") -> Map(Instance("foo1") -> Instance("ffff"))
+    )
+    val rm = RenameMap.fromInstanceRenames(graph, renames)
+    rm.get(tar("~Top|Top/foo1:Foo")) should be(Some(Seq(tar("~Top|Top/ffff:Foo"))))
+    rm.get(tar("~Top|Top/foo2:Foo")) should be(None)
+    // Check of nesting
+    rm.get(tar("~Top|Top/foo1:Foo/bar:Bar")) should be(Some(Seq(tar("~Top|Top/ffff:Foo/bbb:Bar"))))
+    rm.get(tar("~Top|Top/foo2:Foo/bar:Bar")) should be(Some(Seq(tar("~Top|Top/foo2:Foo/bbb:Bar"))))
+    rm.get(tar("~Top|Foo/bar:Bar")) should be(Some(Seq(tar("~Top|Foo/bbb:Bar"))))
+    rm.get(tar("~Top|Top/bar:Bar")) should be(None)
+  }
+}

--- a/src/test/scala/firrtlTests/RenameMapSpec.scala
+++ b/src/test/scala/firrtlTests/RenameMapSpec.scala
@@ -5,6 +5,8 @@ package firrtlTests
 import firrtl.RenameMap
 import firrtl.RenameMap.IllegalRenameException
 import firrtl.annotations._
+import firrtl.annotations.TargetToken.{Instance, OfModule}
+import firrtl.analyses.InstanceKeyGraph
 import firrtl.testutils._
 
 class RenameMapSpec extends FirrtlFlatSpec {

--- a/src/test/scala/firrtlTests/annotationTests/TargetUtilsSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/TargetUtilsSpec.scala
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests.annotationTests
+
+import firrtl.analyses.InstanceKeyGraph.InstanceKey
+import firrtl.annotations._
+import firrtl.annotations.TargetToken._
+import firrtl.annotations.TargetUtils._
+import firrtl.testutils.FirrtlFlatSpec
+
+class TargetUtilsSpec extends FirrtlFlatSpec {
+
+  behavior.of("instKeyPathToTarget")
+
+  it should "create a ModuleTarget for the top module" in {
+    val input = InstanceKey("Top", "Top") :: Nil
+    val expected = ModuleTarget("Top", "Top")
+    instKeyPathToTarget(input) should be(expected)
+  }
+
+  it should "create absolute InstanceTargets" in {
+    val input = InstanceKey("Top", "Top") ::
+      InstanceKey("foo", "Foo") ::
+      InstanceKey("bar", "Bar") ::
+      Nil
+    val expected = InstanceTarget("Top", "Top", Seq((Instance("foo"), OfModule("Foo"))), "bar", "Bar")
+    instKeyPathToTarget(input) should be(expected)
+  }
+
+  it should "support starting somewhere down the path" in {
+    val input = InstanceKey("Top", "Top") ::
+      InstanceKey("foo", "Foo") ::
+      InstanceKey("bar", "Bar") ::
+      InstanceKey("fizz", "Fizz") ::
+      Nil
+    val expected = InstanceTarget("Top", "Bar", Seq(), "fizz", "Fizz")
+    instKeyPathToTarget(input, Some("Bar")) should be(expected)
+  }
+
+  behavior.of("unfoldInstanceTargets")
+
+  it should "return nothing for ModuleTargets" in {
+    val input = ModuleTarget("Top", "Foo")
+    unfoldInstanceTargets(input) should be(Iterable())
+  }
+
+  it should "return all other InstanceTargets to the same instance" in {
+    val input = ModuleTarget("Top", "Top").instOf("foo", "Foo").instOf("bar", "Bar").instOf("fizz", "Fizz")
+    val expected =
+      input ::
+        ModuleTarget("Top", "Foo").instOf("bar", "Bar").instOf("fizz", "Fizz") ::
+        ModuleTarget("Top", "Bar").instOf("fizz", "Fizz") ::
+        Nil
+    unfoldInstanceTargets(input) should be(expected)
+  }
+}


### PR DESCRIPTION
In addition to the added tests, I tested this with 3 different designs, diffing the Verilog and output annotation files and saw the results were identical. Also, pretty sure this is correct because I originally used the `InstanceKeyGraph` from _after_ transformation in `LowerTypes` instead of before, and 2/3 of my designs failed.

Also, not very scientific, but a design that was running very slowly during renaming in LowerTypes had it's total FIRRTL runtime reduced from `36m45s` to `20m45s`, so a massive win.


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - performance improvement

#### API Impact

This adds some new public utilities

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Improve performance and memory use of `LowerTypes`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
