### PR TITLE
Add memory initialization options for synthesis

### DIFF
--- a/src/main/scala/firrtl/annotations/MemoryInitAnnotation.scala
+++ b/src/main/scala/firrtl/annotations/MemoryInitAnnotation.scala
@@ -52,3 +52,8 @@ case class MemoryFileInlineAnnotation(
   override def initValue:    MemoryInitValue = MemoryFileInlineInit(filename, hexOrBinary)
   override def isRandomInit: Boolean = false
 }
+
+/** Defines the memory initialization target, inside or outside the `ifndef SYNTHESIS` block */
+trait MemoryInitTargetAnnotation extends NoTargetAnnotation
+case object MemoryNoSynthInit extends MemoryInitTargetAnnotation
+case object MemorySynthInit extends MemoryInitTargetAnnotation

--- a/src/main/scala/firrtl/annotations/MemoryInitAnnotation.scala
+++ b/src/main/scala/firrtl/annotations/MemoryInitAnnotation.scala
@@ -53,7 +53,8 @@ case class MemoryFileInlineAnnotation(
   override def isRandomInit: Boolean = false
 }
 
-/** Defines the memory initialization target, inside or outside the `ifndef SYNTHESIS` block */
-trait MemoryInitTargetAnnotation extends NoTargetAnnotation
-case object MemoryNoSynthInit extends MemoryInitTargetAnnotation
-case object MemorySynthInit extends MemoryInitTargetAnnotation
+/** Initializes the memory inside the `ifndef SYNTHESIS` block (default) */
+case object MemoryNoSynthInit extends NoTargetAnnotation
+
+/** Initializes the memory outside the `ifndef SYNTHESIS` block */
+case object MemorySynthInit extends NoTargetAnnotation


### PR DESCRIPTION
This PR adds options for memory initialization inside or outside the
`ifndef SYNTHESIS` block.

Fixes #2114.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- new feature/API

#### API Impact

This new feature adds memory initialization options for having the `readmem` blocks inside or outside the existing `ifndef SYNTHESIS`.

In the future, this parameter can be used by the `-target:fpga` PR (https://github.com/chipsalliance/firrtl/pull/2111) that is in development.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

This changes the generated Verilog code based on the parameters:

If using `MemoryNoSynthInit` (current default):

```verilog
...
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
  `endif // RANDOMIZE
  $readmemh("sample.hex", mem);
end // initial
`ifdef FIRRTL_AFTER_INITIAL
`FIRRTL_AFTER_INITIAL
`endif
`endif // SYNTHESIS
endmodule
```

If using `MemorySynthInit`:

```verilog
initial begin
  `ifdef RANDOMIZE
    `ifdef INIT_RANDOM
      `INIT_RANDOM
    `endif
    `ifndef VERILATOR
      `ifdef RANDOMIZE_DELAY
        #`RANDOMIZE_DELAY begin end
      `else
        #0.002 begin end
      `endif
    `endif
  `endif // RANDOMIZE
end // initial
`ifdef FIRRTL_AFTER_INITIAL
`FIRRTL_AFTER_INITIAL
`endif
`endif // SYNTHESIS
  initial begin
    $readmemh("sample.hex", mem);
  end
endmodule
```

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

This PR adds two annotations to determine how `readmem` statements are generated in Verilog code.
By default, it is placed inside the `ifndef SYNTHESIS` block which gets ignored by some FPGA tools.
One can add either `MemorySynthInit` or `MemoryNoSynthInit` (which is the default if not defined) annotation to change the behaviour and have the `readmem` outside this `ifndef` block.

In the future, MemorySynthInit could be set as default for FPGA targets (`-target:FPGA`).

TBD
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
