### PR TITLE
Hoist Transform timing to the Phase level

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -210,22 +210,9 @@ final case object UnknownForm extends CircuitForm(-1) {
 // Internal utilities to keep code DRY, not a clean interface
 private[firrtl] object Transform {
 
-  // Run transform with logging
-  def runTransform(name: String, mk: => CircuitState, logger: Logger): CircuitState = {
-    logger.info(s"======== Starting Transform $name ========")
-
-    val (timeMillis, result) = Utils.time(mk)
-
-    logger.info(s"""----------------------------${"-" * name.size}---------\n""")
-    logger.info(f"Time: $timeMillis%.1f ms")
-
-    result
-  }
-
   def remapAnnotations(name: String, before: CircuitState, after: CircuitState, logger: Logger): CircuitState = {
     val remappedAnnotations = propagateAnnotations(name, logger, before.annotations, after.annotations, after.renames)
 
-    logger.info(s"Form: ${after.form}")
     logger.trace(s"Annotations:")
     logger.trace {
       JsonProtocol
@@ -240,7 +227,6 @@ private[firrtl] object Transform {
     }
 
     logger.trace(s"Circuit:\n${after.circuit.serialize}")
-    logger.info(s"======== Finished Transform $name ========\n")
 
     CircuitState(after.circuit, after.form, remappedAnnotations, None)
   }
@@ -385,7 +371,7 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
     * @return A transformed Firrtl AST
     */
   final def runTransform(state: CircuitState): CircuitState = {
-    val result = Transform.runTransform(name, execute(prepare(state)), logger)
+    val result = execute(prepare(state))
     Transform.remapAnnotations(name, state, result, logger)
   }
 

--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -275,7 +275,14 @@ trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends 
                 |  prerequisites: ${prerequisites.mkString("\n    -", "\n    -", "")}""".stripMargin
           )
         }
-        (t.transform(a), ((state + wrapperToClass(t)).map(dToO).filterNot(t.invalidates).map(oToD)))
+        val logger = t.getLogger
+        logger.info(s"======== Starting ${t.name} ========")
+        val (timeMillis, annosx) = firrtl.Utils.time { t.transform(a) }
+        logger.info(s"""----------------------------${"-" * t.name.size}---------\n""")
+        logger.info(f"Time: $timeMillis%.1f ms")
+        logger.info(s"======== Finished ${t.name} ========")
+        val statex = (state + wrapperToClass(t)).map(dToO).filterNot(t.invalidates).map(oToD)
+        (annosx, statex)
     }._1
   }
 

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -19,7 +19,7 @@ class UpdateAnnotations(val underlying: Transform)
   }
 
   def internalTransform(b: (CircuitState, CircuitState)): (CircuitState, CircuitState) = {
-    val result = Transform.runTransform(name, underlying.transform(b._2), logger)
+    val result = underlying.transform(b._2)
     (b._1, result)
   }
 }

--- a/src/main/scala/logger/Logger.scala
+++ b/src/main/scala/logger/Logger.scala
@@ -47,6 +47,7 @@ object LogLevel extends Enumeration {
   */
 trait LazyLogging {
   protected val logger = new Logger(this.getClass.getName)
+  def getLogger: Logger = logger
 }
 
 /**


### PR DESCRIPTION
With Stage/Phase, users can provide complex functionality at the phase
level rather than just the transform level. It is useful to have the
same logging information at that level. Note that this change still logs
transforms in the same way, but now the time in inclusive of annotation
renaming which can also [unfortunately] be slow.

I think this is the right idea although I'm not certain if it's the right way to do it.

The 3 nice things about this PR:
1. Phases are now timed
2. Parsing is timed (because of the above)
3. Transform timing is inclusive of annotation renaming (sometimes it's slow so the times are deceiving)

One thing that is missing is emission, that isn't timed here.

This changes the output from something like:
```
[info] running (fork) firrtl.stage.FirrtlMain -i e20.pb -o out -X verilog -ll info             
[info] Computed transform order in: 325.3 ms                                                   
[info] Determined Transform order that will be executed:                 
[info]   firrtl.stage.transforms.Compiler                                
[info]   ├── firrtl.transforms.formal.ConvertAsserts$                                          
[info]   ├── firrtl.transforms.formal.RemoveVerificationStatements               
[info]   ├── firrtl.stage.transforms.CheckScalaVersion
                                        .
                                        .
                                        .
[info] ======== Finished Transform firrtl.passes.VerilogPrep$ ========
[info] ======== Starting Transform firrtl.AddDescriptionNodes ========
[info] ---------------------------------------------------------------
[info] Time: 18.3 ms
[info] Form: UnknownForm
[info] ======== Finished Transform firrtl.AddDescriptionNodes ========
[info] ----------------------------------------------------------
[info] Time: 3047.8 ms
[info] Form: UnknownForm
[info] ======== Finished Transform firrtl.VerilogEmitter ========
[info] Total FIRRTL Compile Time: 36514.0 ms
[success] Total time: 75 s (01:15), completed Apr 16, 2021 6:13:46 PM
```


To:
```
[info] running (fork) firrtl.stage.FirrtlMain -i design.pb -o out -X verilog -ll info 
[info] ======== Starting firrtl.stage.phases.ConvertCompilerAnnotations ========             
[info] -----------------------------------------------------------------------------------
[info] Time: 1.2 ms                                                                
[info] ======== Finished firrtl.stage.phases.ConvertCompilerAnnotations ========
[info] ======== Starting firrtl.stage.phases.AddDefaults ========           
[info] --------------------------------------------------------------------
[info] Time: 1.9 ms                                                          
[info] ======== Finished firrtl.stage.phases.AddDefaults ========
[info] ======== Starting firrtl.stage.phases.AddImplicitEmitter ========
[info] ---------------------------------------------------------------------------
[info] Time: 1.7 ms                                                                 
[info] ======== Finished firrtl.stage.phases.AddImplicitEmitter ========
[info] ======== Starting firrtl.stage.phases.Checks ========                 
[info] ---------------------------------------------------------------                 
[info] Time: 1.5 ms                                                                              
[info] ======== Finished firrtl.stage.phases.Checks ======== 
[info] ======== Starting firrtl.stage.phases.AddCircuit ========                       
[info] ------------------------------------------------------------------- 
[info] Time: 1195.1 ms                                                               
[info] ======== Finished firrtl.stage.phases.AddCircuit ========
[info] ======== Starting firrtl.stage.phases.AddImplicitOutputFile ========
[info] ------------------------------------------------------------------------------
[info] Time: 1.1 ms                                                                            
[info] ======== Finished firrtl.stage.phases.AddImplicitOutputFile ========
[info] ======== Starting firrtl.stage.phases.Compiler ========                       
[info] Computed transform order in: 254.5 ms                   
[info] Determined Transform order that will be executed:                 
[info]   firrtl.stage.transforms.Compiler                        
[info]   ├── firrtl.transforms.formal.ConvertAsserts$                      
[info]   ├── firrtl.transforms.formal.RemoveVerificationStatements
[info]   ├── firrtl.stage.transforms.CheckScalaVersion                
                                        .
                                        .
                                        .
[info] ======== Finished firrtl.VerilogEmitter ========
[info] Total FIRRTL Compile Time: 38135.3 ms
[info] -----------------------------------------------------------------
[info] Time: 38462.8 ms                   
[info] ======== Finished firrtl.stage.phases.Compiler ========
[success] Total time: 63 s (01:03), completed Apr 16, 2021 6:06:39 PM
```

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
