### PR TITLE
Fix CSESubAccesses for SubAccesses with flips

### DIFF
--- a/src/test/scala/firrtlTests/transforms/CSESubAccessesSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/CSESubAccessesSpec.scala
@@ -184,4 +184,40 @@ class CSESubAccessesSpec extends FirrtlFlatSpec {
     compile(input) should be(parse(expected).serialize)
   }
 
+  it should "ignore flipped LHS SubAccesses" in {
+    val input = circuit(
+      s"""|input in : { foo : UInt<8> }
+          |input idx : UInt<1>
+          |input out : { flip foo : UInt<8> }[2]
+          |out[0].foo <= UInt(0)
+          |out[1].foo <= UInt(0)
+          |out[idx].foo <= in.foo"""
+    )
+    val expected = circuit(
+      s"""|input in : { foo : UInt<8> }
+          |input idx : UInt<1>
+          |input out : { flip foo : UInt<8> }[2]
+          |out[0].foo <= UInt(0)
+          |out[1].foo <= UInt(0)
+          |out[idx].foo <= in.foo"""
+    )
+    compile(input) should be(parse(expected).serialize)
+  }
+
+  it should "ignore SubAccesses of bidirectional aggregates" in {
+    val input = circuit(
+      s"""|input in : { flip foo : UInt<8>, bar : UInt<8> }
+          |input idx : UInt<2>
+          |output out : { flip foo : UInt<8>, bar : UInt<8> }[4]
+          |out[idx] <= in"""
+    )
+    val expected = circuit(
+      s"""|input in : { flip foo : UInt<8>, bar : UInt<8> }
+          |input idx : UInt<2>
+          |output out : { flip foo : UInt<8>, bar : UInt<8> }[4]
+          |out[idx] <= in"""
+    )
+    compile(input) should be(parse(expected).serialize)
+  }
+
 }


### PR DESCRIPTION
Fixes a bug in https://github.com/chipsalliance/firrtl/pull/2099 that is causing Chisel CI to fail.

The flow of a LHS SubAccess node may still be SourceFlow if the type of
the Vec element has a flip. Tweak the logic of CSESubAccesses to check
every Expression flow while recursing instead of just the flow of the
final SubAccess.

This did highlight a shortcoming of `CSESubAccesses`. Basically, the transform uses nodes to avoid quadratic behavior of `RemoveAccesses` because nodes are unaffected by `ExpandConnects` and thus it only lowers the `SubAccess` once. See https://github.com/chipsalliance/firrtl/issues/643 for more details on that issue. The shortcoming is that nodes cannot be used to represent bidirectional connections, so `CSESubAccesses` fundamentally cannot handle dynamic indexing of bidirectional Vecs. I did try, but it doesn't really work with the current approach.

I think a better approach is to fix the quadratic behavior in `RemoveAccesses` itself, then have `CSESubAccesses` use wires instead of nodes so that it can also handle bidirectional Vecs. Future work!

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

No need for release notes, CSESubAccesses is not yet released.

#### Type of Improvement

 - bug fix   

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
