### PR TITLE
smt: use existing bitWidth API

### DIFF
--- a/src/main/scala/firrtl/Utils.scala
+++ b/src/main/scala/firrtl/Utils.scala
@@ -51,7 +51,18 @@ object getWidth {
   def apply(e: Expression): Width = apply(e.tpe)
 }
 
+/**
+  * Helper object for computing the width of a firrtl type.
+  */
 object bitWidth {
+
+  /**
+    * Compute the width of a firrtl type.
+    * For example, a Vec of 4 UInts of width 8 should have a width of 32.
+    *
+    * @param dt firrtl type
+    * @return Width of the given type
+    */
   def apply(dt:           Type): BigInt = widthOf(dt)
   private def widthOf(dt: Type): BigInt = dt match {
     case t: VectorType => t.size * bitWidth(t.tpe)

--- a/src/main/scala/firrtl/backends/experimental/smt/FirrtlExpressionSemantics.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/FirrtlExpressionSemantics.scala
@@ -8,19 +8,10 @@ import firrtl.PrimOps
 import firrtl.passes.CheckWidths.WidthTooBig
 
 private trait TranslationContext {
-  def getReference(name: String, tpe: ir.Type): BVExpr = BVSymbol(name, FirrtlExpressionSemantics.getWidth(tpe))
+  def getReference(name: String, tpe: ir.Type): BVExpr = BVSymbol(name, firrtl.bitWidth(tpe).toInt)
 }
 
 private object FirrtlExpressionSemantics {
-  def getWidth(tpe: ir.Type): Int = tpe match {
-    case ir.UIntType(ir.IntWidth(w))   => w.toInt
-    case ir.SIntType(ir.IntWidth(w))   => w.toInt
-    case ir.ClockType                  => 1
-    case ir.ResetType                  => 1
-    case ir.AnalogType(ir.IntWidth(w)) => w.toInt
-    case other                         => throw new RuntimeException(s"Cannot handle type $other")
-  }
-
   def toSMT(e: ir.Expression)(implicit ctx: TranslationContext): BVExpr = {
     val eSMT = e match {
       case ir.DoPrim(op, args, consts, _) => onPrim(op, args, consts)
@@ -183,5 +174,7 @@ private object FirrtlExpressionSemantics {
     case _: ir.SIntType => true
     case _ => false
   }
-  private def getWidth(e: ir.Expression): Int = getWidth(e.tpe)
+
+  // Helper function
+  private def getWidth(e: ir.Expression): Int = firrtl.bitWidth(e.tpe).toInt
 }


### PR DESCRIPTION
#### Type of Improvement

refactoring/documentation

#### API Impact
no impact
#### Backend Code Generation Impact
should have no impact
#### Desired Merge Strategy
squash
#### Release Notes
Refactor SMT backend to use the existing public API `firrtl.bitWidth`.
Also adds scaladoc to `firrtl.bitWidth`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
