### PR TITLE
Add typedef in DependencyManager.

### DIFF
--- a/src/main/scala/firrtl/options/DependencyManager.scala
+++ b/src/main/scala/firrtl/options/DependencyManager.scala
@@ -20,11 +20,11 @@ case class DependencyManagerException(message: String, cause: Throwable = null) 
 trait DependencyManager[A, B <: TransformLike[A] with DependencyAPI[B]] extends TransformLike[A] with DependencyAPI[B] {
   import DependencyManagerUtils.CharSet
 
-  override def prerequisites = currentState
+  override def prerequisites: Seq[Dependency[B]] = currentState
 
-  override def optionalPrerequisites = Seq.empty
+  override def optionalPrerequisites: Seq[Dependency[B]] = Seq.empty
 
-  override def optionalPrerequisiteOf = Seq.empty
+  override def optionalPrerequisiteOf: Seq[Dependency[B]] = Seq.empty
 
   override def invalidates(a: B): Boolean = (_currentState &~ _targets)(oToD(a))
 


### PR DESCRIPTION
This is a bug fix, before this PR, Scala compiler will infer `Nothing`, which makes code below failed to compile:
```
class UserCompiler extends TransformManager(Seq(Dependency(UserPass))) {
  override def optionalPrerequisiteOf: Seq[TransformDependency] = Seq(
    Dependency[DedupModules]
  )
}
```

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix
#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
