### PR TITLE
Fix Mergify condition for labeling backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -60,7 +60,7 @@ pull_request_rules:
       - Backported
 - name: label Mergify backport PR
   conditions:
-  - body~=This is an automated backport of pull request \#\d+ done by Mergify
+  - title~=\(bp \#\d+\)
   actions:
     label:
       add:


### PR DESCRIPTION
Mergify [changed the wording slightly](https://github.com/Mergifyio/mergify-engine/pull/1793) so our backport labeling rule no longer works. This just matches on the `(bp #whatever)` in the PR title which seems less likely to change 🤞 

This shouldn't need to be backported, I believe Mergify simply uses `.mergify.yml` from the main branch for all PRs.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - bug fix 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
