### PR TITLE
Fix CI Checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Cache Scala
         uses: coursier/cache-action@v5
       - name: Check Formatting (Scala 2.12 only)
-        if: matrix.scala == '2.12.12'
+        if: startsWith(matrix.scala, '2.12')
         run: sbt ++${{ matrix.scala }} scalafmtCheckAll
       - name: Unidoc
         run: sbt ++${{ matrix.scala }} unidoc
-      - name: Sanity check benchmarking scripts (Scala 2.12 only)
-        if: matrix.scala == '2.12.12'
+      - name: Sanity check benchmarking scripts (Scala 2.13 only)
+        if: startsWith(matrix.scala, '2.13')
         run: |
           benchmark/scripts/benchmark_cold_compile.py -N 2 --designs regress/ICache.fir --versions HEAD
           benchmark/scripts/find_heap_bound.py -- -cp firrtl*jar firrtl.stage.FirrtlMain -i regress/ICache.fir -o out -X verilog

--- a/src/test/scala/firrtlTests/ExpandWhensSpec.scala
+++ b/src/test/scala/firrtlTests/ExpandWhensSpec.scala
@@ -145,7 +145,8 @@ class ExpandWhensSpec extends FirrtlFlatSpec {
         |      assert(clock, eq(in, UInt<1>("h1")), UInt<1>("h1"), "assert0") : test_assert
         |    else :
         |      skip""".stripMargin
-    val check = "assert(clock, eq(in, UInt<1>(\"h1\")), and(and(UInt<1>(\"h1\"), p), UInt<1>(\"h1\")), \"assert0\") : test_assert"
+    val check =
+      "assert(clock, eq(in, UInt<1>(\"h1\")), and(and(UInt<1>(\"h1\"), p), UInt<1>(\"h1\")), \"assert0\") : test_assert"
     executeTest(input, check, true)
   }
   it should "handle stops" in {


### PR DESCRIPTION
Bumping Scala minor version but not bumping CI guards on the version
causes tests to no longer run. Change to using startsWith(...) so that
minor version bumps won't cause issues in the future.

I wanted to know why https://github.com/chipsalliance/firrtl/pull/2062#discussion_r585812506 wasn't caught by CI, welp, here's why. This should fail initially because 1 file isn't formatted properly, I'll push a commit with that fix once I verify that the checks run.

This needs to be backported to 1.4.x, but not 1.3.x nor 1.2.x (we stopped bumping Scala on those). It unfortunately will require a manual backport due to changing the CI workflows.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix   

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Rebase

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
