### PR TITLE
MultiInfo is no longer preserved through serialization + parsing

### DIFF
--- a/src/test/scala/firrtlTests/InfoSpec.scala
+++ b/src/test/scala/firrtlTests/InfoSpec.scala
@@ -321,4 +321,17 @@ class InfoSpec extends FirrtlFlatSpec with FirrtlMatchers {
     for (line <- check)
       result should containLine(line)
   }
+
+  "Source Locators" should "not loose information when going through serialization + parsing" in {
+    def check(info: ir.Info): Unit = {
+      assert(Parser.parseInfo(info.serialize) == info)
+    }
+
+    check(ir.NoInfo)
+    check(ir.FileInfo("B"))
+    check(ir.FileInfo("A 4:5"))
+    check(ir.FileInfo("A 4:6"))
+    check(ir.MultiInfo(ir.FileInfo("A 4:5"), ir.FileInfo("B 5:5")))
+    check(ir.MultiInfo(ir.FileInfo("A 4:5"), ir.FileInfo("A 5:5")))
+  }
 }


### PR DESCRIPTION
It looks like since https://github.com/chipsalliance/firrtl/pull/2212, when we serialize a `MultiInfo` it can be turned into a single `FileInfo` node. This is a problem for applications that need to parse the emitted source locator, like my formal verification library: https://github.com/ekiwi/kiwi-formal/blob/main/test/kiwi/formal/backends/ErrorParserTest.scala#L39




### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
