### PR TITLE
Fix cat of zero-width SInt

### DIFF
--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -135,8 +135,9 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
         }
       }
       nonZeros match {
-        case Nil    => UIntLiteral(ZERO, IntWidth(BigInt(1)))
-        case Seq(x) => x
+        case Nil => UIntLiteral(ZERO, IntWidth(BigInt(1)))
+        // We may have an SInt, Cat has type UInt so cast
+        case Seq(x) => castRhs(tpe, x)
         case seq    => DoPrim(Cat, seq, consts, tpe).map(onExp)
       }
     case DoPrim(Andr, Seq(x), _, _) if (bitWidth(x.tpe) == 0) => UIntLiteral(1) // nothing false

--- a/src/test/scala/firrtlTests/ZeroWidthTests.scala
+++ b/src/test/scala/firrtlTests/ZeroWidthTests.scala
@@ -220,6 +220,23 @@ class ZeroWidthTests extends FirrtlFlatSpec {
         |    x <= UInt<1>(1)""".stripMargin
     (parse(exec(input))) should be(parse(check))
   }
+
+  "Cat of SInt with zero-width" should "keep type correctly" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input x : SInt<0>
+        |    input y : SInt<1>
+        |    output z : UInt<1>
+        |    z <= cat(y, x)""".stripMargin
+    val check =
+      """circuit Top :
+        |  module Top :
+        |    input y : SInt<1>
+        |    output z : UInt<1>
+        |    z <= asUInt(y)""".stripMargin
+    (parse(exec(input))) should be(parse(check))
+  }
 }
 
 class ZeroWidthVerilog extends FirrtlFlatSpec {


### PR DESCRIPTION
Previously, concatenating two SInts where one is of zero-width would
return the non-zero-width SInt. This is incorrect because the output of
Cat should be of type UInt. Now the ZeroWidth transform will introduce a
cast when removing a Cat when the argument type is non-UInt.

Fixes #2096 

h/t @drom for finding the issue and h/t @seldridge for identifying the cause.

For the input in #2096 we don't actually emit the expected behavior because we also constant propagate the register, so the result is:
```verilog
module top_mod(
  input         clock,
  input         reset,
  input  [10:0] inp_e,
  output        tmp15
);
  assign tmp15 = 1'h0;
endmodule
``` 

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix         

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Fix bug in zero-width handling when the type of an SInt concatenated with a zero-width SInt could be incorrectly interpreted as an SInt (instead of a UInt) resulting in incorrect constant propagation.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
