### PR TITLE
Split More, Necessary Expressions

### DIFF
--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -62,7 +62,7 @@ object SplitExpressions extends Pass {
 
       (s match {
         case _: DefNode | _: Connect => s.map(onExp(true))
-        case _                       => s.map(onExp(false))
+        case _ => s.map(onExp(false))
       }) match {
         case x: Block => x.map(onStmt)
         case EmptyStmt => EmptyStmt

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -49,14 +49,24 @@ object SplitExpressions extends Pass {
         case _ => e
       }
 
-      // Recursive. Splits compound nodes
-      def onExp(e: Expression): Expression =
-        e.map(onExp) match {
-          case ex: DoPrim => ex.map(split)
+      /* Split expressions consisting of compound nodes. Do not split the outer expression if it is the RHS of an assignment
+       * (node or connect).  This prevents generating unnecessary nodes and also makes this transform idempotent.
+       */
+      def onExp(e: Expression, isAssign: Boolean): Expression =
+        e.map(onExp(_, false)) match {
+          case ex: DoPrim =>
+            val exx = ex.map(split)
+            isAssign match {
+              case true  => exx
+              case false => split(exx)
+            }
           case ex => ex
         }
 
-      s.map(onExp) match {
+      (s match {
+        case _: DefNode | _: Connect => s.map(onExp(_, true))
+        case _                       => s.map(onExp(_, false))
+      }) match {
         case x: Block => x.map(onStmt)
         case EmptyStmt => EmptyStmt
         case x =>

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -56,10 +56,7 @@ object SplitExpressions extends Pass {
         e.map(onExp(_, false)) match {
           case ex: DoPrim =>
             val exx = ex.map(split)
-            isAssign match {
-              case true  => exx
-              case false => split(exx)
-            }
+            if (isAssign) exx else split(exx)
           case ex => ex
         }
 

--- a/src/main/scala/firrtl/passes/SplitExpressions.scala
+++ b/src/main/scala/firrtl/passes/SplitExpressions.scala
@@ -52,8 +52,8 @@ object SplitExpressions extends Pass {
       /* Split expressions consisting of compound nodes. Do not split the outer expression if it is the RHS of an assignment
        * (node or connect).  This prevents generating unnecessary nodes and also makes this transform idempotent.
        */
-      def onExp(e: Expression, isAssign: Boolean): Expression =
-        e.map(onExp(_, false)) match {
+      def onExp(isAssign: Boolean)(e: Expression): Expression =
+        e.map(onExp(false)) match {
           case ex: DoPrim =>
             val exx = ex.map(split)
             if (isAssign) exx else split(exx)
@@ -61,8 +61,8 @@ object SplitExpressions extends Pass {
         }
 
       (s match {
-        case _: DefNode | _: Connect => s.map(onExp(_, true))
-        case _                       => s.map(onExp(_, false))
+        case _: DefNode | _: Connect => s.map(onExp(true))
+        case _                       => s.map(onExp(false))
       }) match {
         case x: Block => x.map(onStmt)
         case EmptyStmt => EmptyStmt

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -480,12 +480,12 @@ class VerilogEmitterSpec extends FirrtlFlatSpec {
         EmitCircuitAnnotation(classOf[VerilogEmitter])
       )
     )
-    CircuitState(
-      annotations.collectFirst {
-        case FirrtlCircuitAnnotation(circuit) => circuit
-      }.get,
-      annotations
-    ) should containLines(check: _*)
+
+    val output = annotations.collectFirst {
+      case FirrtlCircuitAnnotation(circuit) => circuit.serialize
+    }.get
+
+    check.foreach(output contains _)
   }
 
   behavior.of("Register Updates")

--- a/src/test/scala/firrtlTests/passes/SplitExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/passes/SplitExpressionsSpec.scala
@@ -2,12 +2,7 @@
 
 package firrtlTests.passes
 
-import firrtl.{
-  ir,
-  CircuitState,
-  Parser,
-  PrimOps
-}
+import firrtl.{ir, CircuitState, Parser, PrimOps}
 import firrtl.passes.SplitExpressions
 import firrtl.testutils.FirrtlCheckers._
 
@@ -16,7 +11,7 @@ import org.scalatest.matchers.should.Matchers
 
 class SplitExpressionsSpec extends AnyFlatSpec {
 
-  behavior of "SplitExpressions"
+  behavior.of("SplitExpressions")
 
   it should "be idempotent" in {
 
@@ -30,15 +25,15 @@ class SplitExpressionsSpec extends AnyFlatSpec {
 
     val state = CircuitState(Parser.parse(input), Seq.empty)
 
-    val output = Seq.fill(2)(SplitExpressions).foldLeft(state){ case (acc, a) => a.transform(acc) }
+    val output = Seq.fill(2)(SplitExpressions).foldLeft(state) { case (acc, a) => a.transform(acc) }
 
-    output should be (state)
+    output should be(state)
 
   }
 
   it should "fix issue #2037" in {
 
-    val input=
+    val input =
       """|circuit Foo:
          |  module Foo:
          |    input cond: UInt<1>

--- a/src/test/scala/firrtlTests/passes/SplitExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/passes/SplitExpressionsSpec.scala
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests.passes
+
+import firrtl.{
+  ir,
+  CircuitState,
+  Parser,
+  PrimOps
+}
+import firrtl.passes.SplitExpressions
+import firrtl.testutils.FirrtlCheckers._
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SplitExpressionsSpec extends AnyFlatSpec {
+
+  behavior of "SplitExpressions"
+
+  it should "be idempotent" in {
+
+    val input =
+      """|circuit Foo:
+         |  module Foo:
+         |    input a: UInt<1>
+         |
+         |    node b = not(a)
+         |""".stripMargin
+
+    val state = CircuitState(Parser.parse(input), Seq.empty)
+
+    val output = Seq.fill(2)(SplitExpressions).foldLeft(state){ case (acc, a) => a.transform(acc) }
+
+    output should be (state)
+
+  }
+
+  it should "fix issue #2037" in {
+
+    val input=
+      """|circuit Foo:
+         |  module Foo:
+         |    input cond: UInt<1>
+         |    input a: UInt<1>
+         |    input b: SInt<1>
+         |    output c: SInt<1>
+         |
+         |    c <= mux(cond, asSInt(a), b)
+         |""".stripMargin
+
+    val state = CircuitState(Parser.parse(input), Seq.empty)
+
+    SplitExpressions.transform(state) should containTree {
+      case ir.DefNode(_, _, ir.DoPrim(PrimOps.AsSInt, Seq(ir.Reference("a", _, _, _)), _, _)) => true
+    }
+
+  }
+
+}

--- a/src/test/scala/firrtlTests/passes/VerilogModulusCleanupSpec.scala
+++ b/src/test/scala/firrtlTests/passes/VerilogModulusCleanupSpec.scala
@@ -2,22 +2,15 @@
 
 package firrtlTests.passes
 
-import firrtl.{
-  CircuitState,
-  Parser
-}
-import firrtl.passes.{
-  CheckTypes,
-  InferTypes,
-  VerilogModulusCleanup
-}
+import firrtl.{CircuitState, Parser}
+import firrtl.passes.{CheckTypes, InferTypes, VerilogModulusCleanup}
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class VerilogModulusCleanupSpec extends AnyFlatSpec with Matchers {
 
-  behavior of "VerilogModulusCleanup"
+  behavior.of("VerilogModulusCleanup")
 
   it should "add an 'asSInt' prim op if the 'rem' prim op operates on 'SInt' types" in {
 
@@ -30,14 +23,15 @@ class VerilogModulusCleanupSpec extends AnyFlatSpec with Matchers {
          |""".stripMargin
 
     /* Running CheckTypes after VerilogModulusCleanup will fail if the asSInt prim op isn't generated */
-    val output = (Parser.parse(_: String))
+    val output = (Parser
+      .parse(_: String))
       .andThen(CircuitState(_, Seq.empty))
       .andThen(InferTypes.transform)
       .andThen(VerilogModulusCleanup.transform)
       .andThen(CheckTypes.transform)
       .apply(input)
 
-    output.circuit.serialize should include ("asSInt")
+    output.circuit.serialize should include("asSInt")
 
   }
 

--- a/src/test/scala/firrtlTests/passes/VerilogModulusCleanupSpec.scala
+++ b/src/test/scala/firrtlTests/passes/VerilogModulusCleanupSpec.scala
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests.passes
+
+import firrtl.{
+  CircuitState,
+  Parser
+}
+import firrtl.passes.{
+  CheckTypes,
+  InferTypes,
+  VerilogModulusCleanup
+}
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class VerilogModulusCleanupSpec extends AnyFlatSpec with Matchers {
+
+  behavior of "VerilogModulusCleanup"
+
+  it should "add an 'asSInt' prim op if the 'rem' prim op operates on 'SInt' types" in {
+
+    val input =
+      """|circuit Foo:
+         |  module Bar:
+         |    input a: SInt<2>
+         |    output b: SInt<2>
+         |    b <= rem(a, a)
+         |""".stripMargin
+
+    /* Running CheckTypes after VerilogModulusCleanup will fail if the asSInt prim op isn't generated */
+    val output = (Parser.parse(_: String))
+      .andThen(CircuitState(_, Seq.empty))
+      .andThen(InferTypes.transform)
+      .andThen(VerilogModulusCleanup.transform)
+      .andThen(CheckTypes.transform)
+      .apply(input)
+
+    output.circuit.serialize should include ("asSInt")
+
+  }
+
+}

--- a/src/test/scala/firrtlTests/transforms/LegalizeClocksAndAsyncResets.scala
+++ b/src/test/scala/firrtlTests/transforms/LegalizeClocksAndAsyncResets.scala
@@ -19,7 +19,7 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
         |    stop(asClock(UInt(1)), UInt(1), 1)
         |""".stripMargin
     val result = compile(input).getEmittedCircuit.value
-    result should include (s"always @(posedge _GEN_")
+    result should include(s"always @(posedge _GEN_")
     result shouldNot include("always @(posedge 1")
   }
 
@@ -30,7 +30,7 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
         |    printf(asClock(UInt(1)), UInt(1), "hi")
         |""".stripMargin
     val result = compile(input).getEmittedCircuit.value
-    result should include (s"always @(posedge _GEN_")
+    result should include(s"always @(posedge _GEN_")
     result shouldNot include("always @(posedge 1")
   }
 
@@ -45,7 +45,7 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
         |    out <= r
         |""".stripMargin
     val result = compile(input).getEmittedCircuit.value
-    result should include (s"always @(posedge _GEN_")
+    result should include(s"always @(posedge _GEN_")
     result shouldNot include("always @(posedge 1")
   }
 

--- a/src/test/scala/firrtlTests/transforms/LegalizeClocksAndAsyncResets.scala
+++ b/src/test/scala/firrtlTests/transforms/LegalizeClocksAndAsyncResets.scala
@@ -18,9 +18,9 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
         |  module test :
         |    stop(asClock(UInt(1)), UInt(1), 1)
         |""".stripMargin
-    val result = compile(input)
-    result should containLine(s"always @(posedge _GEN_0) begin")
-    result.getEmittedCircuit.value shouldNot include("always @(posedge 1")
+    val result = compile(input).getEmittedCircuit.value
+    result should include (s"always @(posedge _GEN_")
+    result shouldNot include("always @(posedge 1")
   }
 
   it should "not emit @(posedge 1'h0) for printf" in {
@@ -29,9 +29,9 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
         |  module test :
         |    printf(asClock(UInt(1)), UInt(1), "hi")
         |""".stripMargin
-    val result = compile(input)
-    result should containLine(s"always @(posedge _GEN_0) begin")
-    result.getEmittedCircuit.value shouldNot include("always @(posedge 1")
+    val result = compile(input).getEmittedCircuit.value
+    result should include (s"always @(posedge _GEN_")
+    result shouldNot include("always @(posedge 1")
   }
 
   it should "not emit @(posedge 1'h0) for reg" in {
@@ -44,9 +44,9 @@ class LegalizeClocksTransformSpec extends FirrtlFlatSpec {
         |    r <= in
         |    out <= r
         |""".stripMargin
-    val result = compile(input)
-    result should containLine(s"always @(posedge _GEN_0) begin")
-    result.getEmittedCircuit.value shouldNot include("always @(posedge 1")
+    val result = compile(input).getEmittedCircuit.value
+    result should include (s"always @(posedge _GEN_")
+    result shouldNot include("always @(posedge 1")
   }
 
   it should "not emit @(posedge 1'h0) for mem" in {


### PR DESCRIPTION
Fixes #2037. The example code there will now produce:

```verilog
module Foo(
  input         a,
  input  [12:0] inp_6,
  output [13:0] tmp13
);
  wire [13:0] _GEN_0 = inp_6 + 13'h1;
  assign tmp13 = a ? $signed(_GEN_0) : $signed(14'sh1);
endmodule
```

Change `SplitExpressions` to split more expressions. Previously, the root expression would not be split out, e.g., the true or false condition from a mux which can lead to invalid Verilog like in #2037.

Now, all expressions will be split out unless they are trivial assignments or connects (this transform requires low form so it can safely ignore partial connects). This has the effect of also ensuring idempotency of the transform.

This exposed a weird bug where the invalid types that `VerilogModulusCleanup` produces (it would produce a `bits` op of type `SInt`) would then cause the Verilog emitter to serialize an `UnknownType` string. This PR adds an `asSInt` op and returns the correct types to avoid this.

Note: this may produce slightly more verbose Verilog for situations involving a `rem` op on an `SInt` type which can be cleaned up later with invalidations on inlining, CSE, and DCE. However, that increases the footprint of this PR substantially and changes transform ordering.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

None.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

This fixes a possible bug in generated code, but may produce additional temporary wires for cases involving `rem` of `SInt` types.

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
