### PR TITLE
smt: run DeadCodeElimination after PropagatePresetAnnotations

### DIFF
--- a/src/test/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystemPassSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystemPassSpec.scala
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.backends.experimental.smt
+
+import firrtl.annotations.{CircuitTarget, PresetAnnotation}
+import firrtl.options.Dependency
+import firrtl.testutils.LeanTransformSpec
+
+class FirrtlToTransitionSystemPassSpec extends LeanTransformSpec(Seq(Dependency(firrtl.backends.experimental.smt.FirrtlToTransitionSystem))) {
+  behavior of "FirrtlToTransitionSystem"
+
+  it should "support preset wires" in {
+    // In order to give registers an initial wire, we use preset annotated resets.
+    // When using a wire instead of an input (which has the advantage of working regardless of the
+    // module hierarchy), we need to initialize it in order to get through the wire initialization check.
+    // In Chisel this generates a node which needs to be removed.
+
+    val src = """circuit ModuleAB :
+      |  module ModuleAB :
+      |    input clock : Clock
+      |    node _T = asAsyncReset(UInt<1>("h0"))
+      |    node preset = _T
+      |    reg REG : UInt<1>, clock with :
+      |      reset => (preset, UInt<1>("h0"))
+      |    assert(clock, UInt(1), not(REG), "REG == 0")
+      |""".stripMargin
+    val anno = PresetAnnotation(CircuitTarget("ModuleAB").module("ModuleAB").ref("preset"))
+
+    val result = compile(src, List(anno))
+    val sys = result.annotations.collectFirst{ case TransitionSystemAnnotation(sys) => sys }.get
+    assert(sys.states.head.init.isDefined)
+  }
+}


### PR DESCRIPTION
This enables an important pattern in Chisel:

```scala
val preset = WireInit(false.B.asAsyncReset())
annotate(new ChiselAnnotation {
  override def toFirrtl = PresetAnnotation(preset.toTarget)
})
withReset(preset) {
  // ...
}
```

Note that the problematic part is the use of `WireInit` which is required in order not to run afoul of wire initialization checks in the compiler frontend.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### Type of Improvement

- bug fix

#### API Impact
- none

#### Backend Code Generation Impact

- only affects SMT/Btor2 backends, no change to Verilog generaion


#### Desired Merge Strategy

- squash


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
