### PR TITLE
Restore scalafmt CI check (bp #2047)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
           java-version: adopt@1.8
       - name: Cache Scala
         uses: coursier/cache-action@v5
+      - name: Check Formatting (Scala 2.12 only)
+        if: matrix.scala == '2.12.12'
+        run: sbt ++${{ matrix.scala }} scalafmtCheckAll
       - name: Unidoc builds (Scala 2.12 only)
         if: matrix.scala == '2.12.12'
         run: sbt ++${{ matrix.scala }} unidoc

--- a/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
@@ -11,7 +11,17 @@ import firrtl.passes.PassException
 import firrtl.stage.Forms
 import firrtl.stage.TransformManager.TransformDependency
 import firrtl.transforms.{DeadCodeElimination, PropagatePresetAnnotations}
-import firrtl.{CircuitState, DependencyAPIMigration, MemoryArrayInit, MemoryInitValue, MemoryScalarInit, Namespace, Transform, Utils, ir}
+import firrtl.{
+  ir,
+  CircuitState,
+  DependencyAPIMigration,
+  MemoryArrayInit,
+  MemoryInitValue,
+  MemoryScalarInit,
+  Namespace,
+  Transform,
+  Utils
+}
 import logger.LazyLogging
 
 import scala.collection.mutable

--- a/src/test/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystemPassSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystemPassSpec.scala
@@ -6,8 +6,9 @@ import firrtl.annotations.{CircuitTarget, PresetAnnotation}
 import firrtl.options.Dependency
 import firrtl.testutils.LeanTransformSpec
 
-class FirrtlToTransitionSystemPassSpec extends LeanTransformSpec(Seq(Dependency(firrtl.backends.experimental.smt.FirrtlToTransitionSystem))) {
-  behavior of "FirrtlToTransitionSystem"
+class FirrtlToTransitionSystemPassSpec
+    extends LeanTransformSpec(Seq(Dependency(firrtl.backends.experimental.smt.FirrtlToTransitionSystem))) {
+  behavior.of("FirrtlToTransitionSystem")
 
   it should "support preset wires" in {
     // In order to give registers an initial wire, we use preset annotated resets.
@@ -16,18 +17,18 @@ class FirrtlToTransitionSystemPassSpec extends LeanTransformSpec(Seq(Dependency(
     // In Chisel this generates a node which needs to be removed.
 
     val src = """circuit ModuleAB :
-      |  module ModuleAB :
-      |    input clock : Clock
-      |    node _T = asAsyncReset(UInt<1>("h0"))
-      |    node preset = _T
-      |    reg REG : UInt<1>, clock with :
-      |      reset => (preset, UInt<1>("h0"))
-      |    assert(clock, UInt(1), not(REG), "REG == 0")
-      |""".stripMargin
+                |  module ModuleAB :
+                |    input clock : Clock
+                |    node _T = asAsyncReset(UInt<1>("h0"))
+                |    node preset = _T
+                |    reg REG : UInt<1>, clock with :
+                |      reset => (preset, UInt<1>("h0"))
+                |    assert(clock, UInt(1), not(REG), "REG == 0")
+                |""".stripMargin
     val anno = PresetAnnotation(CircuitTarget("ModuleAB").module("ModuleAB").ref("preset"))
 
     val result = compile(src, List(anno))
-    val sys = result.annotations.collectFirst{ case TransitionSystemAnnotation(sys) => sys }.get
+    val sys = result.annotations.collectFirst { case TransitionSystemAnnotation(sys) => sys }.get
     assert(sys.states.head.init.isDefined)
   }
 }


### PR DESCRIPTION
Fix scalafmtCheckAll failures that snuck through
(cherry picked from commit 6d8e9041e000f9ea5fb3d069d1f9ec06d2158575)

This is a manual backport of https://github.com/chipsalliance/firrtl/pull/2047 done by @jackkoenig 