### PR TITLE
Restore scalafmt CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
           java-version: adopt@1.8
       - name: Cache Scala
         uses: coursier/cache-action@v5
+      - name: Check Formatting (Scala 2.12 only)
+        if: matrix.scala == '2.12.12'
+        run: sbt ++${{ matrix.scala }} scalafmtCheckAll
       - name: Unidoc builds (Scala 2.12 only)
         if: matrix.scala == '2.12.12'
         run: sbt ++${{ matrix.scala }} unidoc

--- a/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
@@ -11,7 +11,17 @@ import firrtl.passes.PassException
 import firrtl.stage.Forms
 import firrtl.stage.TransformManager.TransformDependency
 import firrtl.transforms.{DeadCodeElimination, PropagatePresetAnnotations}
-import firrtl.{CircuitState, DependencyAPIMigration, MemoryArrayInit, MemoryInitValue, MemoryScalarInit, Namespace, Transform, Utils, ir}
+import firrtl.{
+  ir,
+  CircuitState,
+  DependencyAPIMigration,
+  MemoryArrayInit,
+  MemoryInitValue,
+  MemoryScalarInit,
+  Namespace,
+  Transform,
+  Utils
+}
 import logger.LazyLogging
 
 import scala.collection.mutable

--- a/src/test/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystemPassSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystemPassSpec.scala
@@ -6,8 +6,9 @@ import firrtl.annotations.{CircuitTarget, PresetAnnotation}
 import firrtl.options.Dependency
 import firrtl.testutils.LeanTransformSpec
 
-class FirrtlToTransitionSystemPassSpec extends LeanTransformSpec(Seq(Dependency(firrtl.backends.experimental.smt.FirrtlToTransitionSystem))) {
-  behavior of "FirrtlToTransitionSystem"
+class FirrtlToTransitionSystemPassSpec
+    extends LeanTransformSpec(Seq(Dependency(firrtl.backends.experimental.smt.FirrtlToTransitionSystem))) {
+  behavior.of("FirrtlToTransitionSystem")
 
   it should "support preset wires" in {
     // In order to give registers an initial wire, we use preset annotated resets.
@@ -16,18 +17,18 @@ class FirrtlToTransitionSystemPassSpec extends LeanTransformSpec(Seq(Dependency(
     // In Chisel this generates a node which needs to be removed.
 
     val src = """circuit ModuleAB :
-      |  module ModuleAB :
-      |    input clock : Clock
-      |    node _T = asAsyncReset(UInt<1>("h0"))
-      |    node preset = _T
-      |    reg REG : UInt<1>, clock with :
-      |      reset => (preset, UInt<1>("h0"))
-      |    assert(clock, UInt(1), not(REG), "REG == 0")
-      |""".stripMargin
+                |  module ModuleAB :
+                |    input clock : Clock
+                |    node _T = asAsyncReset(UInt<1>("h0"))
+                |    node preset = _T
+                |    reg REG : UInt<1>, clock with :
+                |      reset => (preset, UInt<1>("h0"))
+                |    assert(clock, UInt(1), not(REG), "REG == 0")
+                |""".stripMargin
     val anno = PresetAnnotation(CircuitTarget("ModuleAB").module("ModuleAB").ref("preset"))
 
     val result = compile(src, List(anno))
-    val sys = result.annotations.collectFirst{ case TransitionSystemAnnotation(sys) => sys }.get
+    val sys = result.annotations.collectFirst { case TransitionSystemAnnotation(sys) => sys }.get
     assert(sys.states.head.init.isDefined)
   }
 }


### PR DESCRIPTION
Fix scalafmtCheckAll failures that snuck through.

Backporting to only 1.4.x because it is the only stable branch with scalafmt.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix   

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
