### PR TITLE
Annotation: override getTargets for SingleTargetAnnotation

### DIFF
--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -48,6 +48,9 @@ trait NoTargetAnnotation extends Annotation {
 trait SingleTargetAnnotation[T <: Named] extends Annotation {
   val target: T
 
+  // we can implement getTargets more efficiently since we know that we have exactly one target
+  override def getTargets: Seq[Target] = Seq(target)
+
   /** Create another instance of this Annotation */
   def duplicate(n: T): Annotation
 


### PR DESCRIPTION
This fixes a StackOverflow for one of my annotations that contains a single target + a list of ~90k strings.

### Contributor Checklist
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix

#### API Impact

- none

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy

- squash

#### Release Notes
n/a

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
