### PR TITLE
WiringTransform: cannot run after RemoveWires

### DIFF
--- a/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
+++ b/src/main/scala/firrtl/passes/wiring/WiringTransform.scala
@@ -40,7 +40,9 @@ class WiringTransform extends Transform with DependencyAPIMigration {
 
   override def prerequisites = Forms.MidForm
   override def optionalPrerequisites = Seq.empty
-  override def optionalPrerequisiteOf = Forms.MidEmitters
+  override def optionalPrerequisiteOf = Forms.MidEmitters ++
+    // once wire targets are turned into nodes, our logic to wire them up no longer works
+    Seq(Dependency[firrtl.transforms.RemoveWires])
 
   private val invalidates = Forms.VerilogOptimized.toSet -- Forms.MinimalHighForm
   override def invalidates(a: Transform): Boolean = invalidates(Dependency.fromTransform(a))


### PR DESCRIPTION
The problem this is trying to address is that I sometimes get pass orderings where `RemoveWires` runs before the `Wiring` transform and that gets a wiring target turned from a `Wire` into a `Node` which `Wiring` then fails to deal with properly.


### Contributor Checklist
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
 - bug fix

#### API Impact

- none

#### Backend Code Generation Impact

- none
#### Desired Merge Strategy

- squash


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
