### PR TITLE
Add --start-from option

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -5,7 +5,7 @@ package firrtl.stage
 import firrtl._
 import firrtl.ir.Circuit
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{HasShellOptions, OptionsException, ShellOption, Unserializable}
+import firrtl.options.{Dependency, HasShellOptions, OptionsException, ShellOption, Unserializable}
 import java.io.FileNotFoundException
 import java.nio.file.NoSuchFileException
 
@@ -309,6 +309,49 @@ object DisableFold extends HasShellOptions {
       },
       helpText = "Disable folding of specific primitive operations",
       helpValueName = Some("<primop>")
+    )
+  )
+
+}
+
+/** Indicate to the FIRRTL compiler that specific transforms have already been run.
+  *
+  * The intended use of this is for advanced users who want to skip specific transforms in the FIRRTL compiler.  It is
+  * far safer for users to use the command line options to the FIRRTL compiler via `--start-from = <form>`.
+  * @param currentState a sequence of transforms that have already been run on the circuit
+  */
+case class CurrentFirrtlStateAnnotation(currentState: Seq[TransformDependency])
+    extends NoTargetAnnotation
+    with FirrtlOption
+
+private[stage] object CurrentFirrtlStateAnnotation extends HasShellOptions {
+
+  /** This is just the transforms necessary for resolving types and checking that everything is okay. */
+  private val dontSkip: Set[TransformDependency] = Set(
+    Dependency[firrtl.stage.transforms.CheckScalaVersion],
+    Dependency(passes.ResolveKinds),
+    Dependency(passes.InferTypes),
+    Dependency(passes.ResolveFlows)
+  ) ++ Forms.Checks
+
+  override val options = Seq(
+    new ShellOption[String](
+      longOption = "start-from",
+      toAnnotationSeq = a =>
+        (a match {
+          case "chirrtl" => Seq.empty
+          case "mhigh"   => Forms.MinimalHighForm
+          case "high"    => Forms.HighForm
+          case "middle"  => Forms.MidForm
+          case "low"     => Forms.LowForm
+          case "low-opt" => Forms.LowFormOptimized
+          case _         => throw new OptionsException(s"Unknown start-from argument '$a'! (Did you misspell it?)")
+        }).filterNot(dontSkip) match {
+          case b if a.isEmpty => Seq.empty
+          case b              => Seq(CurrentFirrtlStateAnnotation(b))
+        },
+      helpText = "",
+      helpValueName = Some("<chirrtl|mhigh|high|middle|low|low-opt>")
     )
   )
 

--- a/src/main/scala/firrtl/stage/FirrtlCli.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCli.scala
@@ -23,7 +23,8 @@ trait FirrtlCli { this: Shell =>
     WarnNoScalaVersionDeprecation,
     PrettyNoExprInlining,
     DisableFold,
-    OptimizeForFPGA
+    OptimizeForFPGA,
+    CurrentFirrtlStateAnnotation
   )
     .map(_.addOptions(parser))
 

--- a/src/main/scala/firrtl/stage/package.scala
+++ b/src/main/scala/firrtl/stage/package.scala
@@ -35,6 +35,7 @@ package object stage {
           case WarnNoScalaVersionDeprecation => c
           case PrettyNoExprInlining          => c
           case _: DisableFold => c
+          case CurrentFirrtlStateAnnotation(a) => c
         }
       }
   }

--- a/src/test/scala/firrtl/stage/CurrentFirrtlStateAnnotationSpec.scala
+++ b/src/test/scala/firrtl/stage/CurrentFirrtlStateAnnotationSpec.scala
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtl.stage
+
+import firrtl.options.Dependency
+import firrtl.stage.transforms.Compiler
+import firrtl.stage.TransformManager.TransformDependency
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class CurrentFirrtlStateAnnotationSpec extends AnyFlatSpec with Matchers {
+
+  def getTransforms(input: String): Seq[TransformDependency] = {
+    val currentState = CurrentFirrtlStateAnnotation
+      .options(0)
+      .toAnnotationSeq(input)
+      .collectFirst {
+        case CurrentFirrtlStateAnnotation(currentState) => currentState
+      }
+      .get
+    new Compiler(Forms.VerilogOptimized, currentState).flattenedTransformOrder.map(Dependency.fromTransform)
+  }
+
+  behavior.of("CurrentFirrtlStateAnnotation")
+
+  it should "produce an expected transform order for CHIRRTL -> Verilog" in {
+    getTransforms("chirrtl") should contain(Dependency(firrtl.passes.CheckChirrtl))
+  }
+
+  it should "produce an expected transform order for minimum high FIRRTL -> Verilog" in {
+    val transforms = getTransforms("mhigh")
+    transforms should not contain noneOf(Dependency(firrtl.passes.CheckChirrtl), Dependency(firrtl.passes.InferTypes))
+    transforms should contain(Dependency(firrtl.passes.CheckHighForm))
+  }
+
+  it should "produce an expected transform order for high FIRRTL -> Verilog" in {
+    val transforms = getTransforms("high")
+    transforms should not contain (Dependency[firrtl.transforms.DedupModules])
+    (transforms should contain).allOf(
+      Dependency(firrtl.passes.InferTypes),
+      Dependency[firrtl.passes.ExpandWhensAndCheck]
+    )
+  }
+
+  it should "produce an expected transform order for middle FIRRTL -> Verilog" in {
+    val transforms = getTransforms("middle")
+    transforms should not contain (Dependency[firrtl.passes.ExpandWhensAndCheck])
+    (transforms should contain).allOf(Dependency(firrtl.passes.InferTypes), Dependency(firrtl.passes.LowerTypes))
+  }
+
+  it should "produce an expected transform order for low FIRRTL -> Verilog" in {
+    val transforms = getTransforms("low")
+    transforms should not contain (Dependency(firrtl.passes.LowerTypes))
+    (transforms should contain).allOf(
+      Dependency(firrtl.passes.InferTypes),
+      Dependency(firrtl.passes.CommonSubexpressionElimination)
+    )
+  }
+
+  it should "produce an expected transform order for optimized low FIRRTL -> Verilog" in {
+    val transforms = getTransforms("low-opt")
+    transforms should not contain (Dependency(firrtl.passes.CommonSubexpressionElimination))
+    (transforms should contain).allOf(Dependency(firrtl.passes.InferTypes), Dependency[firrtl.transforms.VerilogRename])
+  }
+
+}


### PR DESCRIPTION
Add a new option to the FIRRTL compiler, `--start-from = <form>`.  If
used, this will cause the compiler to assume that the input FIRRTL
circuit is already in the specific form.  It will then skip unnecessary
passes given this information.

E.g., if a user requests to run "firrtl -X verilog --start-from low"
then the compiler will only run transforms necessary to get from low
FIRRTL to Verilog.  Transforms necessary for ingesting FIRRTL IR will be
run if needed (checks and type/kind/flow resolution).

To implement this, a CurrentFirrtlStateAnnotation is added.  Advanced
users can use this directly to tell the FIRRTL compiler exactly what
transforms have already been run, including the ability to ignore checks
or type/kind/flow resolution if they so desire.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API                   

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Pure API expansion. Adds a new annotation and a command line option.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Add "--start-from = <form>" to enable a user to start from a specific point of FIRRTL compilation.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
