### PR TITLE
Optimize Annotation.getTargets

### DIFF
--- a/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/src/main/scala/firrtl/annotations/Annotation.scala
@@ -5,6 +5,8 @@ package annotations
 
 import firrtl.options.StageUtils
 
+import scala.collection.Traversable
+
 case class AnnotationException(message: String) extends Exception(message)
 
 /** Base type of auxiliary information */
@@ -23,18 +25,19 @@ trait Annotation extends Product {
     * @param ls
     * @return
     */
-  private def extractComponents(ls: scala.collection.Traversable[_]): Seq[Target] = {
-    ls.collect {
+  private def extractComponents(ls: Traversable[_]): Traversable[Target] = {
+    ls.flatMap {
       case c: Target                          => Seq(c)
-      case o: Product                         => extractComponents(o.productIterator.toIterable)
       case x: scala.collection.Traversable[_] => extractComponents(x)
-    }.foldRight(Seq.empty[Target])((seq, c) => c ++ seq)
+      case o: Product                         => extractComponents(o.productIterator.toIterable)
+      case _ => Seq()
+    }
   }
 
   /** Returns all [[firrtl.annotations.Target Target]] members in this annotation
     * @return
     */
-  def getTargets: Seq[Target] = extractComponents(productIterator.toSeq)
+  def getTargets: Seq[Target] = extractComponents(productIterator.toIterable).toSeq
 }
 
 /** If an Annotation does not target any [[Named]] thing in the circuit, then all updates just
@@ -42,6 +45,8 @@ trait Annotation extends Product {
   */
 trait NoTargetAnnotation extends Annotation {
   def update(renames: RenameMap): Seq[NoTargetAnnotation] = Seq(this)
+
+  override def getTargets: Seq[Target] = Seq.empty
 }
 
 /** An Annotation that targets a single [[Named]] thing */
@@ -102,6 +107,8 @@ trait MultiTargetAnnotation extends Annotation {
     * }}}
     */
   def targets: Seq[Seq[Target]]
+
+  override def getTargets: Seq[Target] = targets.flatten
 
   /** Create another instance of this Annotation
     *

--- a/src/test/scala/firrtlTests/annotationTests/AnnotationSpec.scala
+++ b/src/test/scala/firrtlTests/annotationTests/AnnotationSpec.scala
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests.annotationTests
+
+import firrtl.RenameMap
+import firrtl.annotations._
+import firrtl.testutils.FirrtlFlatSpec
+
+object AnnotationSpec {
+  case class TestAnno(pairs: List[(String, ReferenceTarget)]) extends Annotation {
+    def update(renames: RenameMap): Seq[Annotation] = {
+      val pairsx = pairs.flatMap {
+        case (n, t) =>
+          val ts = renames
+            .get(t)
+            .map(_.map(_.asInstanceOf[ReferenceTarget]))
+            .getOrElse(Seq(t))
+          ts.map(n -> _)
+      }
+      Seq(TestAnno(pairsx))
+    }
+  }
+}
+
+class AnnotationSpec extends FirrtlFlatSpec {
+  import AnnotationSpec._
+
+  behavior.of("Annotation.getTargets")
+
+  it should "not stack overflow" in {
+    val ref = CircuitTarget("Top").module("Foo").ref("vec")
+    val anno = TestAnno((0 until 10000).map(i => (i.toString, ref.index(i))).toList)
+    anno.getTargets should be(anno.pairs.map(_._2))
+  }
+}


### PR DESCRIPTION
Inspired by https://github.com/chipsalliance/firrtl/pull/2241

Let's make sure `.getTargets` doesn't stack overflow in practice and also be faster.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - performance improvement  

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash
 
#### Release Notes

Improve performance of `Annotation.getTargets`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
