### PR TITLE
Remove Scala 2.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala: [2.13.4, 2.12.13, 2.11.12]
+        scala: [2.13.4, 2.12.13]
     container:
       image: ucbbar/chisel3-tools
       options: --user github --entrypoint /bin/bash

--- a/build.sc
+++ b/build.sc
@@ -7,7 +7,7 @@ import mill.modules.Util
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
 import mill.contrib.buildinfo.BuildInfo
 
-object firrtl extends mill.Cross[firrtlCrossModule]("2.11.12", "2.12.12", "2.13.2")
+object firrtl extends mill.Cross[firrtlCrossModule]("2.12.12", "2.13.2")
 
 class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule with PublishModule with BuildInfo {
   override def millSourcePath = super.millSourcePath / os.up
@@ -21,10 +21,7 @@ class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule wi
     Some("firrtl.stage.FirrtlMain")
   }
 
-  private def javacCrossOptions = majorVersion match {
-    case i if i < 12 => Seq("-source", "1.7", "-target", "1.7")
-    case _ => Seq("-source", "1.8", "-target", "1.8")
-  }
+  private def javacCrossOptions = Seq("-source", "1.8", "-target", "1.8")
 
   override def scalacOptions = T {
     super.scalacOptions() ++ Seq(
@@ -56,16 +53,11 @@ class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule wi
   }
 
   object test extends Tests {
-    private def ivyCrossDeps = majorVersion match {
-      case i if i < 12 => Agg(ivy"junit:junit:4.13.1")
-      case _ => Agg()
-    }
-
     override def ivyDeps = T {
       Agg(
         ivy"org.scalatest::scalatest:3.2.0",
         ivy"org.scalatestplus::scalacheck-1-14:3.1.3.0"
-      ) ++ ivyCrossDeps
+      )
     }
 
     def testFrameworks = T {

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -255,13 +255,18 @@ case class FirrtlCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation 
   *
   *  - set with `--warn:no-scala-version-deprecation`
   */
+@deprecated("Support for Scala 2.11 has been dropped, this object no longer does anything", "FIRRTL 1.5")
 case object WarnNoScalaVersionDeprecation extends NoTargetAnnotation with FirrtlOption with HasShellOptions {
   def longOption: String = "warn:no-scala-version-deprecation"
   val options = Seq(
     new ShellOption[Unit](
       longOption = longOption,
-      toAnnotationSeq = { _ => Seq(this) },
-      helpText = "Suppress Scala 2.11 deprecation warning (ignored in Scala 2.12+)"
+      toAnnotationSeq = { _ =>
+        val msg = s"'$longOption' no longer does anything and will be removed in FIRRTL 1.6"
+        firrtl.options.StageUtils.dramaticWarning(msg)
+        Seq(this)
+      },
+      helpText = "(deprecated, this option does nothing)"
     )
   )
 }

--- a/src/main/scala/firrtl/stage/transforms/CheckScalaVersion.scala
+++ b/src/main/scala/firrtl/stage/transforms/CheckScalaVersion.scala
@@ -6,13 +6,9 @@ import firrtl.{BuildInfo, CircuitState, DependencyAPIMigration, Transform}
 import firrtl.stage.WarnNoScalaVersionDeprecation
 import firrtl.options.StageUtils.dramaticWarning
 
+@deprecated("Support for 2.11 has been dropped, this logic no longer does anything", "FIRRTL 1.5")
 object CheckScalaVersion {
   def migrationDocumentLink: String = "https://www.chisel-lang.org/chisel3/upgrading-from-scala-2-11.html"
-
-  private def getScalaMajorVersion: Int = {
-    val "2" :: major :: _ :: Nil = BuildInfo.scalaVersion.split("\\.").toList
-    major.toInt
-  }
 
   final def deprecationMessage(version: String, option: String) =
     s"""|FIRRTL support for Scala $version is deprecated, please upgrade to Scala 2.12.
@@ -21,17 +17,10 @@ object CheckScalaVersion {
 
 }
 
+@deprecated("Support for 2.11 has been dropped, this transform no longer does anything", "FIRRTL 1.5")
 class CheckScalaVersion extends Transform with DependencyAPIMigration {
-  import CheckScalaVersion._
 
   override def invalidates(a: Transform) = false
 
-  def execute(state: CircuitState): CircuitState = {
-    def suppress = state.annotations.contains(WarnNoScalaVersionDeprecation)
-    if (getScalaMajorVersion == 11 && !suppress) {
-      val option = s"--${WarnNoScalaVersionDeprecation.longOption}"
-      dramaticWarning(deprecationMessage("2.11", option))
-    }
-    state
-  }
+  def execute(state: CircuitState): CircuitState = state
 }

--- a/src/test/scala/firrtl/backends/experimental/smt/end2end/SMTCompilationTest.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/end2end/SMTCompilationTest.scala
@@ -15,8 +15,7 @@ import scala.sys.process.{Process, ProcessLogger}
 class SMTCompilationTest extends AnyFlatSpec with LazyLogging {
   it should "generate valid SMTLib for AddNot" taggedAs (RequiresZ3) in { compileAndParse("AddNot") }
   it should "generate valid SMTLib for FPU" taggedAs (RequiresZ3) in { compileAndParse("FPU") }
-  // we get a stack overflow in Scala 2.11 because of a deeply nested and(...) expression in the sequencer
-  it should "generate valid SMTLib for HwachaSequencer" taggedAs (RequiresZ3) ignore {
+  it should "generate valid SMTLib for HwachaSequencer" taggedAs (RequiresZ3) in {
     compileAndParse("HwachaSequencer")
   }
   it should "generate valid SMTLib for ICache" taggedAs (RequiresZ3) in { compileAndParse("ICache") }

--- a/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
@@ -164,16 +164,6 @@ class FirrtlMainSpec
          |""".stripMargin
   }
 
-  /** This returns a string containing the default standard out string based on the Scala version. E.g., if there are
-    * version-specific deprecation warnings, those are available here and can be passed to tests that should have them.
-    */
-  val defaultStdOut: Option[String] = BuildInfo.scalaVersion.split("\\.").toList match {
-    case "2" :: v :: _ :: Nil if v.toInt <= 11 =>
-      Some(CheckScalaVersion.deprecationMessage("2.11", s"--${WarnNoScalaVersionDeprecation.longOption}"))
-    case x =>
-      None
-  }
-
   info("As a FIRRTL command line user")
   info("I want to compile some FIRRTL")
   Feature("FirrtlMain command line interface") {
@@ -205,58 +195,48 @@ class FirrtlMainSpec
     Seq(
       /* Test all standard emitters with and without annotation file outputs */
       FirrtlMainTest(args = Array("-X", "none", "-E", "chirrtl"), files = Seq("Top.fir")),
-      FirrtlMainTest(args = Array("-X", "high", "-E", "high"), stdout = defaultStdOut, files = Seq("Top.hi.fir")),
+      FirrtlMainTest(args = Array("-X", "high", "-E", "high"), files = Seq("Top.hi.fir")),
       FirrtlMainTest(
         args = Array("-X", "middle", "-E", "middle", "-foaf", "Top"),
-        stdout = defaultStdOut,
         files = Seq("Top.mid.fir", "Top.anno.json")
       ),
       FirrtlMainTest(
         args = Array("-X", "low", "-E", "low", "-foaf", "annotations.anno.json"),
-        stdout = defaultStdOut,
         files = Seq("Top.lo.fir", "annotations.anno.json")
       ),
       FirrtlMainTest(
         args = Array("-X", "verilog", "-E", "verilog", "-foaf", "foo.anno"),
-        stdout = defaultStdOut,
         files = Seq("Top.v", "foo.anno.anno.json")
       ),
       FirrtlMainTest(
         args = Array("-X", "sverilog", "-E", "sverilog", "-foaf", "foo.json"),
-        stdout = defaultStdOut,
         files = Seq("Top.sv", "foo.json.anno.json")
       ),
       /* Test all one file per module emitters */
       FirrtlMainTest(args = Array("-X", "none", "-e", "chirrtl"), files = Seq("Top.fir", "Child.fir")),
       FirrtlMainTest(
         args = Array("-X", "high", "-e", "high"),
-        stdout = defaultStdOut,
         files = Seq("Top.hi.fir", "Child.hi.fir")
       ),
       FirrtlMainTest(
         args = Array("-X", "middle", "-e", "middle"),
-        stdout = defaultStdOut,
         files = Seq("Top.mid.fir", "Child.mid.fir")
       ),
       FirrtlMainTest(
         args = Array("-X", "low", "-e", "low"),
-        stdout = defaultStdOut,
         files = Seq("Top.lo.fir", "Child.lo.fir")
       ),
       FirrtlMainTest(
         args = Array("-X", "verilog", "-e", "verilog"),
-        stdout = defaultStdOut,
         files = Seq("Top.v", "Child.v")
       ),
       FirrtlMainTest(
         args = Array("-X", "sverilog", "-e", "sverilog"),
-        stdout = defaultStdOut,
         files = Seq("Top.sv", "Child.sv")
       ),
       /* Test mixing of -E with -e */
       FirrtlMainTest(
         args = Array("-X", "middle", "-E", "high", "-e", "middle"),
-        stdout = defaultStdOut,
         files = Seq("Top.hi.fir", "Top.mid.fir", "Child.mid.fir"),
         notFiles = Seq("Child.hi.fir")
       ),
@@ -264,33 +244,27 @@ class FirrtlMainSpec
       FirrtlMainTest(args = Array("-X", "none", "-E", "chirrtl", "-o", "foo"), files = Seq("foo.fir")),
       FirrtlMainTest(
         args = Array("-X", "high", "-E", "high", "-o", "foo"),
-        stdout = defaultStdOut,
         files = Seq("foo.hi.fir")
       ),
       FirrtlMainTest(
         args = Array("-X", "middle", "-E", "middle", "-o", "foo.middle"),
-        stdout = defaultStdOut,
         files = Seq("foo.middle.mid.fir")
       ),
       FirrtlMainTest(
         args = Array("-X", "low", "-E", "low", "-o", "foo.lo.fir"),
-        stdout = defaultStdOut,
         files = Seq("foo.lo.fir")
       ),
       FirrtlMainTest(
         args = Array("-X", "verilog", "-E", "verilog", "-o", "foo.sv"),
-        stdout = defaultStdOut,
         files = Seq("foo.sv.v")
       ),
       FirrtlMainTest(
         args = Array("-X", "sverilog", "-E", "sverilog", "-o", "Foo"),
-        stdout = defaultStdOut,
         files = Seq("Foo.sv")
       ),
       /* Test that an output is generated if no emitter is specified */
       FirrtlMainTest(
         args = Array("-X", "verilog", "-o", "Foo"),
-        stdout = defaultStdOut,
         files = Seq("Foo.v")
       )
     )


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - code refactoring     
  - code cleanup  


#### API Impact

It removes support for Scala 2.11

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Removed support for Scala 2.11. Please see https://www.chisel-lang.org/chisel3/upgrading-from-scala-2-11.html and use Chisel 3.4 and FIRRTL 1.4 to migrate code to Scala 2.12.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
