### PR TITLE
Legalize neg: -x becomes 0 - x

### DIFF
--- a/src/test/resources/passes/Legalize/Legalize.fir
+++ b/src/test/resources/passes/Legalize/Legalize.fir
@@ -39,3 +39,25 @@ circuit Legalize :
     when neq(bar_15, UInt(1)) :
       printf(clock, UInt(1), "Assertion failed!\n bar_15 != 0\n")
       stop(clock, UInt(1), 1)
+
+    ; Check neg of literals
+    node negUInt0 = neg(UInt(123))
+    when neq(negUInt0, SInt(-123)) :
+      printf(clock, UInt(1), "Assertion failed!\n negUInt0 != -123\n")
+      stop(clock, UInt(1), 1)
+    node negUInt1 = neg(UInt<8>(0))
+    when neq(negUInt1, SInt<8>(0)) :
+      printf(clock, UInt(1), "Assertion failed!\n negUInt1 != 0\n")
+      stop(clock, UInt(1), 1)
+    node negSInt0 = neg(SInt(123))
+    when neq(negSInt0, SInt(-123)) :
+      printf(clock, UInt(1), "Assertion failed!\n negSInt0 != -123\n")
+      stop(clock, UInt(1), 1)
+    node negSInt1 = neg(SInt(-123))
+    when neq(negSInt1, SInt(123)) :
+      printf(clock, UInt(1), "Assertion failed!\n negSInt1 != 123\n")
+      stop(clock, UInt(1), 1)
+    node negSInt2 = neg(SInt(0))
+    when neq(negSInt2, SInt(0)) :
+      printf(clock, UInt(1), "Assertion failed!\n negSInt2 != 0\n")
+      stop(clock, UInt(1), 1)

--- a/src/test/scala/firrtlTests/LegalizeSpec.scala
+++ b/src/test/scala/firrtlTests/LegalizeSpec.scala
@@ -2,6 +2,8 @@
 
 package firrtlTests
 
-import firrtl.testutils.ExecutionTest
+import firrtl.testutils.{ExecutionTest, ExecutionTestNoOpt}
 
 class LegalizeExecutionTest extends ExecutionTest("Legalize", "/passes/Legalize")
+// Legalize also needs to work when optimizations are turned off
+class LegalizeExecutionTestNoOpt extends ExecutionTestNoOpt("Legalize", "/passes/Legalize")

--- a/src/test/scala/firrtlTests/NegSpec.scala
+++ b/src/test/scala/firrtlTests/NegSpec.scala
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests
+
+import firrtl.testutils._
+
+class NegSpec extends FirrtlFlatSpec {
+  "unsigned neg" should "be correct and lint-clean" in {
+    val input =
+      """|circuit UnsignedNeg :
+         |  module UnsignedNeg  :
+         |    input in : UInt<8>
+         |    output out : SInt
+         |    out <= neg(in)
+         |""".stripMargin
+    val expected =
+      """|module UnsignedNegRef(
+         |  input [7:0] in,
+         |  output [8:0] out
+         |);
+         |  assign out = 8'd0 - in;
+         |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input, expected)
+    lintVerilog(compileToVerilog(input))
+  }
+
+  "signed neg" should "be correct and lint-clean" in {
+    val input =
+      """|circuit SignedNeg :
+         |  module SignedNeg  :
+         |    input in : SInt<8>
+         |    output out : SInt
+         |    out <= neg(in)
+         |""".stripMargin
+    // -$signed(in) is a lint warning in Verilator but is functionally correct
+    val expected =
+      """|module SignedNegRef(
+         |  input [7:0] in,
+         |  output [8:0] out
+         |);
+         |  assign out = -$signed(in);
+         |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input, expected)
+    lintVerilog(compileToVerilog(input))
+  }
+}


### PR DESCRIPTION
This fixes an error with negating a negative SInt literal and a
[debatable] lint warning in Verilator when negating any value.

This behavior matches that of Chisel (which directly emits the 0 - x
already).

Fixes https://github.com/chipsalliance/firrtl/issues/2026 although it introduces a new lint warning for that case
Fixes https://github.com/chipsalliance/firrtl/issues/2031

Follow on work to do constant propagation on subtraction (which we somehow are still not doing) which will fix the introduced lint warning (but a lint warning is better than an error!)

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


 - bug fix   
 - backend code generation


#### API Impact

Depending on `Legalize` means a transform will no longer see `Neg` prim ops.

#### Backend Code Generation Impact

This changes the emission of `neg` from:
```verilog
-$signed(x);
```
to
```
8'h0 - $signed(x);
```
As described in https://github.com/chipsalliance/firrtl/issues/2031, Verilator has a lint warning on this (warnings default to error). I don't agree with the lint warning, but since Chisel doesn't emit `neg` anyway (instead emitting `0 - x` like this change), I think matching the behavior of Chisel is fine.

We should consider seeing if Verilator might change that warning though.

#### Desired Merge Strategy

   - Squash

#### Release Notes

Canonicalize `neg(x)` to `0 - x`. Fix bug where negated negative literal would result in invalid Verilog.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
