### PR TITLE
ir: make HashCode.toHashString public

### DIFF
--- a/src/main/scala/firrtl/ir/StructuralHash.scala
+++ b/src/main/scala/firrtl/ir/StructuralHash.scala
@@ -115,16 +115,20 @@ object StructuralHash {
 }
 
 trait HashCode {
-  protected val str: String
-  override def hashCode(): Int = str.hashCode
+
+  /** String representation of the hash code.
+    * Two instances of [[HashCode]] are equal if and only if their toHashString values are equal.
+    */
+  def toHashString: String
+  override def hashCode(): Int = toHashString.hashCode
   override def equals(obj: Any): Boolean = obj match {
-    case hashCode: HashCode => this.str.equals(hashCode.str)
+    case hashCode: HashCode => this.toHashString.equals(hashCode.toHashString)
     case _ => false
   }
 }
 
 private class MDHashCode(code: Array[Byte]) extends HashCode {
-  protected override val str: String = code.map(b => f"${b.toInt & 0xff}%02x").mkString("")
+  override val toHashString: String = code.map(b => f"${b.toInt & 0xff}%02x").mkString("")
 }
 
 /** Generic hashing interface which allows us to use different backends to trade of speed and collision resistance */

--- a/src/test/scala/firrtl/ir/StructuralHashSpec.scala
+++ b/src/test/scala/firrtl/ir/StructuralHashSpec.scala
@@ -38,6 +38,16 @@ class StructuralHashSpec extends AnyFlatSpec {
     assert(hash(b1) != hash(UIntLiteral(1, IntWidth(2))))
   }
 
+  it should "generate the same hash String if the objects are structurally the same" in {
+    assert(hash(b0).toHashString == hash(UIntLiteral(0, IntWidth(1))).toHashString)
+    assert(hash(b0).toHashString != hash(UIntLiteral(1, IntWidth(1))).toHashString)
+    assert(hash(b0).toHashString != hash(UIntLiteral(1, IntWidth(2))).toHashString)
+
+    assert(hash(b1).toHashString == hash(UIntLiteral(1, IntWidth(1))).toHashString)
+    assert(hash(b1).toHashString != hash(UIntLiteral(0, IntWidth(1))).toHashString)
+    assert(hash(b1).toHashString != hash(UIntLiteral(1, IntWidth(2))).toHashString)
+  }
+
   it should "ignore expression types" in {
     assert(hash(add) == hash(DoPrim(Add, Seq(b0, b1), Seq(), UnknownType)))
     assert(hash(add) == hash(DoPrim(Add, Seq(b0, b1), Seq(), UIntType(UnknownWidth))))


### PR DESCRIPTION
This will allow chiseltest to save the hash code to disk for the purpose of caching simulation binaries.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### Type of Improvement
- new feature/API

#### API Impact

- `HashCode` produced by ir.StructuralHash now has a public `str` method which returns a string representation of the hash

#### Backend Code Generation Impact

- none
#### Desired Merge Strategy
- squash
- 
### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
