### PR TITLE
Fix renaming of local targets in InlineInstances

### DIFF
--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -200,7 +200,10 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
               renameMap.record(currentModule.ofModuleTarget.ref(name), nextModule.ref(prefix + name))
               renameMap.record(currentModule.ref(name), nextModule.ref(prefix + name))
             case Some(ofModule) =>
-              renameMap.record(currentModule.ofModuleTarget.instOf(name, ofModule), nextModule.instOf(prefix + name, ofModule))
+              renameMap.record(
+                currentModule.ofModuleTarget.instOf(name, ofModule),
+                nextModule.instOf(prefix + name, ofModule)
+              )
               renameMap.record(currentModule.instOf(name, ofModule), nextModule.instOf(prefix + name, ofModule))
           }
           renames(name) = prefix + name

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -179,7 +179,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
 
     /** Add a prefix to all declarations updating a [[Namespace]] and appending to a [[RenameMap]] */
     def appendNamePrefix(
-      currentModule: IsModule,
+      currentModule: InstanceTarget,
       nextModule:    IsModule,
       prefix:        String,
       ns:            Namespace,
@@ -197,8 +197,10 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
           }
           ofModuleOpt match {
             case None =>
+              renameMap.record(currentModule.ofModuleTarget.ref(name), nextModule.ref(prefix + name))
               renameMap.record(currentModule.ref(name), nextModule.ref(prefix + name))
             case Some(ofModule) =>
+              renameMap.record(currentModule.ofModuleTarget.instOf(name, ofModule), nextModule.instOf(prefix + name, ofModule))
               renameMap.record(currentModule.instOf(name, ofModule), nextModule.instOf(prefix + name, ofModule))
           }
           renames(name) = prefix + name
@@ -348,7 +350,6 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
             .map(appendRefPrefix(inlineTarget, prefixMap))
 
           renames.record(inlineTarget, currentModule)
-
           renamedBody
         case sx =>
           sx

--- a/src/test/scala/firrtlTests/InlineInstancesTests.scala
+++ b/src/test/scala/firrtlTests/InlineInstancesTests.scala
@@ -596,7 +596,7 @@ class InlineInstancesTests extends LowTransformSpec {
         DummyAnno(innerNestedInlined.ref("b")),
         DummyAnno(inlineModuleTarget.instOf("bar", "NestedNoInline")),
         DummyAnno(inlineModuleTarget.ref("a"), inlineModuleTarget.ref("b")),
-        DummyAnno(nestedInlineModuleTarget.ref("a")),
+        DummyAnno(nestedInlineModuleTarget.ref("a"))
       ),
       Seq(
         DummyAnno(top.ref("i_a")),
@@ -609,7 +609,7 @@ class InlineInstancesTests extends LowTransformSpec {
         DummyAnno(top.instOf("i_bar", "NestedNoInline").ref("foo_b")),
         DummyAnno(top.instOf("i_bar", "NestedNoInline")),
         DummyAnno(top.ref("i_a"), top.ref("i_b")),
-        DummyAnno(top.ref("i_foo_a"), top.copy(module = "NestedNoInline").ref("foo_a")),
+        DummyAnno(top.ref("i_foo_a"), top.copy(module = "NestedNoInline").ref("foo_a"))
       )
     )
   }

--- a/src/test/scala/firrtlTests/InlineInstancesTests.scala
+++ b/src/test/scala/firrtlTests/InlineInstancesTests.scala
@@ -380,8 +380,12 @@ class InlineInstancesTests extends LowTransformSpec {
     execute(input, check, Seq(inline("Inline")))
   }
 
-  case class DummyAnno(target: ReferenceTarget) extends SingleTargetAnnotation[ReferenceTarget] {
-    override def duplicate(n: ReferenceTarget): Annotation = DummyAnno(n)
+  case class DummyAnno(targets: CompleteTarget*) extends Annotation {
+    override def update(renames: RenameMap): Seq[Annotation] = {
+      Seq(DummyAnno(targets.flatMap { t =>
+        renames.get(t).getOrElse(Seq(t))
+      }: _*))
+    }
   }
   "annotations" should "be renamed" in {
     val input =
@@ -573,6 +577,9 @@ class InlineInstancesTests extends LowTransformSpec {
     val nestedNotInlined = inlined.instOf("bar", "NestedNoInline")
     val innerNestedInlined = nestedNotInlined.instOf("foo", "NestedInline")
 
+    val inlineModuleTarget = top.copy(module = "Inline")
+    val nestedInlineModuleTarget = top.copy(module = "NestedInline")
+
     executeWithAnnos(
       input,
       check,
@@ -586,7 +593,10 @@ class InlineInstancesTests extends LowTransformSpec {
         DummyAnno(nestedNotInlined.ref("a")),
         DummyAnno(nestedNotInlined.ref("b")),
         DummyAnno(innerNestedInlined.ref("a")),
-        DummyAnno(innerNestedInlined.ref("b"))
+        DummyAnno(innerNestedInlined.ref("b")),
+        DummyAnno(inlineModuleTarget.instOf("bar", "NestedNoInline")),
+        DummyAnno(inlineModuleTarget.ref("a"), inlineModuleTarget.ref("b")),
+        DummyAnno(nestedInlineModuleTarget.ref("a")),
       ),
       Seq(
         DummyAnno(top.ref("i_a")),
@@ -596,7 +606,10 @@ class InlineInstancesTests extends LowTransformSpec {
         DummyAnno(top.instOf("i_bar", "NestedNoInline").ref("a")),
         DummyAnno(top.instOf("i_bar", "NestedNoInline").ref("b")),
         DummyAnno(top.instOf("i_bar", "NestedNoInline").ref("foo_a")),
-        DummyAnno(top.instOf("i_bar", "NestedNoInline").ref("foo_b"))
+        DummyAnno(top.instOf("i_bar", "NestedNoInline").ref("foo_b")),
+        DummyAnno(top.instOf("i_bar", "NestedNoInline")),
+        DummyAnno(top.ref("i_a"), top.ref("i_b")),
+        DummyAnno(top.ref("i_foo_a"), top.copy(module = "NestedNoInline").ref("foo_a")),
       )
     )
   }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix

for targets inside inlined instances, `InlineInstances` would only do renames of the form
```
~Top|Mod/parent:Parent/inlined:Inlined>ref -> ~Top|Mod/parent:Parent>ref
~Top|Mod/parent:Parent/inlined:Inlined/child:Child-> ~Top|Mod/parent:Parent/child:Child
```

This does not correctly rename local targets e.g. `~Top|Inlined/child:Child`/`~Top|Inlined>ref`

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
none

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
fix renaming of local targets in `InlineInstances`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
