### PR TITLE
Add indent parameter to Serializer.serialize()

### DIFF
--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -11,7 +11,8 @@ object Serializer {
   val Indent = "  "
 
   /** Converts a `FirrtlNode` into its string representation with
-    * default indentation. */
+    * default indentation.
+    */
   def serialize(node: FirrtlNode): String = {
     serialize(node, 0)
   }

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -10,29 +10,29 @@ object Serializer {
   val NewLine = '\n'
   val Indent = "  "
 
-  /** Converts a `FirrtlNode` into its string representation
-   * with *zero* indents (old behavior for binary compatibility) */
+  /** Converts a `FirrtlNode` into its string representation with
+    * default indentation. */
   def serialize(node: FirrtlNode): String = {
     serialize(node, 0)
   }
 
   /** Converts a `FirrtlNode` into its string representation. */
-  def serialize(node: FirrtlNode, indents: Int): String = {
+  def serialize(node: FirrtlNode, indent: Int): String = {
     val builder = new StringBuilder()
     node match {
-      case n: Info        => s(n)(builder, indents)
-      case n: StringLit   => s(n)(builder, indents)
-      case n: Expression  => s(n)(builder, indents)
-      case n: Statement   => s(n)(builder, indents)
-      case n: Width       => s(n)(builder, indents)
-      case n: Orientation => s(n)(builder, indents)
-      case n: Field       => s(n)(builder, indents)
-      case n: Type        => s(n)(builder, indents)
-      case n: Direction   => s(n)(builder, indents)
-      case n: Port        => s(n)(builder, indents)
-      case n: Param       => s(n)(builder, indents)
-      case n: DefModule   => s(n)(builder, indents)
-      case n: Circuit     => s(n)(builder, indents)
+      case n: Info        => s(n)(builder, indent)
+      case n: StringLit   => s(n)(builder, indent)
+      case n: Expression  => s(n)(builder, indent)
+      case n: Statement   => s(n)(builder, indent)
+      case n: Width       => s(n)(builder, indent)
+      case n: Orientation => s(n)(builder, indent)
+      case n: Field       => s(n)(builder, indent)
+      case n: Type        => s(n)(builder, indent)
+      case n: Direction   => s(n)(builder, indent)
+      case n: Port        => s(n)(builder, indent)
+      case n: Param       => s(n)(builder, indent)
+      case n: DefModule   => s(n)(builder, indent)
+      case n: Circuit     => s(n)(builder, indent)
       case other => builder ++= other.serialize // Handle user-defined nodes
     }
     builder.toString()

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -10,24 +10,29 @@ object Serializer {
   val NewLine = '\n'
   val Indent = "  "
 
-  /** Converts a `FirrtlNode` into its string representation. */
+  /** Converts a `FirrtlNode` into its string representation
+   * with *zero* indents (old behavior for binary compatibility) */
   def serialize(node: FirrtlNode): String = {
+    serialize(node, 0)
+  }
+
+  /** Converts a `FirrtlNode` into its string representation. */
+  def serialize(node: FirrtlNode, indents: Int): String = {
     val builder = new StringBuilder()
-    val indent = 0
     node match {
-      case n: Info        => s(n)(builder, indent)
-      case n: StringLit   => s(n)(builder, indent)
-      case n: Expression  => s(n)(builder, indent)
-      case n: Statement   => s(n)(builder, indent)
-      case n: Width       => s(n)(builder, indent)
-      case n: Orientation => s(n)(builder, indent)
-      case n: Field       => s(n)(builder, indent)
-      case n: Type        => s(n)(builder, indent)
-      case n: Direction   => s(n)(builder, indent)
-      case n: Port        => s(n)(builder, indent)
-      case n: Param       => s(n)(builder, indent)
-      case n: DefModule   => s(n)(builder, indent)
-      case n: Circuit     => s(n)(builder, indent)
+      case n: Info        => s(n)(builder, indents)
+      case n: StringLit   => s(n)(builder, indents)
+      case n: Expression  => s(n)(builder, indents)
+      case n: Statement   => s(n)(builder, indents)
+      case n: Width       => s(n)(builder, indents)
+      case n: Orientation => s(n)(builder, indents)
+      case n: Field       => s(n)(builder, indents)
+      case n: Type        => s(n)(builder, indents)
+      case n: Direction   => s(n)(builder, indents)
+      case n: Port        => s(n)(builder, indents)
+      case n: Param       => s(n)(builder, indents)
+      case n: DefModule   => s(n)(builder, indents)
+      case n: Circuit     => s(n)(builder, indents)
       case other => builder ++= other.serialize // Handle user-defined nodes
     }
     builder.toString()


### PR DESCRIPTION
#### Type of Improvement

Code refactoring

#### API Impact

No impact

#### Backend Code Generation Impact

Should not impact code generation

#### Desired Merge Strategy

Squash

#### Release Notes

Add indentation parameter to `Serializer.serialize()` to indent `FirrtlNode` strings by a certain amount.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
