### PR TITLE
Fix issue where inlined cvt could cause crash

### DIFF
--- a/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineBooleanExpressionsSpec.scala
@@ -392,6 +392,22 @@ class InlineBooleanExpressionsSpec extends FirrtlFlatSpec {
     firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
   }
 
+  // https://github.com/chipsalliance/firrtl/issues/2035
+  // This is interesting because other ways of trying to express this get split out by
+  // SplitExpressions and don't get inlined again
+  // If we were to inline more expressions (ie. not just boolean ones) the issue this represents
+  // would come up more often
+  it should "handle cvt nested inside of a dshl" in {
+    val input =
+      """circuit DshlCvt:
+        |  module DshlCvt:
+        |    input a: UInt<4>
+        |    input b: SInt<1>
+        |    output o: UInt
+        |    o <= dshl(a, asUInt(cvt(b)))""".stripMargin
+    firrtlEquivalenceTest(input, Seq(new InlineBooleanExpressions))
+  }
+
   it should s"respect --${PrettyNoExprInlining.longOption}" in {
     val input =
       """circuit Top :


### PR DESCRIPTION
Due to inlining of Boolean expressions, the following circuit is handled
directly by the VerilogEmitter:
```
input a: UInt<4>
input b: SInt<1>
output o: UInt<5>
o <= dshl(a, asUInt(cvt(b)))
```
Priot to this change, this could crash due to mishandling of cvt in the
logic to inject parentheses based on Verilog precedence rules.

This is a corner case, but similar bugs would drop up if we open up the
VerilogEmitter to more expression inlining.

I considered instead changing `Legalize` to remove `cvt` (that that's perhaps still a good idea), but I wanted to solve a potential class of future issues and, as far as I can tell, this exact case is the only way to hit this bug currently.

Fixes #2035 h/t @drom for finding this issue

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix     

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Fix corner case where `cvt` of a 1-bit `SInt` (a no op) could crash the VerilogEmitter if passed as an argument to the shift amount in `dshl`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
