### PR TITLE
Fix bug in zero-width memory removal

### DIFF
--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -25,19 +25,12 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
     case _          => false
   }
 
-  private def makeEmptyMemBundle(name: String): Field =
-    Field(
-      name,
-      Flip,
-      BundleType(
-        Seq(
-          Field("addr", Default, UIntType(IntWidth(0))),
-          Field("en", Default, UIntType(IntWidth(0))),
-          Field("clk", Default, UIntType(IntWidth(0))),
-          Field("data", Flip, UIntType(IntWidth(0)))
-        )
-      )
-    )
+  private def makeZero(tpe: ir.Type): ir.Type = tpe match {
+    case ClockType        => UIntType(IntWidth(0))
+    case a: UIntType      => a.copy(IntWidth(0))
+    case a: SIntType      => a.copy(IntWidth(0))
+    case a: AggregateType => a.map(makeZero)
+  }
 
   private def onEmptyMemStmt(s: Statement): Statement = s match {
     case d @ DefMemory(info, name, tpe, _, _, _, rs, ws, rws, _) =>
@@ -46,11 +39,9 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
           DefWire(
             info,
             name,
-            BundleType(
-              rs.map(r => makeEmptyMemBundle(r)) ++
-                ws.map(w => makeEmptyMemBundle(w)) ++
-                rws.map(rw => makeEmptyMemBundle(rw))
-            )
+            MemPortUtils
+              .memType(d)
+              .map(makeZero)
           )
         case Some(_) => d
       }

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -26,7 +26,7 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
   }
 
   private def makeZero(tpe: ir.Type): ir.Type = tpe match {
-    case ClockType        => UIntType(IntWidth(0))
+    case ClockType => UIntType(IntWidth(0))
     case a: UIntType      => a.copy(IntWidth(0))
     case a: SIntType      => a.copy(IntWidth(0))
     case a: AggregateType => a.map(makeZero)

--- a/src/test/scala/firrtlTests/ZeroWidthTests.scala
+++ b/src/test/scala/firrtlTests/ZeroWidthTests.scala
@@ -285,20 +285,20 @@ class ZeroWidthTests extends FirrtlFlatSpec {
         |    rwDataOut <= memory.rw.rdata""".stripMargin
     val check =
       s"""circuit Foo:
-        |  module Foo:
-        |    input clock: Clock
-        |    input rAddr: UInt<4>
-        |    input rEn: UInt<1>
-        |    input wAddr: UInt<4>
-        |    input wEn: UInt<1>
-        |    input wMask: UInt<1>
-        |    input rwEn: UInt<1>
-        |    input rwMode: UInt<1>
-        |    input rwAddr: UInt<1>
-        |    input rwMask: UInt<1>
-        |
-        |${Seq.tabulate(17)(_ => "    skip").mkString("\n")}""".stripMargin
-    parse(exec(input)) should be (parse(check))
+         |  module Foo:
+         |    input clock: Clock
+         |    input rAddr: UInt<4>
+         |    input rEn: UInt<1>
+         |    input wAddr: UInt<4>
+         |    input wEn: UInt<1>
+         |    input wMask: UInt<1>
+         |    input rwEn: UInt<1>
+         |    input rwMode: UInt<1>
+         |    input rwAddr: UInt<1>
+         |    input rwMask: UInt<1>
+         |
+         |${Seq.tabulate(17)(_ => "    skip").mkString("\n")}""".stripMargin
+    parse(exec(input)) should be(parse(check))
   }
 }
 

--- a/src/test/scala/firrtlTests/ZeroWidthTests.scala
+++ b/src/test/scala/firrtlTests/ZeroWidthTests.scala
@@ -237,6 +237,69 @@ class ZeroWidthTests extends FirrtlFlatSpec {
         |    z <= asUInt(y)""".stripMargin
     (parse(exec(input))) should be(parse(check))
   }
+
+  "Memories with zero-width data-type" should "be fully removed" in {
+    val input =
+      """circuit Foo:
+        |  module Foo:
+        |    input clock: Clock
+        |    input rAddr: UInt<4>
+        |    input rEn: UInt<1>
+        |    output rData: UInt<0>
+        |    input wAddr: UInt<4>
+        |    input wEn: UInt<1>
+        |    input wMask: UInt<1>
+        |    input wData: UInt<0>
+        |    input rwEn: UInt<1>
+        |    input rwMode: UInt<1>
+        |    input rwAddr: UInt<1>
+        |    input rwMask: UInt<1>
+        |    input rwDataIn: UInt<0>
+        |    output rwDataOut: UInt<0>
+        |
+        |    mem memory:
+        |      data-type => UInt<0>
+        |      depth => 16
+        |      reader => r
+        |      writer => w
+        |      readwriter => rw
+        |      read-latency => 0
+        |      write-latency => 1
+        |      read-under-write => undefined
+        |
+        |    memory.r.clk <= clock
+        |    memory.r.en <= rEn
+        |    memory.r.addr <= rAddr
+        |    rData <= memory.r.data
+        |    memory.w.clk <= clock
+        |    memory.w.en <= wEn
+        |    memory.w.addr <= wAddr
+        |    memory.w.mask <= wMask
+        |    memory.w.data <= wData
+        |    memory.rw.clk <= clock
+        |    memory.rw.en <= rwEn
+        |    memory.rw.addr <= rwAddr
+        |    memory.rw.wmode <= rwMode
+        |    memory.rw.wmask <= rwMask
+        |    memory.rw.wdata <= rwDataIn
+        |    rwDataOut <= memory.rw.rdata""".stripMargin
+    val check =
+      s"""circuit Foo:
+        |  module Foo:
+        |    input clock: Clock
+        |    input rAddr: UInt<4>
+        |    input rEn: UInt<1>
+        |    input wAddr: UInt<4>
+        |    input wEn: UInt<1>
+        |    input wMask: UInt<1>
+        |    input rwEn: UInt<1>
+        |    input rwMode: UInt<1>
+        |    input rwAddr: UInt<1>
+        |    input rwMask: UInt<1>
+        |
+        |${Seq.tabulate(17)(_ => "    skip").mkString("\n")}""".stripMargin
+    parse(exec(input)) should be (parse(check))
+  }
 }
 
 class ZeroWidthVerilog extends FirrtlFlatSpec {


### PR DESCRIPTION
Correctly remove all extraneous connections to all types of memory
ports (read, write, readwrite) for zero-width memories.  Previously,
only read ports were correctly handled.

### Contributor Checklist

- [n/a] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
