### PR TITLE
Emit space after 'if' for all Verilog conditional synchronous assignments

### DIFF
--- a/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
+++ b/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
@@ -756,7 +756,7 @@ class VerilogEmitter extends SeqTransform with Emitter {
       val lines = noResetAlwaysBlocks.getOrElseUpdate(clk, ArrayBuffer[Seq[Any]]())
       if (weq(en, one)) lines += Seq(e, " <= ", value, ";")
       else {
-        lines += Seq("if(", en, ") begin")
+        lines += Seq("if (", en, ") begin")
         lines += Seq(tab, e, " <= ", value, ";", info)
         lines += Seq("end")
       }


### PR DESCRIPTION
**Type of improvement:** Verilog readability
**API impact:** none
**Backend code-generation impact:** whitespace-only change
**Desired merge strategy:** squash
**Release notes:**
Whitespace is used more consistently in emitted Verilog conditional blocks.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
