### PR TITLE
Stop padding multiply and divide ops

### DIFF
--- a/src/main/scala/firrtl/passes/PadWidths.scala
+++ b/src/main/scala/firrtl/passes/PadWidths.scala
@@ -58,7 +58,7 @@ object PadWidths extends Pass {
     case ex: ValidIf => ex.copy(value = fixup(width(ex.tpe))(ex.value))
     case ex: DoPrim =>
       ex.op match {
-        case Lt | Leq | Gt | Geq | Eq | Neq | Not | And | Or | Xor | Add | Sub | Mul | Div | Rem | Shr =>
+        case Lt | Leq | Gt | Geq | Eq | Neq | Not | And | Or | Xor | Add | Sub | Rem | Shr =>
           // sensitive ops
           ex.map(fixup((ex.args.map(width).foldLeft(0))(math.max)))
         case Dshl =>

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -754,6 +754,30 @@ class VerilogEmitterSpec extends FirrtlFlatSpec {
     result should containLine("assign z = _GEN_0[1:0];")
   }
 
+  it should "not pad multiplication" in {
+    val compiler = new VerilogCompiler
+    val result = compileBody(
+      """input x : UInt<2>
+        |input y: UInt<4>
+        |output z : UInt<6>
+        |z <= mul(x, y)
+        |""".stripMargin
+    )
+    result should containLine("assign z = x * y;")
+  }
+
+  it should "not pad division" in {
+    val compiler = new VerilogCompiler
+    val result = compileBody(
+      """input x : UInt<4>
+        |input y: UInt<2>
+        |output z : UInt<4>
+        |z <= div(x, y)
+        |""".stripMargin
+    )
+    result should containLine("assign z = x / y;")
+  }
+
   it should "correctly emit addition with a negative literal with width > 32" in {
     val result = compileBody(
       """input x : SInt<34>

--- a/src/test/scala/firrtlTests/VerilogEquivalenceSpec.scala
+++ b/src/test/scala/firrtlTests/VerilogEquivalenceSpec.scala
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests
+
+import firrtl.testutils._
+
+class VerilogEquivalenceSpec extends FirrtlFlatSpec {
+  "mul followed by cat" should "be correct" in {
+    val header = s"""
+      |circuit Multiply :
+      |  module Multiply :
+      |    input x : UInt<4>
+      |    input y : UInt<2>
+      |    input z : UInt<2>
+      |    output out : UInt<8>
+      |""".stripMargin
+    val input1 = header + """
+      |    out <= cat(z, mul(x, y))""".stripMargin
+    val input2 = header + """
+      |    node n = mul(x, y)
+      |    node m = cat(z, n)
+      |    out <= m""".stripMargin
+    val expected = s"""
+      |module MultiplyRef(
+      |  input [3:0] x,
+      |  input [1:0] y,
+      |  input [1:0] z,
+      |  output [7:0] out
+      |);
+      |  wire [5:0] w = x * y;
+      |  assign out = {z, w};
+      |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input1, expected)
+    firrtlEquivalenceWithVerilog(input2, expected)
+  }
+
+  "div followed by cat" should "be correct" in {
+    val header = s"""
+      |circuit Divide :
+      |  module Divide :
+      |    input x : UInt<4>
+      |    input y : UInt<2>
+      |    input z : UInt<2>
+      |    output out : UInt<6>
+      |""".stripMargin
+    val input1 = header + """
+      |    out <= cat(z, div(x, y))""".stripMargin
+    val input2 = header + """
+      |    node n = div(x, y)
+      |    node m = cat(z, n)
+      |    out <= m""".stripMargin
+    val expected = s"""
+      |module DivideRef(
+      |  input [3:0] x,
+      |  input [1:0] y,
+      |  input [1:0] z,
+      |  output [5:0] out
+      |);
+      |  wire [3:0] w = x / y;
+      |  assign out = {z, w};
+      |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input1, expected)
+    firrtlEquivalenceWithVerilog(input2, expected)
+  }
+
+  "signed mul followed by cat" should "be correct" in {
+    val header = s"""
+      |circuit SignedMultiply :
+      |  module SignedMultiply :
+      |    input x : SInt<4>
+      |    input y : SInt<2>
+      |    input z : SInt<2>
+      |    output out : UInt<8>
+      |""".stripMargin
+    val input1 = header + """
+      |    out <= cat(z, mul(x, y))""".stripMargin
+    val input2 = header + """
+      |    node n = mul(x, y)
+      |    node m = cat(z, n)
+      |    out <= m""".stripMargin
+    val expected = s"""
+      |module SignedMultiplyRef(
+      |  input signed [3:0] x,
+      |  input signed [1:0] y,
+      |  input signed [1:0] z,
+      |  output [7:0] out
+      |);
+      |  wire [5:0] w = x * y;
+      |  assign out = {z, w};
+      |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input1, expected)
+    firrtlEquivalenceWithVerilog(input2, expected)
+  }
+
+  "signed div followed by cat" should "be correct" in {
+    val header = s"""
+      |circuit SignedDivide :
+      |  module SignedDivide :
+      |    input x : SInt<4>
+      |    input y : SInt<2>
+      |    input z : SInt<2>
+      |    output out : UInt<7>
+      |""".stripMargin
+    val input1 = header + """
+      |    out <= cat(z, div(x, y))""".stripMargin
+    val input2 = header + """
+      |    node n = div(x, y)
+      |    node m = cat(z, n)
+      |    out <= m""".stripMargin
+    val expected = s"""
+      |module SignedDivideRef(
+      |  input signed [3:0] x,
+      |  input signed [1:0] y,
+      |  input signed [1:0] z,
+      |  output [6:0] out
+      |);
+      |  wire [4:0] w = x / y;
+      |  assign out = {z, w};
+      |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input1, expected)
+    firrtlEquivalenceWithVerilog(input2, expected)
+  }
+}


### PR DESCRIPTION
Fixes #2052
Also fixes some Verilog lint issues

A lot of work for a change that is literally deleting what 12 characters?

I'm a bit paranoid about this change so I wrote some formal checks, but notably I'm not checking every width, and I'm relying on the reference Verilog being correct. Any thoughts?

As this is a correctness issue, at least the fix should go all the way back.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix  
  - backend code generation

#### API Impact

No change

#### Backend Code Generation Impact

Slightly cleaner emission for multiplication and division

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix lint errors on multiply and divide operations
Fix incorrect Verilog on multiply or divide followed by concatenation

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
