### PR TITLE
SMT Backend: model Invalid and Division by Zero with DefRandom nodes

### DIFF
--- a/src/main/scala/firrtl/backends/experimental/smt/random/InvalidToRandomPass.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/random/InvalidToRandomPass.scala
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.backends.experimental.smt.random
+
+import firrtl._
+import firrtl.annotations.NoTargetAnnotation
+import firrtl.ir._
+import firrtl.passes._
+import firrtl.options.Dependency
+import firrtl.stage.Forms
+import firrtl.transforms.RemoveWires
+
+import scala.collection.mutable
+
+/** Chooses how to model explicit and implicit invalid values in the circuit */
+case class InvalidToRandomOptions(
+  randomizeInvalidSignals: Boolean = true,
+  randomizeDivisionByZero: Boolean = true)
+    extends NoTargetAnnotation
+
+/** Replaces all explicit and implicit "invalid" values with random values.
+  * Explicit invalids are:
+  * - signal is invalid
+  * - signal <= valid(..., expr)
+  * Implicit invalids are:
+  * - a / b when eq(b, 0)
+  */
+object InvalidToRandomPass extends Transform with DependencyAPIMigration {
+  override def prerequisites = Forms.LowForm
+  // once ValidIf has been removed, we can no longer detect and randomize them
+  override def optionalPrerequisiteOf = Seq(Dependency(RemoveValidIf))
+  override def invalidates(a: Transform) = a match {
+    // this pass might destroy SSA form, as we add a wire for the data field of every read port
+    case _: RemoveWires => true
+    // TODO: should we add some optimization passes here? we could be generating some dead code.
+    case _ => false
+  }
+
+  override protected def execute(state: CircuitState): CircuitState = {
+    val opts = state.annotations.collect { case o: InvalidToRandomOptions => o }
+    require(opts.size < 2, s"Multiple options: $opts")
+    val opt = opts.headOption.getOrElse(InvalidToRandomOptions())
+
+    // quick exit if we just want to skip this pass
+    if (!opt.randomizeDivisionByZero && !opt.randomizeInvalidSignals) {
+      state
+    } else {
+      val c = state.circuit.mapModule(onModule(_, opt))
+      state.copy(circuit = c)
+    }
+  }
+
+  private def onModule(m: DefModule, opt: InvalidToRandomOptions): DefModule = m match {
+    case d: DescribedMod =>
+      throw new RuntimeException(s"CompilerError: Unexpected internal node: ${d.serialize}")
+    case e:   ExtModule => e
+    case mod: Module =>
+      val namespace = Namespace(mod)
+      mod.mapStmt(onStmt(namespace, opt, _))
+  }
+
+  private def onStmt(namespace: Namespace, opt: InvalidToRandomOptions, s: Statement): Statement = s match {
+    case IsInvalid(info, loc: RefLikeExpression) if opt.randomizeInvalidSignals =>
+      val name = namespace.newName(loc.serialize.replace('.', '_') + "_invalid")
+      val rand = DefRandom(info, name, loc.tpe, None)
+      Block(List(rand, Connect(info, loc, Reference(rand))))
+    case other =>
+      val info = other match {
+        case h: HasInfo => h.info
+        case _ => NoInfo
+      }
+      val prefix = other match {
+        case c: Connect => c.loc.serialize.replace('.', '_')
+        case h: HasName => h.name
+        case _ => ""
+      }
+      val ctx = ExprCtx(namespace, opt, prefix, info, mutable.ListBuffer[Statement]())
+      val stmt = other.mapExpr(onExpr(ctx, _)).mapStmt(onStmt(namespace, opt, _))
+      if (ctx.rands.isEmpty) { stmt }
+      else { Block(Block(ctx.rands.toList), stmt) }
+  }
+
+  private case class ExprCtx(
+    namespace: Namespace,
+    opt:       InvalidToRandomOptions,
+    prefix:    String,
+    info:      Info,
+    rands:     mutable.ListBuffer[Statement])
+
+  private def onExpr(ctx: ExprCtx, e: Expression): Expression =
+    e.mapExpr(onExpr(ctx, _)) match {
+      case ValidIf(_, value, tpe) if tpe == ClockType =>
+        // we currently assume that clocks are always valid
+        // TODO: is that a good assumption?
+        value
+      case ValidIf(cond, value, tpe) if ctx.opt.randomizeInvalidSignals =>
+        makeRand(ctx, cond, tpe, value, invert = true)
+      case d @ DoPrim(PrimOps.Div, Seq(_, den), _, tpe) if ctx.opt.randomizeDivisionByZero =>
+        val denIsZero = Utils.eq(den, Utils.getGroundZero(den.tpe.asInstanceOf[GroundType]))
+        makeRand(ctx, denIsZero, tpe, d, invert = false)
+      case other => other
+    }
+
+  private def makeRand(
+    ctx:    ExprCtx,
+    cond:   Expression,
+    tpe:    Type,
+    value:  Expression,
+    invert: Boolean
+  ): Expression = {
+    val name = ctx.namespace.newName(if (ctx.prefix.isEmpty) "invalid" else ctx.prefix + "_invalid")
+    // create a condition node if the condition isn't a reference already
+    val condRef = cond match {
+      case r: RefLikeExpression => if (invert) Utils.not(r) else r
+      case other =>
+        val cond = if (invert) Utils.not(other) else other
+        val condNode = DefNode(ctx.info, ctx.namespace.newName(name + "_cond"), cond)
+        ctx.rands.append(condNode)
+        Reference(condNode)
+    }
+    val rand = DefRandom(ctx.info, name, tpe, None, condRef)
+    ctx.rands.append(rand)
+    Utils.mux(condRef, Reference(rand), value)
+  }
+}

--- a/src/test/scala/firrtl/backends/experimental/smt/random/InvalidToRandomSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/random/InvalidToRandomSpec.scala
@@ -1,0 +1,56 @@
+package firrtl.backends.experimental.smt.random
+
+import firrtl.options.Dependency
+import firrtl.testutils.LeanTransformSpec
+
+class InvalidToRandomSpec extends LeanTransformSpec(Seq(Dependency(InvalidToRandomPass))) {
+  behavior.of("InvalidToRandomPass")
+
+  val src1 =
+    s"""
+       |circuit Test:
+       |  module Test:
+       |    input a : UInt<2>
+       |    output o : UInt<8>
+       |    output o2 : UInt<8>
+       |    output o3 : UInt<8>
+       |
+       |    o is invalid
+       |
+       |    when eq(a, UInt(3)):
+       |      o <= UInt(5)
+       |
+       |    o2 is invalid
+       |    node o2_valid = eq(a, UInt(2))
+       |    when o2_valid:
+       |      o2 <= UInt(7)
+       |
+       |    o3 is invalid
+       |    o3 <= UInt(3)
+       |""".stripMargin
+
+  it should "model invalid signals as random" in {
+
+    val circuit = compile(src1, List()).circuit
+    //println(circuit.serialize)
+    val result = circuit.serialize.split('\n').map(_.trim)
+
+    // the condition should end up as a new node if it wasn't a reference already
+    assert(result.contains("node _GEN_0_invalid_cond = not(eq(a, UInt<2>(\"h3\")))"))
+    assert(result.contains("node o2_valid = eq(a, UInt<2>(\"h2\"))"))
+
+    // every invalid results in a random statement
+    assert(result.contains("rand _GEN_0_invalid : UInt<3> when _GEN_0_invalid_cond"))
+    assert(result.contains("rand _GEN_1_invalid : UInt<3> when not(o2_valid)"))
+
+    // the random value is conditionally assigned
+    assert(result.contains("node _GEN_0 = mux(_GEN_0_invalid_cond, _GEN_0_invalid, UInt<3>(\"h5\"))"))
+    assert(result.contains("node _GEN_1 = mux(not(o2_valid), _GEN_1_invalid, UInt<3>(\"h7\"))"))
+
+    // expressions that are trivially valid do not get randomized
+    assert(result.contains("o3 <= UInt<2>(\"h3\")"))
+    val defRandCount = result.count(_.contains("rand "))
+    assert(defRandCount == 2)
+  }
+
+}


### PR DESCRIPTION
This finally removes all randomization code from the transition
system conversion and into a separate pass using DefRandom nodes.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code refactoring

#### API Impact

- new `InvalidToRandomPass` and `InvalidToRandomOptions` annotation in the _experimental_ SMT backend

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy

- squash

#### Release Notes
 n/a

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
