### PR TITLE
Fix protoc handling in Mill

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -119,13 +119,16 @@ class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule wi
     millSourcePath / "src" / "main" / "proto" / "firrtl.proto"
   }
 
+  def protocJarVersion = "3.11.4"
+
   def downloadProtocJar = T.persistent {
-    Util.download(s"https://repo.maven.apache.org/maven2/com/github/os72/protoc-jar/$protocVersion/protoc-jar-$protocVersion.jar")
+    Util.download(s"https://repo.maven.apache.org/maven2/com/github/os72/protoc-jar/$protocJarVersion/protoc-jar-$protocJarVersion.jar")
   }
 
   def generatedProtoSources = T.sources {
     os.proc("java",
       "-jar", downloadProtocJar().path.toString,
+      "-v351",
       "-I", protobufSource().path / os.up,
       s"--java_out=${T.ctx.dest.toString}",
       protobufSource().path.toString()


### PR DESCRIPTION
Master is currently broken because you can't use the version of protobuf for the "protoc jar" which is a separate tool that downloads the right binary for protoc for your system.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix           


#### API Impact

None

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

   - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
