### PR TITLE
make PresetRegAnnotation public

### DIFF
--- a/src/main/scala/firrtl/annotations/PresetAnnotations.scala
+++ b/src/main/scala/firrtl/annotations/PresetAnnotations.scala
@@ -29,8 +29,19 @@ case class PresetAnnotation(target: ReferenceTarget)
 case class PresetRegAnnotation(
   target: ReferenceTarget)
     extends SingleTargetAnnotation[ReferenceTarget]
-    with RegisterEmissionOption {
+    with RegisterEmissionOption
+    with firrtl.transforms.DontTouchAllTargets {
   def duplicate(n: ReferenceTarget) = this.copy(target = n)
   override def useInitAsPreset = true
   override def disableRandomization = true
+}
+
+object PresetRegAnnotation {
+
+  /** Extracts the names of every preset reg in the design by module. */
+  def collect(annotations: AnnotationSeq, main: String): Map[String, Set[String]] =
+    annotations.collect {
+      case a: PresetRegAnnotation if a.target.circuit == main =>
+        a.target.module -> a.target.ref
+    }.groupBy(_._1).map { case (k, v) => k -> v.map(_._2).toSet }
 }

--- a/src/main/scala/firrtl/annotations/PresetAnnotations.scala
+++ b/src/main/scala/firrtl/annotations/PresetAnnotations.scala
@@ -17,11 +17,16 @@ case class PresetAnnotation(target: ReferenceTarget)
 
 /**
   * Transform the targeted asynchronously-reset Reg into a bitstream preset Reg
-  * Used internally to annotate all registers associated to an AsyncReset tree
+  * Thus you can use this annotation in order to initialize a register
+  * at the beginning of simulation or through the FPGA bit-stream to its `init` value.
+  *
+  * The register must fulfil the following requirements:
+  * - the reset signal is `UInt(0)`
+  * - the `init` value is a Literal
   *
   * @param target ReferenceTarget to a Reg
   */
-private[firrtl] case class PresetRegAnnotation(
+case class PresetRegAnnotation(
   target: ReferenceTarget)
     extends SingleTargetAnnotation[ReferenceTarget]
     with RegisterEmissionOption {

--- a/src/test/scala/firrtlTests/PresetRegAnnotationSpec.scala
+++ b/src/test/scala/firrtlTests/PresetRegAnnotationSpec.scala
@@ -1,0 +1,81 @@
+package firrtlTests
+
+import firrtl._
+import firrtl.annotations.{CircuitTarget, PresetRegAnnotation}
+import firrtl.options.Dependency
+import firrtl.testutils.LeanTransformSpec
+import firrtl.transforms.PropagatePresetAnnotations
+import logger.{LogLevel, LogLevelAnnotation, Logger}
+
+import scala.collection.mutable
+
+/** Tests the use of the [[firrtl.annotations.PresetRegAnnotation]]
+  * from a pass that needs to create a register with an initial value.
+  */
+class PresetRegAnnotationSpec
+    extends LeanTransformSpec(Seq(Dependency(MakePresetRegs), Dependency[SystemVerilogEmitter])) {
+  behavior.of("PresetRegAnnotation")
+
+  val src =
+    """circuit test:
+      |  module test:
+      |    input clock : Clock
+      |    output out : UInt<8>
+      |
+      |    reg r : UInt<8>, clock with :
+      |      reset => (UInt(0), UInt<8>("h7b"))
+      |    out <= r
+      |""".stripMargin
+
+  val ll = LogLevel.Error
+
+  it should "allow passes to mark registers to be initialized" in {
+    val result = Logger.makeScope(Seq(LogLevelAnnotation(ll))) { compile(src) }
+    val verilog = result.getEmittedCircuit.value
+    val lines = verilog.split('\n').map(_.trim).toSet
+
+    // the register should be assigned its initial value
+    assert(lines.contains("reg [7:0] r = 8'h7b;"))
+    assert(lines.contains("assign out = r;"))
+
+    // no asynchronous reset should be emitted
+    assert(!lines.contains("if (reset) begin"))
+    assert(!lines.contains("always @(posedge clock or posedge reset) begin"))
+  }
+}
+
+/** Adds preset reg annotations for all registers that have:
+  * 1. reset = false
+  * 2. init = a literal
+  */
+private object MakePresetRegs extends Transform with DependencyAPIMigration {
+  // run on lowered firrtl
+  override def prerequisites = Seq(Dependency(firrtl.passes.ExpandWhens), Dependency(firrtl.passes.LowerTypes))
+  override def invalidates(a: Transform) = false
+  // since we generate PresetRegAnnotations, we need to run after preset propagation
+  override def optionalPrerequisites = Seq(Dependency[PropagatePresetAnnotations])
+  // we want to run before the actual Verilog is emitted
+  // we want to look at the reset value, which may be removed by the RemoveReset transform.
+  override def optionalPrerequisiteOf = Seq(Dependency[SystemVerilogEmitter], Dependency(firrtl.transforms.RemoveReset))
+
+  override def execute(state: CircuitState): CircuitState = {
+    val c = CircuitTarget(state.circuit.main)
+    val newAnnos = state.circuit.modules.flatMap(onModule(c, _))
+    state.copy(annotations = newAnnos ++: state.annotations)
+  }
+
+  private def onModule(c: CircuitTarget, m: ir.DefModule): List[PresetRegAnnotation] = m match {
+    case mod: ir.Module =>
+      val regs = mutable.ListBuffer[String]()
+      mod.foreachStmt(onStmt(_, regs))
+      val m = c.module(mod.name)
+      regs.map(r => PresetRegAnnotation(m.ref(r))).toList
+    case _ => List()
+  }
+
+  private def onStmt(s: ir.Statement, regs: mutable.ListBuffer[String]): Unit = s match {
+    case ir.DefRegister(_, name, _, _, reset, init) if reset == Utils.False() && Utils.isLiteral(init) =>
+      regs.append(name)
+    case other => other.foreachStmt(onStmt(_, regs))
+  }
+}


### PR DESCRIPTION
this annotation is useful outside the firrtl compiler:
- to implement a pass that creates registers which
  need to be initialized at the beginning of simulation
  (e.g., for formal verification)
- to support preset registers in treadle

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- make annotation public

#### API Impact

- `PresetRegAnnotation` is now public

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy
- squash

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
