### PR TITLE
Fix post-merge publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala: [2.13.2, 2.12.12, 2.11.12]
+        scala: [2.13.4, 2.12.13, 2.11.12]
     container:
       image: ucbbar/chisel3-tools
       options: --user github --entrypoint /bin/bash
@@ -34,8 +34,7 @@ jobs:
       - name: Check Formatting (Scala 2.12 only)
         if: matrix.scala == '2.12.12'
         run: sbt ++${{ matrix.scala }} scalafmtCheckAll
-      - name: Unidoc builds (Scala 2.12 only)
-        if: matrix.scala == '2.12.12'
+      - name: Unidoc
         run: sbt ++${{ matrix.scala }} unidoc
       - name: Sanity check benchmarking scripts (Scala 2.12 only)
         if: matrix.scala == '2.12.12'

--- a/build.sbt
+++ b/build.sbt
@@ -16,13 +16,15 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   }
 }
 
-
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
+  scalaVersion := "2.12.13",
+  crossScalaVersions := Seq("2.13.4", "2.12.13", "2.11.12")
+)
+
+lazy val firrtlSettings = Seq(
   name := "firrtl",
   version := "1.5-SNAPSHOT",
-  scalaVersion := "2.12.13",
-  crossScalaVersions := Seq("2.13.4", "2.12.13", "2.11.12"),
   addCompilerPlugin(scalafixSemanticdb),
   scalacOptions := Seq(
     "-deprecation",
@@ -170,6 +172,7 @@ lazy val firrtl = (project in file("."))
     Test / testForkedParallel := true
   )
   .settings(commonSettings)
+  .settings(firrtlSettings)
   .settings(protobufSettings)
   .settings(antlrSettings)
   .settings(assemblySettings)
@@ -187,6 +190,7 @@ lazy val firrtl = (project in file("."))
 
 lazy val benchmark = (project in file("benchmark"))
   .dependsOn(firrtl)
+  .settings(commonSettings)
   .settings(
     assemblyJarName in assembly := "firrtl-benchmark.jar",
     test in assembly := {},
@@ -196,6 +200,7 @@ lazy val benchmark = (project in file("benchmark"))
 val JQF_VERSION = "1.5"
 
 lazy val jqf = (project in file("jqf"))
+  .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
       "edu.berkeley.cs.jqf" % "jqf-fuzz" % JQF_VERSION,
@@ -221,6 +226,7 @@ lazy val testClassAndMethodParser = {
 
 lazy val fuzzer = (project in file("fuzzer"))
   .dependsOn(firrtl)
+  .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
       "com.pholser" % "junit-quickcheck-core" % "0.8",

--- a/src/main/scala/firrtl/FileUtils.scala
+++ b/src/main/scala/firrtl/FileUtils.scala
@@ -71,7 +71,7 @@ object FileUtils {
     val ioToDevNull = BasicIO(withIn = false, ProcessLogger(line => sb.append(line)))
 
     try {
-      cmd.run(ioToDevNull).exitValue == 0
+      cmd.run(ioToDevNull).exitValue() == 0
     } catch {
       case _: Throwable => false
     }

--- a/src/main/scala/firrtl/LexerHelper.scala
+++ b/src/main/scala/firrtl/LexerHelper.scala
@@ -98,7 +98,7 @@ abstract class LexerHelper {
       if (tokenBuffer.isEmpty)
         pullToken()
       else
-        tokenBuffer.dequeue
+        tokenBuffer.dequeue()
 
     if (reachedEof)
       t
@@ -157,6 +157,6 @@ abstract class LexerHelper {
     doPop()
 
     indentations.push(targetIndent)
-    tokenBuffer.dequeue
+    tokenBuffer.dequeue()
   }
 }

--- a/src/main/scala/firrtl/LoweringCompilers.scala
+++ b/src/main/scala/firrtl/LoweringCompilers.scala
@@ -123,7 +123,7 @@ class NoneCompiler extends Compiler {
 )
 class HighFirrtlCompiler extends Compiler {
   val emitter = new HighFirrtlEmitter
-  def transforms: Seq[Transform] = Forms.HighForm.map(_.getObject)
+  def transforms: Seq[Transform] = Forms.HighForm.map(_.getObject())
 }
 
 /** Emits middle Firrtl input circuit */
@@ -133,7 +133,7 @@ class HighFirrtlCompiler extends Compiler {
 )
 class MiddleFirrtlCompiler extends Compiler {
   val emitter = new MiddleFirrtlEmitter
-  def transforms: Seq[Transform] = Forms.MidForm.map(_.getObject)
+  def transforms: Seq[Transform] = Forms.MidForm.map(_.getObject())
 }
 
 /** Emits lowered input circuit */
@@ -143,7 +143,7 @@ class MiddleFirrtlCompiler extends Compiler {
 )
 class LowFirrtlCompiler extends Compiler {
   val emitter = new LowFirrtlEmitter
-  def transforms: Seq[Transform] = Forms.LowForm.map(_.getObject)
+  def transforms: Seq[Transform] = Forms.LowForm.map(_.getObject())
 }
 
 /** Emits Verilog */
@@ -153,7 +153,7 @@ class LowFirrtlCompiler extends Compiler {
 )
 class VerilogCompiler extends Compiler {
   val emitter = new VerilogEmitter
-  def transforms: Seq[Transform] = Forms.LowFormOptimized.map(_.getObject)
+  def transforms: Seq[Transform] = Forms.LowFormOptimized.map(_.getObject())
 }
 
 /** Emits Verilog without optimizations */
@@ -163,7 +163,7 @@ class VerilogCompiler extends Compiler {
 )
 class MinimumVerilogCompiler extends Compiler {
   val emitter = new MinimumVerilogEmitter
-  def transforms: Seq[Transform] = Forms.LowFormMinimumOptimized.map(_.getObject)
+  def transforms: Seq[Transform] = Forms.LowFormMinimumOptimized.map(_.getObject())
 }
 
 /** Currently just an alias for the [[VerilogCompiler]] */

--- a/src/main/scala/firrtl/analyses/ConnectionGraph.scala
+++ b/src/main/scala/firrtl/analyses/ConnectionGraph.scala
@@ -147,7 +147,7 @@ class ConnectionGraph protected (val circuit: Circuit, val digraph: DiGraph[Refe
     val bfsQueue = new mutable.PriorityQueue[ReferenceTarget]()(ordering)
     bfsQueue.enqueue(root)
     while (bfsQueue.nonEmpty) {
-      val u = bfsQueue.dequeue
+      val u = bfsQueue.dequeue()
       for (v <- getEdges(u)) {
         if (!prev.contains(v) && !blacklist.contains(v)) {
           prev(v) = u

--- a/src/main/scala/firrtl/analyses/InstanceGraph.scala
+++ b/src/main/scala/firrtl/analyses/InstanceGraph.scala
@@ -45,7 +45,7 @@ class InstanceGraph(c: Circuit) {
     val topInstance = DefInstance(subTop, subTop)
     instanceQueue.enqueue(topInstance)
     while (instanceQueue.nonEmpty) {
-      val current = instanceQueue.dequeue
+      val current = instanceQueue.dequeue()
       instanceGraph.addVertex(current)
       for (child <- childInstances(current.module)) {
         if (!instanceGraph.contains(child)) {

--- a/src/main/scala/firrtl/analyses/InstanceKeyGraph.scala
+++ b/src/main/scala/firrtl/analyses/InstanceKeyGraph.scala
@@ -158,7 +158,7 @@ object InstanceKeyGraph {
       val instanceQueue = new mutable.Queue[InstanceKey]
       instanceQueue.enqueue(topInstance)
       while (instanceQueue.nonEmpty) {
-        val current = instanceQueue.dequeue
+        val current = instanceQueue.dequeue()
         instanceGraph.addVertex(current)
         for (child <- childInstanceMap(current.module)) {
           if (!instanceGraph.contains(child)) {

--- a/src/main/scala/firrtl/graph/DiGraph.scala
+++ b/src/main/scala/firrtl/graph/DiGraph.scala
@@ -153,7 +153,7 @@ class DiGraph[T](private[graph] val edges: LinkedHashMap[T, LinkedHashSet[T]]) {
     val queue = new mutable.Queue[T]
     queue.enqueue(root)
     while (queue.nonEmpty) {
-      val u = queue.dequeue
+      val u = queue.dequeue()
       for (v <- getEdges(u)) {
         if (!prev.contains(v) && !blacklist.contains(v)) {
           prev(v) = u
@@ -257,7 +257,7 @@ class DiGraph[T](private[graph] val edges: LinkedHashMap[T, LinkedHashSet[T]]) {
         }
         frame.childCall = None
         while (frame.edgeIter.hasNext && frame.childCall.isEmpty) {
-          val w = frame.edgeIter.next
+          val w = frame.edgeIter.next()
           if (!indices.contains(w)) {
             frame.childCall = Some(w)
             callStack.push(new StrongConnectFrame(w, getEdges(w).iterator))
@@ -269,13 +269,13 @@ class DiGraph[T](private[graph] val edges: LinkedHashMap[T, LinkedHashSet[T]]) {
           if (lowlinks(v) == indices(v)) {
             val scc = new mutable.ArrayBuffer[T]
             do {
-              val w = stack.pop
+              val w = stack.pop()
               onstack -= w
               scc += w
             } while (scc.last != v);
             sccs.append(scc.toSeq)
           }
-          callStack.pop
+          callStack.pop()
         }
       }
     }
@@ -305,7 +305,7 @@ class DiGraph[T](private[graph] val edges: LinkedHashMap[T, LinkedHashSet[T]]) {
     queue += start
     queue ++= linearize.filter(reachable.contains(_))
     while (!queue.isEmpty) {
-      val current = queue.dequeue
+      val current = queue.dequeue()
       for (v <- getEdges(current)) {
         for (p <- paths(current)) {
           addBinding(v, p :+ v)

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -99,7 +99,7 @@ object Serializer {
     case Block(stmts) =>
       val it = stmts.iterator
       while (it.hasNext) {
-        s(it.next)
+        s(it.next())
         if (it.hasNext) newLineAndIndent()
       }
     case Stop(info, ret, clk, en) =>

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -91,7 +91,7 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     }
 
     while (queue.nonEmpty) {
-      val u: Dependency[B] = queue.dequeue
+      val u: Dependency[B] = queue.dequeue()
       for (v <- extractor(dependencyToObject(u))) {
         if (!blacklist.contains(v) && !edges.contains(v)) {
           queue.enqueue(v)
@@ -193,13 +193,13 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
       )
   }
 
-  /** An ordering of [[firrtl.options.TransformLike TransformLike]]s that causes the requested [[DependencyManager.targets
-    * targets]] to be executed starting from the [[DependencyManager.currentState currentState]]. This ordering respects
+  /** An ordering of [[firrtl.options.TransformLike TransformLike]]s that causes the requested [[firrtl.options.DependencyManager.targets
+    * targets]] to be executed starting from the [[firrtl.options.DependencyManager.currentState currentState]]. This ordering respects
     * prerequisites, optionalPrerequisites, optionalPrerequisiteOf, and invalidates of all constituent
     * [[firrtl.options.TransformLike TransformLike]]s. This uses an algorithm that attempts to reduce the number of
-    * re-lowerings due to invalidations. Re-lowerings are implemented as new [[DependencyManager]]s.
-    * @throws DependencyManagerException if a cycle exists in either the [[DependencyManager.dependencyGraph
-    * dependencyGraph]] or the [[DependencyManager.invalidateGraph invalidateGraph]].
+    * re-lowerings due to invalidations. Re-lowerings are implemented as new [[firrtl.options.DependencyManager]]s.
+    * @throws firrtl.options.DependencyManagerException if a cycle exists in either the [[firrtl.options.DependencyManager.dependencyGraph
+    * dependencyGraph]] or the [[firrtl.options.DependencyManager.invalidateGraph invalidateGraph]].
     */
   lazy val transformOrder: Seq[B] = {
 
@@ -244,8 +244,8 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
     l ++ postprocessing
   }
 
-  /** A version of the [[DependencyManager.transformOrder transformOrder]] that flattens the transforms of any internal
-    * [[DependencyManager]]s.
+  /** A version of the [[firrtl.options.DependencyManager.transformOrder transformOrder]] that flattens the transforms of any internal
+    * [[firrtl.options.DependencyManager DependencyManager]]s.
     */
   lazy val flattenedTransformOrder: Seq[B] = transformOrder.flatMap {
     case p: DependencyManager[A, B] => p.flattenedTransformOrder

--- a/src/main/scala/firrtl/options/Stage.scala
+++ b/src/main/scala/firrtl/options/Stage.scala
@@ -28,7 +28,7 @@ abstract class Stage extends Phase {
   /** Execute this stage on some input annotations. Annotations will be read from any input annotation files.
     * @param annotations input annotations
     * @return output annotations
-    * @throws OptionsException if command line or annotation validation fails
+    * @throws firrtl.options.OptionsException if command line or annotation validation fails
     */
   final def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val annotationsx =
@@ -52,7 +52,7 @@ abstract class Stage extends Phase {
     * @param args command line arguments
     * @param initialAnnotations annotation
     * @return output annotations
-    * @throws OptionsException if command line or annotation validation fails
+    * @throws firrtl.options.OptionsException if command line or annotation validation fails
     */
   final def execute(args: Array[String], annotations: AnnotationSeq): AnnotationSeq =
     transform(shell.parse(args, annotations))

--- a/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringUtils.scala
@@ -150,11 +150,11 @@ object WiringUtils {
       * sources/sinks not under sinks/sources.
       */
     if (queue.size == 1) {
-      val u = queue.dequeue
+      val u = queue.dequeue()
       sinkInsts.foreach { v => owners(v) = Vector(u) }
     } else {
       while (queue.nonEmpty) {
-        val u = queue.dequeue
+        val u = queue.dequeue()
         visited(u) = true
 
         val edges = (i.graph.getEdges(u.last).map(u :+ _).toVector :+ u.dropRight(1))
@@ -222,11 +222,11 @@ object WiringUtils {
       * sources/sinks not under sinks/sources.
       */
     if (queue.size == 1) {
-      val u = queue.dequeue
+      val u = queue.dequeue()
       sinkInsts.foreach { v => owners(v) = Vector(u) }
     } else {
       while (queue.nonEmpty) {
-        val u = queue.dequeue
+        val u = queue.dequeue()
         visited(u) = true
 
         val edges = i.graph.getEdges(u.last).map(u :+ _).toVector :+ u.dropRight(1)

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -180,7 +180,7 @@ case class RunFirrtlTransformAnnotation(transform: Transform) extends NoTargetAn
 object RunFirrtlTransformAnnotation extends HasShellOptions {
 
   def apply(transform: TransformDependency): RunFirrtlTransformAnnotation =
-    RunFirrtlTransformAnnotation(transform.getObject)
+    RunFirrtlTransformAnnotation(transform.getObject())
 
   private[firrtl] def stringToEmitter(a: String): RunFirrtlTransformAnnotation = {
     val emitter = a match {

--- a/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
+++ b/src/main/scala/firrtl/stage/phases/DriverCompatibility.scala
@@ -58,8 +58,8 @@ object DriverCompatibility {
     def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
       .opt[Unit]("top-name")
       .abbr("tn")
-      .hidden
-      .unbounded
+      .hidden()
+      .unbounded()
       .action((_, _) => throw new OptionsException(optionRemoved("--top-name/-tn")))
   }
 
@@ -71,8 +71,8 @@ object DriverCompatibility {
     def addOptions(p: OptionParser[AnnotationSeq]): Unit = p
       .opt[Unit]("split-modules")
       .abbr("fsm")
-      .hidden
-      .unbounded
+      .hidden()
+      .unbounded()
       .action((_, _) => throw new OptionsException(optionRemoved("--split-modules/-fsm")))
 
   }

--- a/src/main/scala/firrtl/transforms/ConstantPropagation.scala
+++ b/src/main/scala/firrtl/transforms/ConstantPropagation.scala
@@ -647,7 +647,8 @@ class ConstantPropagation extends Transform with DependencyAPIMigration {
         case WRef(rname, _, kind, _) if betterName(lname, rname) && !swapMap.contains(rname) && kind != PortKind =>
           assert(!swapMap.contains(lname)) // <- Shouldn't be possible because lname is either a
           // node declaration or the single connection to a wire or register
-          swapMap += (lname -> rname, rname -> lname)
+          swapMap += lname -> rname
+          swapMap += rname -> lname
         case _ =>
       }
       nodeMap(lname) = InfoExpr.wrap(info, value)

--- a/src/main/scala/firrtl/transforms/ManipulateNames.scala
+++ b/src/main/scala/firrtl/transforms/ManipulateNames.scala
@@ -464,7 +464,7 @@ abstract class ManipulateNames[A <: ManipulateNames[_]: ClassTag] extends Transf
 
     val block = state.annotations.collect {
       case ManipulateNamesBlocklistAnnotation(targetSeq, t) =>
-        t.getObject match {
+        t.getObject() match {
           case _: A => targetSeq
           case _ => Nil
         }
@@ -473,7 +473,7 @@ abstract class ManipulateNames[A <: ManipulateNames[_]: ClassTag] extends Transf
     val allow = {
       val allowx = state.annotations.collect {
         case ManipulateNamesAllowlistAnnotation(targetSeq, t) =>
-          t.getObject match {
+          t.getObject() match {
             case _: A => targetSeq
             case _ => Nil
           }
@@ -491,13 +491,13 @@ abstract class ManipulateNames[A <: ManipulateNames[_]: ClassTag] extends Transf
     val annotationsx = state.annotations.flatMap {
       /* Consume blocklist annotations */
       case foo @ ManipulateNamesBlocklistAnnotation(_, t) =>
-        t.getObject match {
+        t.getObject() match {
           case _: A => None
           case _ => Some(foo)
         }
       /* Convert allowlist annotations to result annotations */
       case foo @ ManipulateNamesAllowlistAnnotation(a, t) =>
-        t.getObject match {
+        t.getObject() match {
           case _: A =>
             (a, a.map(_.map(renames(_)).flatten)) match {
               case (a, b) => Some(ManipulateNamesAllowlistResultAnnotation(b, t, a))

--- a/src/main/scala/logger/LoggerOptions.scala
+++ b/src/main/scala/logger/LoggerOptions.scala
@@ -32,7 +32,7 @@ class LoggerOptions private[logger] (
   }
 
   /** Return the name of the log file, defaults to `a.log` if unspecified */
-  def getLogFileName(): Option[String] = if (!logToFile) None else logFileName.orElse(Some("a.log"))
+  def getLogFileName(): Option[String] = if (!logToFile()) None else logFileName.orElse(Some("a.log"))
 
   /** True if a [[Logger]] should be writing to a file */
   @deprecated("logToFile was removed, use logFileName.nonEmpty", "FIRRTL 1.2")

--- a/src/main/scala/tutorial/lesson1-circuit-traversal/AnalyzeCircuit.scala
+++ b/src/main/scala/tutorial/lesson1-circuit-traversal/AnalyzeCircuit.scala
@@ -142,7 +142,7 @@ class AnalyzeCircuit extends Transform {
     visited match {
       // If e is a [[firrtl.ir.Mux Mux]], increment our ledger and return e.
       case Mux(cond, tval, fval, tpe) =>
-        ledger.foundMux
+        ledger.foundMux()
         e
       // If e is not a [[firrtl.ir.Mux Mux]], return e.
       case notmux => notmux


### PR DESCRIPTION
Fix bug in CI introduced in https://github.com/chipsalliance/firrtl/pull/2053. `1.4.x` milestone because #2053 was backported to 1.4.x.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

This change shouldn't be visible to users, purely CI fix.

#### Type of Improvement

   - bug fix


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
