### PR TITLE
Replace mem macros renaming

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -218,15 +218,18 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     }
   }
 
-  /** Mapping from (module, memory name) pairs to blackbox names */
-  private type NameMap = collection.mutable.HashMap[(String, String), String]
+  /** Mapping from (module, memory name) pairs to pair of blackbox wrapper name and blackbox name */
+  private type NameMap = collection.mutable.HashMap[(String, String), (String, String)]
 
   /** Construct NameMap by assigning unique names for each memory blackbox */
   private def constructNameMap(namespace: Namespace, nameMap: NameMap, mname: String)(s: Statement): Statement = {
     s match {
       case m: DefAnnotatedMemory =>
         m.memRef match {
-          case None    => nameMap(mname -> m.name) = namespace.newName(m.name)
+          case None =>
+            val wrapperName = namespace.newName(m.name)
+            val blackboxName = namespace.newName(s"${wrapperName}_ext")
+            nameMap(mname -> m.name) = (wrapperName, blackboxName)
           case Some(_) =>
         }
       case _ =>
@@ -254,18 +257,17 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
       m.memRef match {
         case None =>
           // prototype mem
-          val newWrapperName = nameMap(mname -> m.name)
-          val newMemBBName = namespace.newName(s"${newWrapperName}_ext")
+          val (newWrapperName, newMemBBName) = nameMap(mname -> m.name)
           val newMem = m.copy(name = newMemBBName)
           memMods ++= createMemModule(newMem, newWrapperName, annotatedMemoriesBuffer)
           val renameFrom = moduleTarget.ref(m.name)
-          val renameTo = moduleTarget.instOf(m.name, newWrapperName).instOf(newMem.name, newMem.name)
+          val renameTo = moduleTarget.instOf(m.name, newWrapperName).instOf(newMemBBName, newMemBBName)
           renameMap.record(renameFrom, renameTo)
           WDefInstance(m.info, m.name, newWrapperName, UnknownType)
         case Some((module, mem)) =>
-          val memModuleName = nameMap(module -> mem)
+          val (memModuleName, newMemBBName) = nameMap(module -> mem)
           val renameFrom = moduleTarget.ref(m.name)
-          val renameTo = moduleTarget.instOf(m.name, memModuleName)
+          val renameTo = moduleTarget.instOf(m.name, memModuleName).instOf(newMemBBName, newMemBBName)
           renameMap.record(renameFrom, renameTo)
           WDefInstance(m.info, m.name, memModuleName, UnknownType)
       }

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -621,25 +621,24 @@ circuit Top :
 
   "ReplSeqMem" should "rename reference targets to blackbox instance targets" in {
     val input = """
-circuit CustomMemory :
-  module CustomMemory :
-    input clock : Clock
-    input reset : UInt<1>
-    output io : {flip rClk : Clock, flip rAddr : UInt<3>, dO : UInt<16>, flip wClk : Clock, flip wAddr : UInt<3>, flip wEn : UInt<1>, flip dI : UInt<16>}
+      |circuit CustomMemory :
+      |  module CustomMemory :
+      |    input clock : Clock
+      |    input reset : UInt<1>
+      |    output io : {flip rClk : Clock, flip rAddr : UInt<3>, dO : UInt<16>, flip wClk : Clock, flip wAddr : UInt<3>, flip wEn : UInt<1>, flip dI : UInt<16>}
 
-    io is invalid
-    smem mem_0 : UInt<16>[7]
-    smem mem_1 : UInt<16>[7]
-    read mport _T_17 = mem_0[io.rAddr], clock
-    read mport _T_19 = mem_1[io.rAddr], clock
-    io.dO <= and(_T_17, _T_19)
-    when io.wEn :
-      write mport _T_18 = mem_0[io.wAddr], clock
-      write mport _T_20 = mem_1[io.wAddr], clock
-      _T_18 <= io.dI
-      _T_20 <= io.dI
-      skip
-"""
+      |    io is invalid
+      |    smem mem_0 : UInt<16>[7]
+      |    smem mem_1 : UInt<16>[7]
+      |    read mport _T_17 = mem_0[io.rAddr], clock
+      |    read mport _T_19 = mem_1[io.rAddr], clock
+      |    io.dO <= and(_T_17, _T_19)
+      |    when io.wEn :
+      |      write mport _T_18 = mem_0[io.wAddr], clock
+      |      write mport _T_20 = mem_1[io.wAddr], clock
+      |      _T_18 <= io.dI
+      |      _T_20 <= io.dI
+      |""".stripMargin
     val mems = Set(
       MemConf("mem_0_ext", 7, 16, Map(WritePort -> 1, ReadPort -> 1), None)
     )
@@ -652,20 +651,17 @@ circuit CustomMemory :
       )
     )
     val res = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
-    (res.annotations.flatMap {
-      case a: DummyAnno => a.targets
-      case _ => Seq.empty
-    }) should be(
-      Seq(
-        CircuitTarget("CustomMemory")
-          .module("CustomMemory")
-          .instOf("mem_0", "mem_0")
-          .instOf("mem_0_ext", "mem_0_ext"),
-        CircuitTarget("CustomMemory")
-          .module("CustomMemory")
-          .instOf("mem_1", "mem_0")
-          .instOf("mem_0_ext", "mem_0_ext")
-      )
+    val resAnnos = res.annotations.collect { case a: DummyAnno => a.targets }
+    val expected = Seq(
+      CircuitTarget("CustomMemory")
+        .module("CustomMemory")
+        .instOf("mem_0", "mem_0"
+        .instOf("mem_0_ext", "mem_0_ext"),
+      CircuitTarget("CustomMemory")
+        .module("CustomMemory")
+        .instOf("mem_1", "mem_0")
+        .instOf("mem_0_ext", "mem_0_ext")
     )
+    resAnnos should be(expected)
   }
 }

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -652,7 +652,7 @@ circuit Top :
       )
     )
     val res = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
-    val resAnnos = res.annotations.collect { case a: DummyAnno => a.targets }
+    val resAnnos = res.annotations.collect { case a: DummyAnno => a.targets }.flatten
     val expected = Seq(
       CircuitTarget("CustomMemory")
         .module("CustomMemory")

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -620,25 +620,26 @@ circuit Top :
   }
 
   "ReplSeqMem" should "rename reference targets to blackbox instance targets" in {
-    val input = """
-      |circuit CustomMemory :
-      |  module CustomMemory :
-      |    input clock : Clock
-      |    input reset : UInt<1>
-      |    output io : {flip rClk : Clock, flip rAddr : UInt<3>, dO : UInt<16>, flip wClk : Clock, flip wAddr : UInt<3>, flip wEn : UInt<1>, flip dI : UInt<16>}
+    val input =
+      """
+        |circuit CustomMemory :
+        |  module CustomMemory :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output io : {flip rClk : Clock, flip rAddr : UInt<3>, dO : UInt<16>, flip wClk : Clock, flip wAddr : UInt<3>, flip wEn : UInt<1>, flip dI : UInt<16>}
 
-      |    io is invalid
-      |    smem mem_0 : UInt<16>[7]
-      |    smem mem_1 : UInt<16>[7]
-      |    read mport _T_17 = mem_0[io.rAddr], clock
-      |    read mport _T_19 = mem_1[io.rAddr], clock
-      |    io.dO <= and(_T_17, _T_19)
-      |    when io.wEn :
-      |      write mport _T_18 = mem_0[io.wAddr], clock
-      |      write mport _T_20 = mem_1[io.wAddr], clock
-      |      _T_18 <= io.dI
-      |      _T_20 <= io.dI
-      |""".stripMargin
+        |    io is invalid
+        |    smem mem_0 : UInt<16>[7]
+        |    smem mem_1 : UInt<16>[7]
+        |    read mport _T_17 = mem_0[io.rAddr], clock
+        |    read mport _T_19 = mem_1[io.rAddr], clock
+        |    io.dO <= and(_T_17, _T_19)
+        |    when io.wEn :
+        |      write mport _T_18 = mem_0[io.wAddr], clock
+        |      write mport _T_20 = mem_1[io.wAddr], clock
+        |      _T_18 <= io.dI
+        |      _T_20 <= io.dI
+        |""".stripMargin
     val mems = Set(
       MemConf("mem_0_ext", 7, 16, Map(WritePort -> 1, ReadPort -> 1), None)
     )
@@ -655,7 +656,7 @@ circuit Top :
     val expected = Seq(
       CircuitTarget("CustomMemory")
         .module("CustomMemory")
-        .instOf("mem_0", "mem_0"
+        .instOf("mem_0", "mem_0")
         .instOf("mem_0_ext", "mem_0_ext"),
       CircuitTarget("CustomMemory")
         .module("CustomMemory")


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->
- bug fix

This change makes `ReplaceMemMacros` rename replaced memory ReferenceTargets to InstanceTargets that target the memory blackbox e.g. `~Top|Mod>mem -> ~Top|Mod/mem:mem/mem_ext:mem_ext`.

Chisel emits ReferenceTargets for memories. and because `ReplaceMemMacros` didn't update these ReferenceTargets to instance targets when it replaced them, these targets would never get updated because downstream transforms would only record InstanceTarget renames instead of ReferenceTarget renames.

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
no API changes, but does make `ResolveMemoryReference` delete `NoDedupMemAnnotation`s after it runs. This is needed because `SingleTargetAnnotation[ComponentName]` will throw an exception if its target is renamed to an instance. i think ideally it would extend `SingleTargetAnnotation[IsComponent]` instead which would allow it to be renamed from a reference to instance, but that would break the existing api.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
none

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
`ReplaceMemMacros` will now rename replaced memory `ReferenceTarget`s to `InstanceTarget`s that target the memory blackbox.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
