### PR TITLE
Deprecate memlib APIs.

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/CreateMemoryAnnotations.scala
+++ b/src/main/scala/firrtl/passes/memlib/CreateMemoryAnnotations.scala
@@ -6,6 +6,7 @@ package memlib
 
 import firrtl.stage.Forms
 
+@deprecated("CreateMemoryAnnotations will not take reader: Option[YamlFileReader] as argument since 1.5.", "FIRRTL 1.4")
 class CreateMemoryAnnotations(reader: Option[YamlFileReader]) extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -24,6 +24,7 @@ object ReplaceMemMacros {
   * This will not generate wmask ports if not needed.
   * Creates the minimum # of black boxes needed by the design.
   */
+@deprecated("ReplaceMemMacros will not take writer: ConfWriter as argument since 1.5.", "FIRRTL 1.4")
 class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
@@ -121,11 +122,14 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
     })
   )
 
+  @deprecated("memToBundle will become private in 1.5.", "FIRRTL 1.4")
   def memToBundle(s: DefAnnotatedMemory) = BundleType(
     s.readers.map(Field(_, Flip, rPortToBundle(s))) ++
       s.writers.map(Field(_, Flip, wPortToBundle(s))) ++
       s.readwriters.map(Field(_, Flip, rwPortToBundle(s)))
   )
+
+  @deprecated("memToFlattenBundle will become private in 1.5.", "FIRRTL 1.4")
   def memToFlattenBundle(s: DefAnnotatedMemory) = BundleType(
     s.readers.map(Field(_, Flip, rPortToFlattenBundle(s))) ++
       s.writers.map(Field(_, Flip, wPortToFlattenBundle(s))) ++
@@ -136,6 +140,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
     *  The wrapper module has the same type as the memory it replaces
     *  The external module
     */
+  @deprecated("createMemModule will become private in 1.5.", "FIRRTL 1.4")
   def createMemModule(m: DefAnnotatedMemory, wrapperName: String): Seq[DefModule] = {
     assert(m.dataType != UnknownType)
     val wrapperIoType = memToBundle(m)
@@ -162,18 +167,22 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
 
   // TODO(shunshou): get rid of copy pasta
   // Connects the clk, en, and addr fields from the wrapperPort to the bbPort
+  @deprecated("defaultConnects will become private in 1.5.", "FIRRTL 1.4")
   def defaultConnects(wrapperPort: WRef, bbPort: WSubField): Seq[Connect] =
     Seq("clk", "en", "addr").map(f => connectFields(bbPort, f, wrapperPort, f))
 
   // Generates mask bits (concatenates an aggregate to ground type)
   // depending on mask granularity (# bits = data width / mask granularity)
+  @deprecated("maskBits will become private in 1.5.", "FIRRTL 1.4")
   def maskBits(mask: WSubField, dataType: Type, fillMask: Boolean): Expression =
     if (fillMask) toBitMask(mask, dataType) else toBits(mask)
 
+  @deprecated("adaptReader will become private in 1.5.", "FIRRTL 1.4")
   def adaptReader(wrapperPort: WRef, bbPort: WSubField): Seq[Statement] =
     defaultConnects(wrapperPort, bbPort) :+
       fromBits(WSubField(wrapperPort, "data"), WSubField(bbPort, "data"))
 
+  @deprecated("adaptWriter will become private in 1.5.", "FIRRTL 1.4")
   def adaptWriter(wrapperPort: WRef, bbPort: WSubField, hasMask: Boolean, fillMask: Boolean): Seq[Statement] = {
     val wrapperData = WSubField(wrapperPort, "data")
     val defaultSeq = defaultConnects(wrapperPort, bbPort) :+
@@ -189,6 +198,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
     }
   }
 
+  @deprecated("adaptReadWriter will become private in 1.5.", "FIRRTL 1.4")
   def adaptReadWriter(wrapperPort: WRef, bbPort: WSubField, hasMask: Boolean, fillMask: Boolean): Seq[Statement] = {
     val wrapperWData = WSubField(wrapperPort, "wdata")
     val defaultSeq = defaultConnects(wrapperPort, bbPort) ++ Seq(
@@ -211,6 +221,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
   private type NameMap = collection.mutable.HashMap[(String, String), String]
 
   /** Construct NameMap by assigning unique names for each memory blackbox */
+  @deprecated("constructNameMap will become private in 1.5.", "FIRRTL 1.4")
   def constructNameMap(namespace: Namespace, nameMap: NameMap, mname: String)(s: Statement): Statement = {
     s match {
       case m: DefAnnotatedMemory =>
@@ -223,6 +234,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
     s.map(constructNameMap(namespace, nameMap, mname))
   }
 
+  @deprecated("updateMemStmts will be private in 1.5.", "FIRRTL 1.4")
   def updateMemStmts(
     namespace:  Namespace,
     nameMap:    NameMap,
@@ -250,6 +262,7 @@ class ReplaceMemMacros(writer: ConfWriter) extends Transform with DependencyAPIM
     case sx => sx.map(updateMemStmts(namespace, nameMap, mname, memPortMap, memMods))
   }
 
+  @deprecated("updateMemMods will be private in 1.5.", "FIRRTL 1.4")
   def updateMemMods(namespace: Namespace, nameMap: NameMap, memMods: Modules)(m: DefModule) = {
     val memPortMap = new MemPortMap
 

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -43,6 +43,7 @@ object PassConfigUtil {
   }
 }
 
+@deprecated("ConfWriter will be removed in 1.5.", "FIRRTL 1.4")
 class ConfWriter(filename: String) {
   val outputBuffer = new CharArrayWriter
   def append(m: DefAnnotatedMemory) = {
@@ -111,6 +112,7 @@ class SimpleTransform(p: Pass, form: CircuitForm) extends Transform {
 class SimpleMidTransform(p: Pass) extends SimpleTransform(p, MidForm)
 
 // SimpleRun instead of PassBased because of the arguments to passSeq
+@deprecated("Migrate to a SeqTransform. API will be changed in 1.5.", "FIRRTL 1.4")
 class ReplSeqMem extends Transform with HasShellOptions with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
@@ -132,6 +134,7 @@ class ReplSeqMem extends Transform with HasShellOptions with DependencyAPIMigrat
     )
   )
 
+  @deprecated("API will be replaced with a val in 1.5.", "FIRRTL 1.4")
   def transforms(inConfigFile: Option[YamlFileReader], outConfigFile: ConfWriter): Seq[Transform] =
     Seq(
       new SimpleMidTransform(Legalize),
@@ -144,6 +147,7 @@ class ReplSeqMem extends Transform with HasShellOptions with DependencyAPIMigrat
       new WiringTransform
     )
 
+  @deprecated("API will be removed in 1.5.", "FIRRTL 1.4")
   def execute(state: CircuitState): CircuitState = {
     val annos = state.annotations.collect { case a: ReplSeqMemAnnotation => a }
     annos match {

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -30,6 +30,7 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
     }
   )
 
+  @deprecated("API will be changed in 1.5.", "FIRRTL 1.4")
   def checkMemConf(filename: String, mems: Set[MemConf]) {
     // Read the mem conf
     val text = FileUtils.getText(filename)


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code refactoring

#### API Impact
deprecate APIs:
CreateMemoryAnnotations
ConfWriter
ReplSeqMem
ReplaceMemMacros and its functions:
.memToBundle
.memToFlattenBundle
.createMemModule
.defaultConnects
.maskBits
.adaptReader
.adaptWriter
.adaptReadWriter
.constructNameMap
.updateMemStmts
.updateMemMods

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?