### PR TITLE
Add NoConstantPropagationAnnotation to disable constatnt propagation

### DIFF
--- a/src/main/resources/META-INF/services/firrtl.options.RegisteredTransform
+++ b/src/main/resources/META-INF/services/firrtl.options.RegisteredTransform
@@ -3,3 +3,4 @@ firrtl.transforms.CheckCombLoops
 firrtl.passes.InlineInstances
 firrtl.passes.clocklist.ClockListTransform
 firrtl.transforms.formal.AssertSubmoduleAssumptions
+firrtl.transforms.ConstantPropagation

--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -291,6 +291,7 @@ case object PrettyNoExprInlining extends NoTargetAnnotation with FirrtlOption wi
   */
 case class DisableFold(op: ir.PrimOp) extends NoTargetAnnotation with FirrtlOption
 
+@deprecated("will be removed and merged into ConstantPropagation in 1.5", "1.4")
 object DisableFold extends HasShellOptions {
 
   private val mapping: Map[String, ir.PrimOp] = PrimOps.builtinPrimOps.map { case op => op.toString -> op }.toMap

--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -9,6 +9,9 @@ import firrtl.passes.PassException
 /** Indicate that DCE should not be run */
 case object NoDCEAnnotation extends NoTargetAnnotation
 
+/** Indicate that ConstantPropagation should not be run */
+case object NoConstantPropagationAnnotation extends NoTargetAnnotation
+
 /** Lets an annotation mark its ReferenceTarget members as DontTouch
   *
   * This permits a transform to run and remove its associated annotations,

--- a/src/test/scala/firrtlTests/ConstantPropagationTests.scala
+++ b/src/test/scala/firrtlTests/ConstantPropagationTests.scala
@@ -908,6 +908,17 @@ class ConstantPropagationIntegrationSpec extends LowTransformSpec {
     execute(input, check, Seq(dontTouch("Child.in1")))
   }
 
+  it should "NOT optimize if no-constant-propagation is enabled" in {
+    val input =
+      """circuit Foo:
+        |  module Foo:
+        |    input a: UInt<1>
+        |    output b: UInt<1>
+        |    b <= and(UInt<1>(0), a)""".stripMargin
+    val check = parse(input).serialize
+    execute(input, check, Seq(NoConstantPropagationAnnotation))
+  }
+
   it should "still propagate constants even when there is name swapping" in {
     val input =
       """circuit Top :


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- new feature/API

#### API Impact
add

#### Backend Code Generation Impact
none

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
--no-constant-propagation can be used to disable constant propagation.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?