### PR TITLE
Fix Mill support for non-M1 Macs

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -139,6 +139,7 @@ class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule wi
 
     val protocBinary =
       if (isMac)
+        // MacOS ARM 64-bit still supports x86_64 binaries via Rosetta 2
         if (aarch_64 || x86_64) "osx-x86_64"
         else throw new Exception("mill cannot detect your architecture of your Mac")
       else if (isLinux)

--- a/build.sc
+++ b/build.sc
@@ -135,11 +135,11 @@ class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule wi
     val ppcle_64 = architecture().equals("ppc64le")
     val s390x = architecture().equals("s390x")
     val x86_32 = architecture().matches("^(x8632|x86|i[3-6]86|ia32|x32)$")
-    val x86_64 = architecture().matches("^(x8664|amd64|ia32e|em64t|x64)$")
+    val x86_64 = architecture().matches("^(x8664|amd64|ia32e|em64t|x64|x86_64)$")
 
     val protocBinary =
       if (isMac)
-        if (aarch_64) "osx-x86_64"
+        if (aarch_64 || x86_64) "osx-x86_64"
         else throw new Exception("mill cannot detect your architecture of your Mac")
       else if (isLinux)
         if (aarch_64) "linux-aarch_64"


### PR DESCRIPTION
Fixes bug in https://github.com/chipsalliance/firrtl/pull/2162

Honestly, I'm not sure how os72/protoc-jar works on Macs because the logic is similar to what @sequencer did in #2162 and that doesn't work on my Mac. Anyway, this fixes it.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix     


#### API Impact
No impact

#### Backend Code Generation Impact
No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
