### PR TITLE
smt: include firrtl statement names in SMT and btor2 output

### DIFF
--- a/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
@@ -464,7 +464,6 @@ private class ModuleScanner(
         insertDummyAssignsForUnusedOutputs(pred)
         insertDummyAssignsForUnusedOutputs(en)
         val name = s.name
-        println("Name: " + name)
         val predicate = onExpression(pred)
         val enabled = onExpression(en)
         val e = BVImplies(enabled, predicate)

--- a/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/FirrtlToTransitionSystem.scala
@@ -14,7 +14,7 @@ import firrtl.passes.PassException
 import firrtl.passes.memlib.VerilogMemDelays
 import firrtl.stage.Forms
 import firrtl.stage.TransformManager.TransformDependency
-import firrtl.transforms.{DeadCodeElimination, PropagatePresetAnnotations}
+import firrtl.transforms.{DeadCodeElimination, EnsureNamedStatements, PropagatePresetAnnotations}
 import firrtl.{
   ir,
   CircuitState,
@@ -63,7 +63,12 @@ object FirrtlToTransitionSystem extends Transform with DependencyAPIMigration {
   // TODO: We also would like to run some optimization passes, but RemoveValidIf won't allow us to model DontCare
   //       precisely and PadWidths emits ill-typed firrtl.
   override def prerequisites: Seq[Dependency[Transform]] = Forms.LowForm ++
-    Seq(Dependency(InvalidToRandomPass), Dependency(UndefinedMemoryBehaviorPass), Dependency(VerilogMemDelays))
+    Seq(
+      Dependency(InvalidToRandomPass),
+      Dependency(UndefinedMemoryBehaviorPass),
+      Dependency(VerilogMemDelays),
+      Dependency(EnsureNamedStatements) // this is required to give assert/assume statements good names
+    )
   override def invalidates(a: Transform): Boolean = false
   // since this pass only runs on the main module, inlining needs to happen before
   override def optionalPrerequisites: Seq[TransformDependency] = Seq(Dependency[firrtl.passes.InlineInstances])
@@ -458,7 +463,8 @@ private class ModuleScanner(
       } else {
         insertDummyAssignsForUnusedOutputs(pred)
         insertDummyAssignsForUnusedOutputs(en)
-        val name = namespace.newName(msgToName(op.toString, msg.string))
+        val name = s.name
+        println("Name: " + name)
         val predicate = onExpression(pred)
         val enabled = onExpression(en)
         val e = BVImplies(enabled, predicate)
@@ -595,10 +601,6 @@ private class ModuleScanner(
     FirrtlExpressionSemantics.toSMT(e)
   }
 
-  private def msgToName(prefix: String, msg: String): String = {
-    // TODO: ensure that we can generate unique names
-    prefix + "_" + msg.replace(" ", "_").replace("|", "")
-  }
   private def error(msg:        String):  Unit = throw new RuntimeException(msg)
   private def isGroundType(tpe: ir.Type): Boolean = tpe.isInstanceOf[ir.GroundType]
   private def isClock(tpe:      ir.Type): Boolean = tpe == ir.ClockType

--- a/src/test/scala/firrtl/backends/experimental/smt/Btor2Spec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/Btor2Spec.scala
@@ -3,6 +3,7 @@
 package firrtl.backends.experimental.smt
 
 private class Btor2Spec extends SMTBackendBaseSpec {
+  behavior.of("Botr2Spec")
 
   it should "convert a hello world module" in {
     val src =
@@ -12,7 +13,7 @@ private class Btor2Spec extends SMTBackendBaseSpec {
         |    input a: UInt<8>
         |    output b: UInt<16>
         |    b <= a
-        |    assert(clock, eq(a, b), UInt(1), "")
+        |    assert(clock, eq(a, b), UInt(1), "") : a_eq_b
         |""".stripMargin
 
     val expected =
@@ -25,7 +26,7 @@ private class Btor2Spec extends SMTBackendBaseSpec {
         |7 uext 3 2 8
         |8 eq 6 7 4
         |9 not 6 8
-        |10 bad 9 ; assert_
+        |10 bad 9 ; a_eq_b
         |""".stripMargin
 
     assert(toBotr2Str(src) == expected)

--- a/src/test/scala/firrtl/backends/experimental/smt/Btor2Spec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/Btor2Spec.scala
@@ -2,8 +2,10 @@
 
 package firrtl.backends.experimental.smt
 
-private class Btor2Spec extends SMTBackendBaseSpec {
-  behavior.of("Botr2Spec")
+import org.scalatest.flatspec.AnyFlatSpec
+
+class Btor2Spec extends AnyFlatSpec {
+  behavior.of("btor2 backend")
 
   it should "convert a hello world module" in {
     val src =
@@ -29,7 +31,7 @@ private class Btor2Spec extends SMTBackendBaseSpec {
         |10 bad 9 ; a_eq_b
         |""".stripMargin
 
-    assert(toBotr2Str(src) == expected)
+    assert(SMTBackendHelpers.toBotr2Str(src) == expected)
   }
 
   it should "include FileInfo in the output" in {
@@ -54,9 +56,9 @@ private class Btor2Spec extends SMTBackendBaseSpec {
         |7 uext 3 2 8
         |8 eq 6 7 4
         |9 not 6 8
-        |10 bad 9 ; assert_ @ assert 0:0
+        |10 bad 9 ; assert_0 @ assert 0:0
         |""".stripMargin
 
-    assert(toBotr2Str(src) == expected)
+    assert(SMTBackendHelpers.toBotr2Str(src) == expected)
   }
 }

--- a/src/test/scala/firrtl/backends/experimental/smt/SMTBackendBaseSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/SMTBackendBaseSpec.scala
@@ -8,7 +8,7 @@ import firrtl.stage.{Forms, TransformManager}
 import org.scalatest.flatspec.AnyFlatSpec
 
 private abstract class SMTBackendBaseSpec extends AnyFlatSpec {
-  private val dependencies = Forms.LowForm
+  private val dependencies = Forms.LowForm ++ FirrtlToTransitionSystem.prerequisites
   private val compiler = new TransformManager(dependencies)
 
   protected def compile(src: String, annos: Seq[Annotation] = List()): ir.Circuit = {

--- a/src/test/scala/firrtl/backends/experimental/smt/SMTBackendHelpers.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/SMTBackendHelpers.scala
@@ -5,18 +5,17 @@ package firrtl.backends.experimental.smt
 import firrtl.annotations.Annotation
 import firrtl.{ir, MemoryInitValue}
 import firrtl.stage.{Forms, TransformManager}
-import org.scalatest.flatspec.AnyFlatSpec
 
-private abstract class SMTBackendBaseSpec extends AnyFlatSpec {
+private object SMTBackendHelpers {
   private val dependencies = Forms.LowForm ++ FirrtlToTransitionSystem.prerequisites
   private val compiler = new TransformManager(dependencies)
 
-  protected def compile(src: String, annos: Seq[Annotation] = List()): ir.Circuit = {
+  def compile(src: String, annos: Seq[Annotation] = List()): ir.Circuit = {
     val c = firrtl.Parser.parse(src)
     compiler.runTransform(firrtl.CircuitState(c, annos)).circuit
   }
 
-  protected def toSys(
+  def toSys(
     src:        String,
     mod:        String = "m",
     presetRegs: Set[String] = Set(),
@@ -28,15 +27,15 @@ private abstract class SMTBackendBaseSpec extends AnyFlatSpec {
     new ModuleToTransitionSystem().run(module, presetRegs = presetRegs, memInit = memInit)
   }
 
-  protected def toBotr2(src: String, mod: String = "m"): Iterable[String] =
+  def toBotr2(src: String, mod: String = "m"): Iterable[String] =
     Btor2Serializer.serialize(toSys(src, mod))
 
-  protected def toBotr2Str(src: String, mod: String = "m"): String =
+  def toBotr2Str(src: String, mod: String = "m"): String =
     toBotr2(src, mod).mkString("\n") + "\n"
 
-  protected def toSMTLib(src: String, mod: String = "m"): Iterable[String] =
+  def toSMTLib(src: String, mod: String = "m"): Iterable[String] =
     SMTTransitionSystemEncoder.encode(toSys(src, mod)).map(SMTLibSerializer.serialize)
 
-  protected def toSMTLibStr(src: String, mod: String = "m"): String =
+  def toSMTLibStr(src: String, mod: String = "m"): String =
     toSMTLib(src, mod).mkString("\n") + "\n"
 }

--- a/src/test/scala/firrtl/backends/experimental/smt/SMTLibSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/SMTLibSpec.scala
@@ -12,7 +12,7 @@ private class SMTLibSpec extends SMTBackendBaseSpec {
         |    input a: UInt<8>
         |    output b: UInt<16>
         |    b <= a
-        |    assert(clock, eq(a, b), UInt(1), "")
+        |    assert(clock, eq(a, b), UInt(1), "") : a_eq_b
         |""".stripMargin
 
     val expected =
@@ -21,11 +21,11 @@ private class SMTLibSpec extends SMTBackendBaseSpec {
         |(declare-fun a_f (m_s) (_ BitVec 8))
         |; firrtl-smt2-output b 16
         |(define-fun b_f ((state m_s)) (_ BitVec 16) ((_ zero_extend 8) (a_f state)))
-        |; firrtl-smt2-assert assert_ 1
-        |(define-fun assert__f ((state m_s)) Bool (= ((_ zero_extend 8) (a_f state)) (b_f state)))
+        |; firrtl-smt2-assert a_eq_b 1
+        |(define-fun a_eq_b_f ((state m_s)) Bool (= ((_ zero_extend 8) (a_f state)) (b_f state)))
         |(define-fun m_t ((state m_s) (state_n m_s)) Bool true)
         |(define-fun m_i ((state m_s)) Bool true)
-        |(define-fun m_a ((state m_s)) Bool (assert__f state))
+        |(define-fun m_a ((state m_s)) Bool (a_eq_b_f state))
         |(define-fun m_u ((state m_s)) Bool true)
         |""".stripMargin
 

--- a/src/test/scala/firrtl/backends/experimental/smt/SMTLibSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/SMTLibSpec.scala
@@ -2,7 +2,10 @@
 
 package firrtl.backends.experimental.smt
 
-private class SMTLibSpec extends SMTBackendBaseSpec {
+import org.scalatest.flatspec.AnyFlatSpec
+
+class SMTLibSpec extends AnyFlatSpec {
+  behavior.of("SMTLib backend")
 
   it should "convert a hello world module" in {
     val src =
@@ -29,7 +32,7 @@ private class SMTLibSpec extends SMTBackendBaseSpec {
         |(define-fun m_u ((state m_s)) Bool true)
         |""".stripMargin
 
-    assert(toSMTLibStr(src) == expected)
+    assert(SMTBackendHelpers.toSMTLibStr(src) == expected)
   }
 
   it should "include FileInfo in the output" in {
@@ -52,15 +55,15 @@ private class SMTLibSpec extends SMTBackendBaseSpec {
         |; firrtl-smt2-output b 16
         |; @ b 0:0, b_a 0:0
         |(define-fun b_f ((state m_s)) (_ BitVec 16) ((_ zero_extend 8) (a_f state)))
-        |; firrtl-smt2-assert assert_ 1
+        |; firrtl-smt2-assert assert_0 1
         |; @ assert 0:0
-        |(define-fun assert__f ((state m_s)) Bool (= ((_ zero_extend 8) (a_f state)) (b_f state)))
+        |(define-fun assert_0_f ((state m_s)) Bool (= ((_ zero_extend 8) (a_f state)) (b_f state)))
         |(define-fun m_t ((state m_s) (state_n m_s)) Bool true)
         |(define-fun m_i ((state m_s)) Bool true)
-        |(define-fun m_a ((state m_s)) Bool (assert__f state))
+        |(define-fun m_a ((state m_s)) Bool (assert_0_f state))
         |(define-fun m_u ((state m_s)) Bool true)
         |""".stripMargin
 
-    assert(toSMTLibStr(src) == expected)
+    assert(SMTBackendHelpers.toSMTLibStr(src) == expected)
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### Type of Improvement

- small improvement to naming

#### API Impact

- SMTLib and btor2 output now contains the assert/assume names

#### Backend Code Generation Impact

- not for Verilog, only for SMTLib/Btor2
- 
#### Desired Merge Strategy
- squash

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
