### PR TITLE
IR: turn some IR nodes into data classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val firrtlSettings = Seq(
     "net.jcazevedo" %% "moultingyaml" % "0.4.2",
     "org.json4s" %% "json4s-native" % "3.6.9",
     "org.apache.commons" % "commons-text" % "1.8",
-    "io.github.alexarchambault" %% "data-class" % "0.2.1",
+    "io.github.alexarchambault" %% "data-class" % "0.2.5",
   ),
   // macros for the data-class library
   libraryDependencies ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,11 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("2.13.4", "2.12.13", "2.11.12")
 )
 
+lazy val isAtLeastScala213 = Def.setting {
+  import Ordering.Implicits._
+  CrossVersion.partialVersion(scalaVersion.value).exists(_ >= (2, 13))
+}
+
 lazy val firrtlSettings = Seq(
   name := "firrtl",
   version := "1.5-SNAPSHOT",
@@ -42,8 +47,18 @@ lazy val firrtlSettings = Seq(
     "com.github.scopt" %% "scopt" % "3.7.1",
     "net.jcazevedo" %% "moultingyaml" % "0.4.2",
     "org.json4s" %% "json4s-native" % "3.6.9",
-    "org.apache.commons" % "commons-text" % "1.8"
+    "org.apache.commons" % "commons-text" % "1.8",
+    "io.github.alexarchambault" %% "data-class" % "0.2.1",
   ),
+  // macros for the data-class library
+  libraryDependencies ++= {
+    if (isAtLeastScala213.value) Nil
+    else Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+  },
+  scalacOptions ++= {
+    if (isAtLeastScala213.value) Seq("-Ymacro-annotations")
+    else Nil
+  },
   // starting with scala 2.13 the parallel collections are separate from the standard library
   libraryDependencies ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -636,7 +636,13 @@ object Stop {
   def foreachType(f:   Type => Unit):   Unit = ()
   def foreachString(f: String => Unit): Unit = ()
   def foreachInfo(f:   Info => Unit):   Unit = f(info)
-  def copy(info: Info = info, string: StringLit = string, args: Seq[Expression] = args, clk: Expression = clk, en: Expression = en): Print = {
+  def copy(
+    info:   Info = info,
+    string: StringLit = string,
+    args:   Seq[Expression] = args,
+    clk:    Expression = clk,
+    en:     Expression = en
+  ): Print = {
     Print(info, string, args, clk, en)
   }
 }
@@ -674,7 +680,14 @@ object Formal extends Enumeration {
   def foreachType(f:   Type => Unit):   Unit = ()
   def foreachString(f: String => Unit): Unit = ()
   def foreachInfo(f:   Info => Unit):   Unit = f(info)
-  def copy(op: Formal.Value = op, info: Info = info, clk:  Expression = clk, pred: Expression = pred, en: Expression = en, msg: StringLit = msg): Verification = {
+  def copy(
+    op:   Formal.Value = op,
+    info: Info = info,
+    clk:  Expression = clk,
+    pred: Expression = pred,
+    en:   Expression = en,
+    msg:  StringLit = msg
+  ): Verification = {
     Verification(op, info, clk, pred, en, msg)
   }
 }

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -613,7 +613,7 @@ case class Attach(info: Info, exprs: Seq[Expression]) extends Statement with Has
   }
 }
 object Stop {
-  def unapply(s: Stop): Option[(Info, Int, Expression, Expression)] = {
+  def unapply(s: Stop): Some[(Info, Int, Expression, Expression)] = {
     Some((s.info, s.ret, s.clk, s.en))
   }
 }
@@ -647,7 +647,7 @@ object Stop {
   }
 }
 object Print {
-  def unapply(s: Print): Option[(Info, StringLit, Seq[Expression], Expression, Expression)] = {
+  def unapply(s: Print): Some[(Info, StringLit, Seq[Expression], Expression, Expression)] = {
     Some((s.info, s.string, s.args, s.clk, s.en))
   }
 }
@@ -692,7 +692,7 @@ object Formal extends Enumeration {
   }
 }
 object Verification {
-  def unapply(s: Verification): Option[(Formal.Value, Info, Expression, Expression, Expression, StringLit)] = {
+  def unapply(s: Verification): Some[(Formal.Value, Info, Expression, Expression, Expression, StringLit)] = {
     Some((s.op, s.info, s.clk, s.pred, s.en, s.msg))
   }
 }

--- a/src/main/scala/firrtl/ir/IR.scala
+++ b/src/main/scala/firrtl/ir/IR.scala
@@ -4,6 +4,7 @@ package firrtl
 package ir
 
 import Utils.{dec2string, trim}
+import dataclass.data
 import firrtl.constraint.{Constraint, IsKnown, IsVar}
 import org.apache.commons.text.translate.{AggregateTranslator, JavaUnicodeEscaper, LookupTranslator}
 
@@ -593,7 +594,7 @@ case class Attach(info: Info, exprs: Seq[Expression]) extends Statement with Has
   def foreachString(f: String => Unit):           Unit = ()
   def foreachInfo(f:   Info => Unit):             Unit = f(info)
 }
-case class Stop(info: Info, ret: Int, clk: Expression, en: Expression)
+@data class Stop(info: Info, ret: Int, clk: Expression, en: Expression)
     extends Statement
     with HasInfo
     with UseSerializer {
@@ -607,8 +608,16 @@ case class Stop(info: Info, ret: Int, clk: Expression, en: Expression)
   def foreachType(f:   Type => Unit):   Unit = ()
   def foreachString(f: String => Unit): Unit = ()
   def foreachInfo(f:   Info => Unit):   Unit = f(info)
+  def copy(info: Info = info, ret: Int = ret, clk: Expression = clk, en: Expression = en): Stop = {
+    Stop(info, ret, clk, en)
+  }
 }
-case class Print(
+object Stop {
+  def unapply(s: Stop): Option[(Info, Int, Expression, Expression)] = {
+    Some((s.info, s.ret, s.clk, s.en))
+  }
+}
+@data class Print(
   info:   Info,
   string: StringLit,
   args:   Seq[Expression],
@@ -627,6 +636,14 @@ case class Print(
   def foreachType(f:   Type => Unit):   Unit = ()
   def foreachString(f: String => Unit): Unit = ()
   def foreachInfo(f:   Info => Unit):   Unit = f(info)
+  def copy(info: Info = info, string: StringLit = string, args: Seq[Expression] = args, clk: Expression = clk, en: Expression = en): Print = {
+    Print(info, string, args, clk, en)
+  }
+}
+object Print {
+  def unapply(s: Print): Option[(Info, StringLit, Seq[Expression], Expression, Expression)] = {
+    Some((s.info, s.string, s.args, s.clk, s.en))
+  }
 }
 
 // formal
@@ -636,7 +653,7 @@ object Formal extends Enumeration {
   val Cover = Value("cover")
 }
 
-case class Verification(
+@data class Verification(
   op:   Formal.Value,
   info: Info,
   clk:  Expression,
@@ -657,6 +674,14 @@ case class Verification(
   def foreachType(f:   Type => Unit):   Unit = ()
   def foreachString(f: String => Unit): Unit = ()
   def foreachInfo(f:   Info => Unit):   Unit = f(info)
+  def copy(op: Formal.Value = op, info: Info = info, clk:  Expression = clk, pred: Expression = pred, en: Expression = en, msg: StringLit = msg): Verification = {
+    Verification(op, info, clk, pred, en, msg)
+  }
+}
+object Verification {
+  def unapply(s: Verification): Option[(Formal.Value, Info, Expression, Expression, Expression, StringLit)] = {
+    Some((s.op, s.info, s.clk, s.pred, s.en, s.msg))
+  }
 }
 // end formal
 


### PR DESCRIPTION
As discussed with @jackkoenig , I am changing Stop, Print and Verification to be a data class.
This is done in preparation for a new `name` field in order to preserve backwards compatibility.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code refactoring

#### API Impact

- it should maintain the current API

#### Backend Code Generation Impact
- none

#### Desired Merge Strategy

- squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
