### PR TITLE
Add -fpga flag to enable FPGA-oriented compilation strategies (currently for memories)

### DIFF
--- a/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
+++ b/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
@@ -1065,32 +1065,53 @@ class VerilogEmitter extends SeqTransform with Emitter {
           val decl = if (fullSize > (1 << 29)) "reg /* sparse */" else "reg"
           declareVectorType(decl, sx.name, sx.dataType, sx.depth, sx.info)
           initialize_mem(sx, options)
-          if (sx.readLatency != 0 || sx.writeLatency != 1)
+          // Currently, no idiomatic way to directly emit write-first RW ports
+          val hasComplexRW = (sx.readwriters.nonEmpty &&
+            (sx.readLatency != 1 || sx.readUnderWrite == ReadUnderWrite.New))
+          if (sx.readLatency > 1 || sx.writeLatency != 1 || hasComplexRW)
             throw EmitterException(
-              "All memories should be transformed into " +
-                "blackboxes or combinational by previous passses"
+              Seq(
+                s"Memory ${sx.name} is too complex to emit directly.",
+                "Consider running VerilogMemDelays to simplify complex memories.",
+                "Alternatively, add the --repl-seq-mem flag to replace memories with blackboxes."
+              ).mkString(" ")
             )
+          def createMemWire(name: String, tpe: Type, rhs: InfoExpr): Unit = {
+            declare("wire", name, tpe, MultiInfo(sx.info, rhs.info), rhs.expr)
+          }
+
           for (r <- sx.readers) {
             val data = memPortField(sx, r, "data")
             val addr = memPortField(sx, r, "addr")
-            // Ports should share an always@posedge, so can't have intermediary wire
-
-            declare("wire", LowerTypes.loweredName(data), data.tpe, sx.info)
-            declare("wire", LowerTypes.loweredName(addr), addr.tpe, sx.info)
-            // declare("wire", LowerTypes.loweredName(en), en.tpe)
-
-            //; Read port
-            assign(addr, netlist(addr))
-            // assign(en, netlist(en))     //;Connects value to m.r.en
-            val mem = WRef(sx.name, memType(sx), MemKind, UnknownFlow)
-            val memPort = WSubAccess(mem, addr, sx.dataType, UnknownFlow)
+            val en = memPortField(sx, r, "en")
+            val memPort = WSubAccess(WRef(sx), addr, sx.dataType, UnknownFlow)
             val depthValue = UIntLiteral(sx.depth, IntWidth(sx.depth.bitLength))
             val garbageGuard = DoPrim(Geq, Seq(addr, depthValue), Seq(), UnknownType)
 
-            if ((sx.depth & (sx.depth - 1)) == 0)
-              assign(data, memPort, sx.info)
-            else
-              garbageAssign(data, memPort, garbageGuard, sx.info)
+            val clkSource = netlist(memPortField(sx, r, "clk")).expr
+
+            createMemWire(LowerTypes.loweredName(en), en.tpe, netlist(en))
+
+            if (sx.readLatency == 1 && sx.readUnderWrite != ReadUnderWrite.Old) {
+              val InfoExpr(addrInfo, addrDriver) = netlist(addr)
+              declare("reg", LowerTypes.loweredName(addr), addr.tpe, sx.info)
+              initialize(WRef(LowerTypes.loweredName(addr), addr.tpe), zero, zero)
+              update(addr, addrDriver, clkSource, en, addrInfo)
+            } else {
+              createMemWire(LowerTypes.loweredName(addr), addr.tpe, netlist(addr))
+            }
+
+            if (sx.readLatency == 1 && sx.readUnderWrite == ReadUnderWrite.Old) {
+              declare("reg", LowerTypes.loweredName(data), data.tpe, sx.info)
+              initialize(WRef(LowerTypes.loweredName(data), data.tpe), zero, zero)
+              update(data, memPort, clkSource, en, sx.info)
+            } else {
+              declare("wire", LowerTypes.loweredName(data), data.tpe, sx.info)
+              if ((sx.depth & (sx.depth - 1)) == 0)
+                assign(data, memPort, sx.info)
+              else
+                garbageAssign(data, memPort, garbageGuard, sx.info)
+            }
           }
 
           for (w <- sx.writers) {
@@ -1098,31 +1119,41 @@ class VerilogEmitter extends SeqTransform with Emitter {
             val addr = memPortField(sx, w, "addr")
             val mask = memPortField(sx, w, "mask")
             val en = memPortField(sx, w, "en")
-            //Ports should share an always@posedge, so can't have intermediary wire
-            // TODO should we use the info here for anything?
-            val InfoExpr(_, clk) = netlist(memPortField(sx, w, "clk"))
 
-            declare("wire", LowerTypes.loweredName(data), data.tpe, sx.info)
-            declare("wire", LowerTypes.loweredName(addr), addr.tpe, sx.info)
-            declare("wire", LowerTypes.loweredName(mask), mask.tpe, sx.info)
-            declare("wire", LowerTypes.loweredName(en), en.tpe, sx.info)
+            val clkSource = netlist(memPortField(sx, w, "clk")).expr
 
-            // Write port
-            assign(data, netlist(data))
-            assign(addr, netlist(addr))
-            assign(mask, netlist(mask))
-            assign(en, netlist(en))
+            createMemWire(LowerTypes.loweredName(data), data.tpe, netlist(data))
+            createMemWire(LowerTypes.loweredName(addr), addr.tpe, netlist(addr))
+            createMemWire(LowerTypes.loweredName(mask), mask.tpe, netlist(mask))
+            createMemWire(LowerTypes.loweredName(en), en.tpe, netlist(en))
 
-            val mem = WRef(sx.name, memType(sx), MemKind, UnknownFlow)
-            val memPort = WSubAccess(mem, addr, sx.dataType, UnknownFlow)
-            update(memPort, data, clk, AND(en, mask), sx.info)
+            val memPort = WSubAccess(WRef(sx), addr, sx.dataType, UnknownFlow)
+            update(memPort, data, clkSource, AND(en, mask), sx.info)
           }
 
-          if (sx.readwriters.nonEmpty)
-            throw EmitterException(
-              "All readwrite ports should be transformed into " +
-                "read & write ports by previous passes"
-            )
+          for (rw <- sx.readwriters) {
+            val rdata = memPortField(sx, rw, "rdata")
+            val wdata = memPortField(sx, rw, "wdata")
+            val addr = memPortField(sx, rw, "addr")
+            val en = memPortField(sx, rw, "en")
+            val wmode = memPortField(sx, rw, "wmode")
+            val wmask = memPortField(sx, rw, "wmask")
+            val memPort = WSubAccess(WRef(sx), addr, sx.dataType, UnknownFlow)
+
+            val clkSource = netlist(memPortField(sx, rw, "clk")).expr
+
+            createMemWire(LowerTypes.loweredName(wdata), wdata.tpe, netlist(wdata))
+            createMemWire(LowerTypes.loweredName(addr), addr.tpe, netlist(addr))
+            createMemWire(LowerTypes.loweredName(wmode), wmode.tpe, netlist(wmode))
+            createMemWire(LowerTypes.loweredName(wmask), wmask.tpe, netlist(wmask))
+            createMemWire(LowerTypes.loweredName(en), en.tpe, netlist(en))
+
+            declare("reg", LowerTypes.loweredName(rdata), rdata.tpe, sx.info)
+            initialize(WRef(LowerTypes.loweredName(rdata), rdata.tpe), zero, zero)
+            update(rdata, memPort, clkSource, en, sx.info)
+            update(memPort, wdata, clkSource, AND(en, AND(wmode, wmask)), sx.info)
+          }
+
         case _ =>
       }
     }

--- a/src/main/scala/firrtl/passes/memlib/SeparateWriteClocks.scala
+++ b/src/main/scala/firrtl/passes/memlib/SeparateWriteClocks.scala
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.passes
+package memlib
+
+import firrtl._
+import firrtl.ir._
+import firrtl.passes.LowerTypes
+import firrtl.options.{Dependency, OptionsException}
+
+/**
+  * This transform introduces an intermediate wire on the clock field of each write port of synchronous-read memories
+  * that have *multiple* write/readwrite ports and undefined read-under-write collision behavior. Ultimately, the
+  * introduction of these intermediate wires does not change which clock net clocks each port; therefore, the purpose of
+  * this transform is to help generate Verilog that is more amenable to inference of RAM macros with multiple write
+  * ports in FPGA synthesis flows. This change will cause each write and each readwrite port to be emitted in a separate
+  * clocked procedure, yielding multiple benefits:
+  *
+  * 1) Separate write procedures avoid implicitly constraining cross-port read-write and write-write collision behaviors
+  * 2) The preference for separate clocked procedures for each write port is explicitly specified by Intel and Xilinx
+  *
+  * While this feature is not intended to be vendor-specific, inference of *multiple-write* RAM macros from behavioral
+  * Verilog or VHDL requires both advanced underlying RAM primitives and advanced synthesis tools. Currently, mapping
+  * such memories to programmable devices beyond modern Intel and Xilinx architectures can be prohibitive for users.
+  *
+  * Though the emission of separate processes for write ports could be absorbed into the Verilog emitter, the use of a
+  * pure-FIRRTL transform reduces implementation complexity and enhances reliability.
+  */
+class SeparateWriteClocks extends Transform with DependencyAPIMigration {
+  override def prerequisites = Seq(Dependency(passes.RemoveCHIRRTL), Dependency(passes.ExpandConnects))
+  override def optionalPrerequisites = Seq(Dependency[InferReadWrite])
+  override def optionalPrerequisiteOf = Seq(Dependency[SetDefaultReadUnderWrite])
+  override def invalidates(a: Transform): Boolean = a match {
+    case ResolveFlows => true
+    case _            => false
+  }
+
+  private type ExprMap = collection.mutable.HashMap[WrappedExpression, Reference]
+
+  private def onExpr(replaceExprs: ExprMap)(expr: Expression): Expression = expr match {
+    case wsf: WSubField if (replaceExprs.contains(WrappedExpression(wsf))) =>
+      replaceExprs(WrappedExpression(wsf))
+    case e => e.mapExpr(onExpr(replaceExprs))
+  }
+
+  private def isMultiWriteSyncReadUndefinedRUW(mem: DefMemory): Boolean = {
+    (mem.writers.size + mem.readwriters.size) > 1 &&
+    mem.readLatency == 1 && mem.writeLatency == 1 &&
+    mem.readUnderWrite == ReadUnderWrite.Undefined
+  }
+
+  private def onStmt(replaceExprs: ExprMap, ns: Namespace)(stmt: Statement): Statement = stmt match {
+    case mem: DefMemory if isMultiWriteSyncReadUndefinedRUW(mem) =>
+      val clockRefs = (mem.writers ++ mem.readwriters).map { p => MemPortUtils.memPortField(mem, p, "clk") }
+      val clockWireMap = clockRefs.map { pClk =>
+        WrappedExpression(pClk) -> DefWire(mem.info, ns.newName(LowerTypes.loweredName(pClk)), ClockType)
+      }
+      val clockStmts = clockWireMap.flatMap {
+        case (pClk, clkWire) => Seq(clkWire, Connect(mem.info, pClk.e1, Reference(clkWire)))
+      }
+      replaceExprs ++= clockWireMap.map { case (pClk, clkWire) => pClk -> Reference(clkWire) }
+      Block(mem +: clockStmts)
+    case Connect(i, lhs, rhs)        => Connect(i, onExpr(replaceExprs)(lhs), rhs)
+    case PartialConnect(i, lhs, rhs) => PartialConnect(i, onExpr(replaceExprs)(lhs), rhs)
+    case IsInvalid(i, invalidated)   => IsInvalid(i, onExpr(replaceExprs)(invalidated))
+    case s                           => s.mapStmt(onStmt(replaceExprs, ns))
+  }
+
+  override def execute(state: CircuitState): CircuitState = {
+    val c = state.circuit
+    val cPrime = c.copy(modules = c.modules.map(m => m.mapStmt(onStmt(new ExprMap, Namespace(m)))))
+    state.copy(circuit = cPrime)
+  }
+}

--- a/src/main/scala/firrtl/passes/memlib/SetDefaultReadUnderWrite.scala
+++ b/src/main/scala/firrtl/passes/memlib/SetDefaultReadUnderWrite.scala
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.passes
+package memlib
+
+import firrtl._
+import firrtl.ir._
+import firrtl.options.{Dependency, OptionsException}
+import firrtl.annotations.NoTargetAnnotation
+
+sealed trait DefaultReadUnderWriteAnnotation extends NoTargetAnnotation
+
+/** This annotation directs the [[SetDefaultReadUnderWrite]] transform to assign a default value of 'old' (read-first
+  * behavior) to all synchronous-read memories with 'undefined' read-under-write parameters.
+  */
+case object DefaultReadFirstAnnotation extends DefaultReadUnderWriteAnnotation
+
+/** This annotation directs the [[SetDefaultReadUnderWrite]] transform to assign a default value of 'new' (write-first
+  * behavior) to all synchronous-read memories with 'undefined' read-under-write parameters.
+  */
+case object DefaultWriteFirstAnnotation extends DefaultReadUnderWriteAnnotation
+
+/**
+  * Adding a [[DefaultReadUnderWriteAnnotation]] and running the [[SetDefaultReadUnderWrite]] transform will cause all
+  * synchronous-read memories with 'undefined' read-under-write parameters to be assigned a default parameter value,
+  * either 'old' (read-first behavior) or 'new' (write-first behavior). This can help generate Verilog that is amenable
+  * to RAM macro inference for various FPGA tools, or it can be used to satisfy other downstream design constraints.
+  */
+class SetDefaultReadUnderWrite extends Transform with DependencyAPIMigration {
+  override def prerequisites = firrtl.stage.Forms.HighForm
+  override def optionalPrerequisites = Seq(Dependency[InferReadWrite])
+  override def optionalPrerequisiteOf = Seq(Dependency(VerilogMemDelays))
+  override def invalidates(a: Transform): Boolean = false
+
+  private def onStmt(defaultRUW: ReadUnderWrite.Value)(stmt: Statement): Statement = stmt match {
+    case mem: DefMemory if (mem.readLatency > 0 && mem.readUnderWrite == ReadUnderWrite.Undefined) =>
+      mem.copy(readUnderWrite = defaultRUW)
+    case s => s.mapStmt(onStmt(defaultRUW))
+  }
+
+  override def execute(state: CircuitState): CircuitState = {
+    val c = state.circuit
+    val ruwDefaults = state.annotations
+      .collect({
+        case DefaultReadFirstAnnotation  => ReadUnderWrite.Old
+        case DefaultWriteFirstAnnotation => ReadUnderWrite.New
+      })
+      .toSet
+    if (ruwDefaults.size == 0) {
+      state
+    } else if (ruwDefaults.size == 1) {
+      state.copy(circuit = c.copy(modules = c.modules.map(m => m.mapStmt(onStmt(ruwDefaults.head)))))
+    } else {
+      throw new OptionsException("Conflicting default read-under-write settings.")
+    }
+  }
+}

--- a/src/main/scala/firrtl/stage/FirrtlCli.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCli.scala
@@ -22,7 +22,8 @@ trait FirrtlCli { this: Shell =>
     NoCircuitDedupAnnotation,
     WarnNoScalaVersionDeprecation,
     PrettyNoExprInlining,
-    DisableFold
+    DisableFold,
+    OptimizeForFPGA
   )
     .map(_.addOptions(parser))
 

--- a/src/main/scala/firrtl/stage/FirrtlCompilerTargets.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCompilerTargets.scala
@@ -13,9 +13,7 @@ import firrtl.options.{HasShellOptions, ShellOption}
   * to any particular vendor; instead, they aim to emit simple Verilog that more closely reflects traditional
   * human-written definitions of synchronous-read memories.
   *
-  * 1) Add a [[firrtl.passes.memlib.PassthroughSimpleSyncReadMemsAnnotation]] to allow some synchronous-read memories
-  *    and readwrite ports to pass through [[firrtl.passes.memlib.VerilogMemDelays]] without introducing explicit
-  *    pipeline registers or splitting ports.
+  * 1) Enable the [[firrtl.passes.memlib.InferReadWrite]] transform to reduce port count, where applicable.
   *
   * 2) Use the [[firrtl.transforms.SimplifyMems]] transform to Lower aggregate-typed memories with always-high masks to
   *    packed memories without splitting them into multiple independent ground-typed memories.
@@ -30,7 +28,9 @@ import firrtl.options.{HasShellOptions, ShellOption}
   *    default. This eliminates the difficulty of inferring a RAM macro that matches the strict semantics of
   *    "write-first" ports.
   *
-  * 5) Enable the [[firrtl.passes.memlib.InferReadWrite]] transform to reduce port count, where applicable.
+  * 5) Add a [[firrtl.passes.memlib.PassthroughSimpleSyncReadMemsAnnotation]] to allow some synchronous-read memories
+  *    and readwrite ports to pass through [[firrtl.passes.memlib.VerilogMemDelays]] without introducing explicit
+  *    pipeline registers or splitting ports.
   */
 object OptimizeForFPGA extends HasShellOptions {
   private val fpgaAnnos = Seq(

--- a/src/main/scala/firrtl/stage/FirrtlCompilerTargets.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCompilerTargets.scala
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.stage
+
+import firrtl.transforms._
+import firrtl.passes.memlib._
+import firrtl.options.{HasShellOptions, ShellOption}
+
+/**
+  * This flag enables a set of options that guide the FIRRTL compilation flow to ultimately generate Verilog that is
+  * more amenable to using for synthesized FPGA designs. Currently, this flag affects only memories, as the need to emit
+  * memories that support downstream inference of hardened RAM macros. These options are not intended to be specialized
+  * to any particular vendor; instead, they aim to emit simple Verilog that more closely reflects traditional
+  * human-written definitions of synchronous-read memories.
+  *
+  * 1) Add a [[firrtl.passes.memlib.PassthroughSimpleSyncReadMemsAnnotation]] to allow some synchronous-read memories
+  *    and readwrite ports to pass through [[firrtl.passes.memlib.VerilogMemDelays]] without introducing explicit
+  *    pipeline registers or splitting ports.
+  *
+  * 2) Use the [[firrtl.transforms.SimplifyMems]] transform to Lower aggregate-typed memories with always-high masks to
+  *    packed memories without splitting them into multiple independent ground-typed memories.
+  *
+  * 3) Use the [[firrtl.passes.memlib.SeparateWriteClocks]] transform to ensure that each write port of a
+  *    multiple-write, synchronous-read memory with 'undefined' collision behavior ultimately maps to a separate clocked
+  *    process in the emitted Verilog. This avoids the issue of implicitly constraining cross-port collision and write
+  *    ordering behavior and helps simplify inference of true dual-port RAM macros.
+  *
+  * 4) Use the [[firrtl.passes.memlib.SetDefaultReadUnderWrite]] to specify that memories with undefined
+  *    read-under-write behavior should map to emitted microarchitectures characteristic of "read-first" ports by
+  *    default. This eliminates the difficulty of inferring a RAM macro that matches the strict semantics of
+  *    "write-first" ports.
+  *
+  * 5) Enable the [[firrtl.passes.memlib.InferReadWrite]] transform to reduce port count, where applicable.
+  */
+object OptimizeForFPGA extends HasShellOptions {
+  private val fpgaAnnos = Seq(
+    InferReadWriteAnnotation,
+    RunFirrtlTransformAnnotation(new InferReadWrite),
+    RunFirrtlTransformAnnotation(new SeparateWriteClocks),
+    DefaultReadFirstAnnotation,
+    RunFirrtlTransformAnnotation(new SetDefaultReadUnderWrite),
+    RunFirrtlTransformAnnotation(new SimplifyMems),
+    PassthroughSimpleSyncReadMemsAnnotation
+  )
+  val options = Seq(
+    new ShellOption[Unit](
+      longOption = "target:fpga",
+      toAnnotationSeq = a => fpgaAnnos,
+      helpText = "Choose compilation strategies that generally favor FPGA targets"
+    )
+  )
+}

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -6,6 +6,7 @@ package transforms
 import firrtl.ir._
 import firrtl.Mappers._
 import firrtl.annotations._
+import firrtl.options.Dependency
 import firrtl.passes._
 import firrtl.passes.memlib._
 import firrtl.stage.Forms
@@ -21,7 +22,7 @@ import ResolveMaskGranularity._
 class SimplifyMems extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
-  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites = Seq(Dependency[InferReadWrite])
   override def optionalPrerequisiteOf = Forms.MidEmitters
   override def invalidates(a: Transform) = a match {
     case InferTypes => true

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -23,7 +23,10 @@ class SimplifyMems extends Transform with DependencyAPIMigration {
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
   override def optionalPrerequisiteOf = Forms.MidEmitters
-  override def invalidates(a: Transform) = false
+  override def invalidates(a: Transform) = a match {
+    case InferTypes => true
+    case _          => false
+  }
 
   def onModule(c: Circuit, renames: RenameMap)(m: DefModule): DefModule = {
     val moduleNS = Namespace(m)

--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -91,11 +91,11 @@ class InfoSpec extends FirrtlFlatSpec with FirrtlMatchers {
     result should containTree { case DefMemory(Info1, "m", _, _, _, _, _, _, _, _) => true }
     result should containLine(s"reg [7:0] m [0:31]; //$Info1")
     result should containLine(s"wire [7:0] m_r_data; //$Info1")
-    result should containLine(s"wire [4:0] m_r_addr; //$Info1")
-    result should containLine(s"wire [7:0] m_w_data; //$Info1")
-    result should containLine(s"wire [4:0] m_w_addr; //$Info1")
-    result should containLine(s"wire  m_w_mask; //$Info1")
-    result should containLine(s"wire  m_w_en; //$Info1")
+    result should containLine(s"wire [4:0] m_r_addr = addr; //$Info1")
+    result should containLine(s"wire [7:0] m_w_data = 8'h0; //$Info1")
+    result should containLine(s"wire [4:0] m_w_addr = addr; //$Info1")
+    result should containLine(s"wire  m_w_mask = 1'h0; //$Info1")
+    result should containLine(s"wire  m_w_en = 1'h0; //$Info1")
     result should containLine(s"assign m_r_data = m[m_r_addr]; //$Info1")
     result should containLine(s"m[m_w_addr] <= m_w_data; //$Info1")
   }

--- a/src/test/scala/firrtlTests/SeparateWriteClocksSpec.scala
+++ b/src/test/scala/firrtlTests/SeparateWriteClocksSpec.scala
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests
+
+import firrtl._
+import firrtl.ir._
+import firrtl.passes.memlib.SeparateWriteClocks
+import firrtl.testutils._
+import firrtl.testutils.FirrtlCheckers._
+
+class SeparateWriteClocksSpec extends FirrtlFlatSpec {
+  def transform(input: String): CircuitState = {
+    val csx = (new SeparateWriteClocks).execute(CircuitState(parse(input), MidForm))
+    val emittedCirc = EmittedFirrtlCircuit("top", csx.circuit.serialize, ".fir")
+    csx.copy(annotations = Seq(EmittedFirrtlCircuitAnnotation(emittedCirc)))
+  }
+
+  behavior.of("SeparateWriteClocks")
+
+  it should "add intermediate wires to clocks of multi-write sync-read memories" in {
+    val result = transform(s"""
+                              |circuit top:
+                              |  module top:
+                              |    input clk: Clock
+                              |    input raddr: UInt<10>
+                              |    output rdata: UInt<8>[4]
+                              |    input waddr_a: UInt<10>
+                              |    input we_a: UInt<1>
+                              |    input wdata_a: UInt<8>[4]
+                              |    input waddr_a: UInt<10>
+                              |    input we_a: UInt<1>
+                              |    input wdata_a: UInt<8>[4]
+                              |
+                              |    mem m:
+                              |      data-type => UInt<8>
+                              |      depth => 1024
+                              |      reader => r
+                              |      writer => w_a
+                              |      writer => w_b
+                              |      read-latency => 1
+                              |      write-latency => 1
+                              |      read-under-write => undefined
+                              |
+                              |    m.r.clk <= clk
+                              |    m.r.addr <= raddr
+                              |    m.r.en <= UInt(1)
+                              |    rdata <= m.r.data
+                              |
+                              |    m.w_a.clk <= clk
+                              |    m.w_a.addr <= waddr_a
+                              |    m.w_a.en <= we_a
+                              |    m.w_a.mask <= UInt(1)
+                              |    m.w_a.data <= wdata_a
+                              |
+                              |    m.w_b.clk <= clk
+                              |    m.w_b.addr <= waddr_b
+                              |    m.w_b.en <= we_b
+                              |    m.w_b.mask <= UInt(1)
+                              |    m.w_b.data <= wdata_b""".stripMargin)
+
+    println(result.circuit.serialize)
+    result should containLine("m.r.clk <= clk")
+    result should containLine("m.w_a.clk <= m_w_a_clk")
+    result should containLine("m.w_b.clk <= m_w_b_clk")
+    result shouldNot containLine("m.w_a.clk <= clk")
+    result shouldNot containLine("m.w_b.clk <= clk")
+  }
+}


### PR DESCRIPTION
**Type of change:** enhancement
**API impact:** API addition + make an internal method private (can keep public in backport).
**Backend code-generation impact:** More readwrite inference. Also, significant changes to emitted Verilog iff new flags set.
**Desired merge strategy:** merge

**Release notes (WIP):**
`FirrtlStage` now supports new flags to incorporate compilation strategies intended to better integrate with downstream FPGA tools. When the `--target:fpga` flag is used, the Verilog emitted for synchronous-read memories will change significantly. However, the default flow will produce Verilog that is identical to head-of-tree before this PR, aside from the purely syntactic change of using more net-declaration assignments.

The existing, optional `InferReadWrite` pass may now infer readwrite ports from read/write port pairs that share the same clock and address for undefined read-under-write synchronous-read memories. Previously recognized cases with mutually exclusive read and write enables will continue to be combined as before.

**Commentary:**

*(This is a draft; it still needs documentation and more tests.)*

After the discussion on #2092 and #2094, I am opening this to subsume both of those PRs and a few related changes. This PR introduces a number of optional compiler strategies that are all enabled by the `--target:fpga` flag:
1. (From #2092) Allowing some synchronous-read memories and readwrite ports to pass through `VerilogMemDelays` without introducing explicit pipeline registers or splitting ports.
2. (From #1111) Lower aggregate-typed memories with always-high masks to packed memories without splitting.
3. (From firesim/firesim#639) Specify that memories with undefined read-under-write behavior should map to microarchitectures characteristic of "read-first" ports by default. This could be further modified by adding heuristics of when a memory is worth changing, but read-first ports provide a good path to Xilinx BRAMs.
4. Enable `InferReadWrite` (which also receives some enhancements; see below).

Most of these are effectively vendor-neutral, as they simply avoid the elaborate and inference-unfriendly permutation of FIRRTL memories and work around the behavioral memory API in Chisel. While the strong preference for read-first ports in (3) is based largely on experience with Xilinx FPGAs, the extremely strict semantics of write-first FIRRTL memories are also not the simplest or most generic pattern for inference to any underlying macro.

Furthermore, these are combined with some other enhancements. The VerilogEmitter is now capable of emitting simple synchronous-read memories intact; however, this will never happen with the default flow, as `VerilogMemDelays` retains its previous, conservative behavior without the `--target:fpga` flag. Finally, when `InferReadWrite` is enabled, some extra matching-address port pairs (from #2094) will be combined. One open question is whether this enhancement should be tied to the `--target:fpga` flag or made available by default as part of `--infer-rw`.

**Milestone:**
This will backport cleanly to `1.4.x` with a couple of minor changes. Notably, this sets up a deprecation for a future change of `VerilogMemDelays` from a `Pass` to a `Transform` so that it can look at annotations. For now, it uses an override of `execute` and a deprecation warning. Since this flow is generally made up of optional features, the consensus in the meeting was that this would make sense as a `1.4.x` milestone if there is general support to add these features as options.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
