### PR TITLE
Use os-lib to rewrite Z3ModelChecker

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val firrtlSettings = Seq(
     "org.json4s" %% "json4s-native" % "3.6.11",
     "org.apache.commons" % "commons-text" % "1.8",
     "io.github.alexarchambault" %% "data-class" % "0.2.5",
+    "com.lihaoyi" %% "os-lib" % "0.7.6",
   ),
   // macros for the data-class library
   libraryDependencies ++= {

--- a/build.sc
+++ b/build.sc
@@ -45,7 +45,8 @@ class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule wi
       ivy"org.apache.commons:commons-text:1.8",
       ivy"io.github.alexarchambault::data-class:0.2.5",
       ivy"org.antlr:antlr4-runtime:$antlr4Version",
-      ivy"com.google.protobuf:protobuf-java:$protocVersion"
+      ivy"com.google.protobuf:protobuf-java:$protocVersion",
+      ivy"com.lihaoyi::os-lib:0.7.6",
     ) ++ {
       if (majorVersion == 13)
         Agg(ivy"org.scala-lang.modules::scala-parallel-collections:1.0.3")

--- a/src/test/scala/firrtl/backends/experimental/smt/end2end/EndToEndSMTSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/end2end/EndToEndSMTSpec.scala
@@ -2,16 +2,15 @@
 
 package firrtl.backends.experimental.smt.end2end
 
-import java.io.{File, PrintWriter}
-
 import firrtl.annotations.{Annotation, CircuitTarget, PresetAnnotation}
 import firrtl.backends.experimental.smt.{Btor2Emitter, SMTLibEmitter}
 import firrtl.options.TargetDirAnnotation
 import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlStage, OutputFileAnnotation, RunFirrtlTransformAnnotation}
-import firrtl.util.BackendCompilationUtilities
+import firrtl.util.BackendCompilationUtilities.timeStamp
 import logger.{LazyLogging, LogLevel, LogLevelAnnotation}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
+import os._
 
 import scala.sys.process._
 
@@ -132,7 +131,10 @@ abstract class EndToEndSMTBaseSpec extends AnyFlatSpec with Matchers {
     }
     val fir = firrtl.Parser.parse(src)
     val name = fir.main
-    val testDir = BackendCompilationUtilities.createTestDirectory("EndToEndSMT." + name)
+    // @todo rewrite BackendCompilationUtilities
+    val testBaseDir = os.pwd / "test_run_dir" / s"EndToEndSMT.$name"
+    os.makeDir.all(testBaseDir)
+    val testDir = os.temp.dir(testBaseDir, timeStamp, deleteOnExit = false)
     // we automagically add a preset annotation if an input called preset exists
     val presetAnno = if (!src.contains("input preset")) { None }
     else {
@@ -145,7 +147,7 @@ abstract class EndToEndSMTBaseSpec extends AnyFlatSpec with Matchers {
         RunFirrtlTransformAnnotation(new SMTLibEmitter),
         RunFirrtlTransformAnnotation(new Btor2Emitter),
         FirrtlCircuitAnnotation(fir),
-        TargetDirAnnotation(testDir.getAbsolutePath)
+        TargetDirAnnotation(testDir.toString)
       ) ++ presetAnno ++ annos
     )
     assert(res.collectFirst { case _: OutputFileAnnotation => true }.isDefined)
@@ -167,42 +169,32 @@ private object Z3ModelChecker extends LazyLogging {
     version
   }
 
-  def bmc(testDir: File, main: String, kmax: Int): MCResult = {
+  def bmc(testDir: Path, main: String, kmax: Int): MCResult = {
     assert(kmax >= 0 && kmax < 50, "Trying to keep kmax in a reasonable range.")
-    val smtFile = new File(testDir, main + ".smt2")
-    val header = read(smtFile)
-    val steps = (0 to kmax).map(k => new File(testDir, main + s"_step$k.smt2")).zipWithIndex
-    steps.foreach {
-      case (f, k) =>
-        writeStep(f, main, header, k)
-        val success = executeStep(f.getAbsolutePath)
-        if (!success) return MCFail(k)
+    Seq.tabulate(kmax + 1) { k =>
+      val stepFile = testDir / s"${main}_step$k.smt2"
+      os.copy(testDir / s"$main.smt2", stepFile)
+      os.write.append(stepFile, s"""${step(main, k)}
+                                   |(check-sat)
+                                   |""".stripMargin)
+      if (!executeStep(stepFile)) return MCFail(k)
     }
     MCSuccess
   }
 
-  private def executeStep(filename: String): Boolean = {
-    val (out, ret) = executeCmd(filename)
-    assert(ret == 0, s"expected success (0), not $ret: `$out`\nz3 $filename")
-    assert(out == "sat" || out == "unsat", s"Unexpected output: $out")
-    out == "unsat"
+  private def executeStep(path: Path): Boolean = {
+    val (out, ret) = executeCmd(path.toString)
+    assert(ret == 0, s"expected success (0), not $ret: `$out`\nz3 ${path.toString}")
+    assert(out == "sat\n" || out == "unsat\n", s"Unexpected output: $out")
+    out == "unsat\n"
   }
 
   private def executeCmd(cmd: String): (String, Int) = {
-    var out = ""
-    val log = ProcessLogger(s => out = s, logger.warn(_))
-    val ret = Process(Seq("z3", cmd)).run(log).exitValue()
-    (out, ret)
+    val process = os.proc("z3", cmd).call(stderr = ProcessOutput.Readlines(logger.warn(_)))
+    (process.out.chunks.mkString, process.exitCode)
   }
 
-  private def writeStep(f: File, main: String, header: Iterable[String], k: Int): Unit = {
-    val pw = new PrintWriter(f)
-    val lines = header ++ step(main, k) ++ List("(check-sat)")
-    lines.foreach(pw.println)
-    pw.close()
-  }
-
-  private def step(main: String, k: Int): Iterable[String] = {
+  private def step(main: String, k: Int): String = {
     // define all states
     (0 to k).map(ii => s"(declare-fun s$ii () $main$StateTpe)") ++
       // assert that init holds in state 0
@@ -215,13 +207,7 @@ private object Z3ModelChecker extends LazyLogging {
       (0 until k).map(ii => s"(assert ($main$Asserts s$ii))") ++
       // check to see if we can violate the assertions in the last state
       List(s"(assert (not ($main$Asserts s$k)))")
-  }
-
-  private def read(f: File): Iterable[String] = {
-    val source = scala.io.Source.fromFile(f)
-    try source.getLines().toVector
-    finally source.close()
-  }
+  }.mkString("\n")
 
   // the following suffixes have to match the ones in [[SMTTransitionSystemEncoder]]
   private val Transition = "_t"

--- a/src/test/scala/firrtl/backends/experimental/smt/end2end/EndToEndSMTSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/end2end/EndToEndSMTSpec.scala
@@ -171,13 +171,14 @@ private object Z3ModelChecker extends LazyLogging {
 
   def bmc(testDir: Path, main: String, kmax: Int): MCResult = {
     assert(kmax >= 0 && kmax < 50, "Trying to keep kmax in a reasonable range.")
-    Seq.tabulate(kmax + 1) { k =>
+    (0 to kmax).foreach { k =>
       val stepFile = testDir / s"${main}_step$k.smt2"
       os.copy(testDir / s"$main.smt2", stepFile)
       os.write.append(stepFile, s"""${step(main, k)}
                                    |(check-sat)
                                    |""".stripMargin)
-      if (!executeStep(stepFile)) return MCFail(k)
+      val success = executeStep(stepFile)
+      if (!success) return MCFail(k)
     }
     MCSuccess
   }


### PR DESCRIPTION
This PR doesn't add any public API or create any API modification and provides a simple example for #2219
After #2219 merged, I'll create a series of PRs like this to retire `java.io.File` gradually.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
<!--   - code refactoring                   -->

#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
