### PR TITLE
Doc DontTouchAnnotation as optimization barrier

### DIFF
--- a/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/OptimizationAnnotations.scala
@@ -33,9 +33,10 @@ trait DontTouchAllTargets extends HasDontTouches { self: Annotation =>
   }
 }
 
-/** A component that should be preserved
+/** Mark that a target is an optimization barrier to the FIRRTL compiler.  This has the effect of guaranteeing that the
+  * target will not be removed from the circuit by an optimization pass.
   *
-  * DCE treats the component as a top-level sink of the circuit
+  * @note DCE treats the component as a top-level sink of the circuit.
   */
 case class DontTouchAnnotation(target: ReferenceTarget)
     extends SingleTargetAnnotation[ReferenceTarget]


### PR DESCRIPTION
Update Scaladoc documentation on DontTouchAnnotation to indicate that
this is an optimization barrier as opposed to just a component that
should not be DCE'd.

Companion PR to https://github.com/chipsalliance/chisel3/pull/2015. I'll update the language in this once https://github.com/chipsalliance/chisel3/pull/2015 converges.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [n/a] Did you update the FIRRTL spec to include every new feature/behavior?
- [n/a] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
- documentation                     
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

None.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

None.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
