### PR TITLE
Allow InferReadWrite to combine shared-address R/W ports when appropriate

### DIFF
--- a/src/test/scala/firrtlTests/InferReadWriteSpec.scala
+++ b/src/test/scala/firrtlTests/InferReadWriteSpec.scala
@@ -177,4 +177,53 @@ circuit sram6t :
     // Check correctness of firrtl
     res should containLine(s"mem.rw.wmode <= wen")
   }
+
+  def sameAddr(ruw: String): String = {
+    s"""
+    |circuit sram6t :
+    |  module sram6t :
+    |    input clock : Clock
+    |    output io : { flip addr : UInt<11>, flip valid : UInt<1>, flip write : UInt<1>, flip dataIn : UInt<32>, dataOut : UInt<32>}
+    |
+    |    mem mem:
+    |      data-type => UInt<4>
+    |      depth => 64
+    |      reader => r
+    |      writer => w
+    |      read-latency => 1
+    |      write-latency => 1
+    |      read-under-write => ${ruw}
+    |
+    |    mem.r.clk <= clock
+    |    mem.r.addr <= io.addr
+    |    mem.r.en <= io.valid
+    |    io.dataOut <= mem.r.data
+    |
+    |    node wen = and(io.valid, io.write)
+    |    mem.w.clk <= clock
+    |    mem.w.addr <= io.addr
+    |    mem.w.en <= wen
+    |    mem.w.mask <= UInt(1)
+    |    mem.w.data <= io.dataIn""".stripMargin
+  }
+
+  "Infer ReadWrite Ports" should "infer readwrite ports from shared addresses with undefined readUnderWrite" in {
+    val input = sameAddr("undefined")
+    val annos = Seq(memlib.InferReadWriteAnnotation)
+    val res = compileAndEmit(CircuitState(parse(input), HighForm, annos))
+    // Check correctness of firrtl
+    res should containLine(s"mem.rw.wmode <= wen")
+  }
+
+  "Infer ReadWrite Ports" should "not infer readwrite ports from shared addresses with 'new' readUnderWrite" in {
+    val input = sameAddr("new")
+    val annos = Seq(memlib.InferReadWriteAnnotation)
+    intercept[Exception] {
+      compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
+    } match {
+      case CustomTransformException(_: InferReadWriteCheckException) => // success
+      case _ => fail()
+    }
+  }
+
 }


### PR DESCRIPTION
I would categorize this as an "RFC" to see if anyone is interested in expanded readwrite inference. In cases where a read and write port of a `SyncReadMem` share the same clock and address, the semantics of the default `undefined` read-under-write behavior mean that it is legal to combine the ports into an RW port. The definition of this behavior in the spec implies that this is legal even in cases where there is a partial write mask.

**Type of improvement:** enhancement of optional inference pass
**API impact:** none
**Backend code-generation impact:** when `--infer-rw` is enabled, more RW inference may occur
**Release notes:**
The existing, optional InferReadWrite pass may now infer readwrite ports from read/write port pairs that share the same clock and address for undefined read-under-write synchronous-read memories. Previously recognized cases with mutually exclusive read and write enables will continue to be combined as before.

### Contributor Checklist
- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
