### PR TITLE
RFC: Emit sync-read mems intact, with readwrite ports if applicable

### DIFF
--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -91,11 +91,11 @@ class InfoSpec extends FirrtlFlatSpec with FirrtlMatchers {
     result should containTree { case DefMemory(Info1, "m", _, _, _, _, _, _, _, _) => true }
     result should containLine(s"reg [7:0] m [0:31]; //$Info1")
     result should containLine(s"wire [7:0] m_r_data; //$Info1")
-    result should containLine(s"wire [4:0] m_r_addr; //$Info1")
-    result should containLine(s"wire [7:0] m_w_data; //$Info1")
-    result should containLine(s"wire [4:0] m_w_addr; //$Info1")
-    result should containLine(s"wire  m_w_mask; //$Info1")
-    result should containLine(s"wire  m_w_en; //$Info1")
+    result should containLine(s"wire [4:0] m_r_addr = addr; //$Info1")
+    result should containLine(s"wire [7:0] m_w_data = 8'h0; //$Info1")
+    result should containLine(s"wire [4:0] m_w_addr = addr; //$Info1")
+    result should containLine(s"wire  m_w_mask = 1'h0; //$Info1")
+    result should containLine(s"wire  m_w_en = 1'h0; //$Info1")
     result should containLine(s"assign m_r_data = m[m_r_addr]; //$Info1")
     result should containLine(s"m[m_w_addr] <= m_w_data; //$Info1")
   }


### PR DESCRIPTION
The default handling of sync-read memories by the FIRRTL compiler has been mentioned in several issues, including recently in chipsalliance/chisel3#1788. While `--repl-seq-mem` can be used along with Verilog memory-generation flows, the emission of native FIRRTL memories has been a point of surprise and an FPGA QoR hurdle for new Chisel/FIRRTL users.

I think arguments can be made either way about adding this feature, so I'd like to hear what anyone thinks about:
- Adding this as an emission option
- Emitting sync-read mems this way by default (note that this will not affect flows with `--repl-seq-mem`).

If there's strong sentiment either way, it's easy to tweak this for different disabled/address-out-of-range behavior.

**Type of improvement:** Verilog emission
**API impact:** No public API changes, but passes downstream of VerilogMemDelays may now see sync-read mems.
**Backend code-generation impact:** most sync-read mems will now (potentially optionally) be emitted directly from FIRRTL to Verilog without splitting readwrite ports or adding pipelining registers.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
