### PR TITLE
Ensure InlineCasts does not inline complex Expressions

### DIFF
--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -165,10 +165,14 @@ trait FirrtlRunners extends BackendCompilationUtilities {
 
   /** Compiles input Firrtl to Verilog */
   def compileToVerilog(input: String, annotations: AnnotationSeq = Seq.empty): String = {
+    compileToVerilogCircuitState(input, annotations).getEmittedCircuit.value
+  }
+
+  /** Compiles input Firrtl to Verilog */
+  def compileToVerilogCircuitState(input: String, annotations: AnnotationSeq = Seq.empty): CircuitState = {
     val circuit = Parser.parse(input.split("\n").toIterator)
     val compiler = new VerilogCompiler
-    val res = compiler.compileAndEmit(CircuitState(circuit, HighForm, annotations), extraCheckTransforms)
-    res.getEmittedCircuit.value
+    compiler.compileAndEmit(CircuitState(circuit, HighForm, annotations), extraCheckTransforms)
   }
 
   /** Compile a Firrtl file

--- a/src/test/scala/firrtlTests/InlineCastsSpec.scala
+++ b/src/test/scala/firrtlTests/InlineCastsSpec.scala
@@ -4,18 +4,19 @@ package firrtlTests
 
 import firrtl.transforms.InlineCastsTransform
 import firrtl.testutils.FirrtlFlatSpec
+import firrtl.testutils.FirrtlCheckers._
 
-/*
- * Note: InlineCasts is still part of mverilog, so this test must both:
- * - Test that the InlineCasts fix is effective given the current mverilog
- * - Provide a test that will be robust if and when InlineCasts is no longer run in mverilog
- *
- * This is why the test passes InlineCasts as a custom transform: to future-proof it so that
- * it can do real LEC against no-InlineCasts. It currently is just a sanity check that the
- * emitted Verilog is legal, but it will automatically become a more meaningful test when
- * InlineCasts is not run in mverilog.
- */
 class InlineCastsEquivalenceSpec extends FirrtlFlatSpec {
+  /*
+   * Note: InlineCasts is still part of mverilog, so this test must both:
+   * - Test that the InlineCasts fix is effective given the current mverilog
+   * - Provide a test that will be robust if and when InlineCasts is no longer run in mverilog
+   *
+   * This is why the test passes InlineCasts as a custom transform: to future-proof it so that
+   * it can do real LEC against no-InlineCasts. It currently is just a sanity check that the
+   * emitted Verilog is legal, but it will automatically become a more meaningful test when
+   * InlineCasts is not run in mverilog.
+   */
   "InlineCastsTransform" should "not produce broken Verilog" in {
     val input =
       s"""circuit literalsel_fir:
@@ -25,5 +26,52 @@ class InlineCastsEquivalenceSpec extends FirrtlFlatSpec {
          |    o <= pad(asSInt(UInt<2>("h1")), 8)
          |""".stripMargin
     firrtlEquivalenceTest(input, Seq(new InlineCastsTransform))
+  }
+
+  it should "not inline complex expressions into other complex expressions" in {
+    val input =
+      """circuit NeverInlineComplexIntoComplex :
+        |  module NeverInlineComplexIntoComplex :
+        |    input a : SInt<3>
+        |    input b : UInt<2>
+        |    input c : UInt<2>
+        |    input sel : UInt<1>
+        |    output out : SInt<3>
+        |    node diff = sub(b, c)
+        |    out <= mux(sel, a, asSInt(diff))
+        |""".stripMargin
+    val expected =
+      """module NeverInlineComplexIntoComplexRef(
+        |  input  [2:0] a,
+        |  input  [1:0] b,
+        |  input  [1:0] c,
+        |  input        sel,
+        |  output [2:0] out
+        |);
+        |  wire [2:0] diff = b - c;
+        |  assign out = sel ? $signed(a) : $signed(diff);
+        |endmodule
+        |""".stripMargin
+    firrtlEquivalenceWithVerilog(input, expected)
+  }
+
+  it should "inline casts on both sides of a more complex expression" in {
+    val input =
+      """circuit test :
+        |  module test :
+        |    input clock : Clock
+        |    input in : UInt<8>
+        |    output out : UInt<8>
+        |
+        |    node _T_1 = asUInt(clock)
+        |    node _T_2 = not(_T_1)
+        |    node clock_n = asClock(_T_2)
+        |    reg r : UInt<8>, clock_n
+        |    r <= in
+        |    out <= r
+        |""".stripMargin
+    val verilog = compileToVerilogCircuitState(input)
+    verilog should containLine("always @(posedge clock_n) begin")
+
   }
 }


### PR DESCRIPTION
Previously, InlineCasts could inline complex (ie. non-cast) Expressions
into other complex Expressions. Now it will only inline so long as there
no more than 1 complex Expression in the current nested Expression.

This fixes the bug that https://github.com/chipsalliance/firrtl/pull/2128 is hitting in CI (the change in #2128 exposes this bug).

These tests probably aren't backportable but the bugfix should be, this is a functional bug.
First test is the functional bug, second is because my original fix caused some Verilog differences, namely the clock in that test would be named `_T_2` which is obviously not what we want. I think code gen would benefit from some "better name" handling that works across casts. Regardless, this PR is a minor bugfix so I wanted it to not cause Verilog diffs if possible, and it doesn't.

The diff looks small but most of the diff is because I added an inner method to `onExpr` to propagate `seenComplexExpr`. I didn't really want to expose that on the public API.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix    

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Fix bug where expression inlining could emit Verilog that doesn't match the input FIRRTL's semantics

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
