### PR TITLE
Deprecate DependencyAPIMigration.

### DIFF
--- a/src/main/scala/firrtl/DependencyAPIMigration.scala
+++ b/src/main/scala/firrtl/DependencyAPIMigration.scala
@@ -16,7 +16,7 @@ import firrtl.stage.TransformManager.TransformDependency
   * For more information, see: https://bit.ly/2Voppre
   */
 @deprecated(
-  "DependencyAPIMigration will finish its job in FIRRTL 1.5, and it will be removed in FIRRTL 1.6",
+  "Please remove DependencyAPIMigration from your Transform to be compatible with FIRRTL 1.6."
   "FIRRTL 1.5"
 )
 trait DependencyAPIMigration { this: Transform =>

--- a/src/main/scala/firrtl/DependencyAPIMigration.scala
+++ b/src/main/scala/firrtl/DependencyAPIMigration.scala
@@ -16,7 +16,7 @@ import firrtl.stage.TransformManager.TransformDependency
   * For more information, see: https://bit.ly/2Voppre
   */
 @deprecated(
-  "Please remove DependencyAPIMigration from your Transform to be compatible with FIRRTL 1.6."
+  "Please remove DependencyAPIMigration from your Transform to be compatible with FIRRTL 1.6.",
   "FIRRTL 1.5"
 )
 trait DependencyAPIMigration { this: Transform =>

--- a/src/main/scala/firrtl/DependencyAPIMigration.scala
+++ b/src/main/scala/firrtl/DependencyAPIMigration.scala
@@ -15,6 +15,10 @@ import firrtl.stage.TransformManager.TransformDependency
   *
   * For more information, see: https://bit.ly/2Voppre
   */
+@deprecated(
+  "DependencyAPIMigration will finish its job in FIRRTL 1.5, and it will be removed in FIRRTL 1.6",
+  "FIRRTL 1.5"
+)
 trait DependencyAPIMigration { this: Transform =>
 
   @deprecated("Use Dependency API methods for equivalent functionality. See: https://bit.ly/2Voppre", "FIRRTL 1.3")


### PR DESCRIPTION
Again and again, I suffers from forgetting to add `override def invalidates(a: Transform): Boolean = false` to my transforms.
I think this is a right time to deprecate it.
My proposal is that we can deprecate it in FIRRTL 1.5, and remove this in FIRRTL 1.6.
After this PR get merged, I will start to fix all dependency to `DependencyAPIMigration` in the firrtl project.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code cleanup

#### API Impact
deprecate `DependencyAPIMigration`.

#### Backend Code Generation Impact
None

#### Desired Merge Strategy

- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
deprecate `DependencyAPIMigration`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
