### PR TITLE
Add JsonProtocol.serializeRecover

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -214,17 +214,7 @@ private[firrtl] object Transform {
     val remappedAnnotations = propagateAnnotations(name, logger, before.annotations, after.annotations, after.renames)
 
     logger.trace(s"Annotations:")
-    logger.trace {
-      JsonProtocol
-        .serializeTry(remappedAnnotations)
-        .recoverWith {
-          case NonFatal(e) =>
-            val msg = s"Exception thrown during Annotation serialization:\n  " +
-              e.toString.replaceAll("\n", "\n  ")
-            Try(msg)
-        }
-        .get
-    }
+    logger.trace(JsonProtocol.serializeRecover(remappedAnnotations))
 
     logger.trace(s"Circuit:\n${after.circuit.serialize}")
 

--- a/src/test/scala/firrtlTests/annotationTests/JsonProtocolSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/JsonProtocolSpec.scala
@@ -3,9 +3,10 @@
 package firrtlTests.annotationTests
 
 import firrtl._
-import firrtl.annotations.{JsonProtocol, NoTargetAnnotation, UnserializableAnnotationException}
+import firrtl.annotations._
 import firrtl.ir._
 import firrtl.options.Dependency
+import firrtl.transforms.DontTouchAnnotation
 import scala.util.Failure
 import _root_.logger.{LogLevel, LogLevelAnnotation, Logger}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -76,5 +77,14 @@ class JsonProtocolSpec extends AnyFlatSpec with Matchers {
         // From json4s Exception
         e.getMessage should include("Classes defined in method bodies are not supported")
     }
+  }
+  "JsonProtocol.serializeRecover" should "emit even annotations that cannot be serialized" in {
+    case class MyAnno(x: Int) extends NoTargetAnnotation
+    val target = CircuitTarget("Top").module("Foo").ref("x")
+    val annos = MyAnno(3) :: DontTouchAnnotation(target) :: Nil
+    val res = JsonProtocol.serializeRecover(annos)
+    res should include(""""class":"firrtl.annotations.UnserializeableAnnotation",""")
+    res should include(""""error":"Classes defined in method bodies are not supported.",""")
+    res should include(""""content":"MyAnno(3)"""")
   }
 }


### PR DESCRIPTION
This function will safely wrap any unserializeable annotations in
UnserializeableAnnotations so that they can be safely serialized to JSON
for logging.

Follow on to https://github.com/chipsalliance/firrtl/pull/1885, makes `-ll trace` *much* more useful if you happen to have 1 unserializable annotation making your whole log worthless.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- new feature/API   

#### API Impact

There is a new public method, `JsonProtocol.serializeRecover` which will always succeed because it wraps any unserializable annotations in `UnserializableAnnotations` with the error and `.toString` of the underlying `Annotation` as contents.

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

   - Squash

#### Release Notes

* Add new `JsonProtocol.serializeRecover` which wraps unserializable annotations in `UnserializableAnnotations` so that a valid JSON is always created.
* Use this new API in `--log-level trace` so that the logged annotations are always useful, even when there are unserializable annotations

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
