### PR TITLE
Require Andr, Orr, Xorr, Neg to have one operand

### DIFF
--- a/src/main/scala/firrtl/passes/CheckHighForm.scala
+++ b/src/main/scala/firrtl/passes/CheckHighForm.scala
@@ -187,7 +187,7 @@ trait CheckHighFormLike { this: Pass =>
         case AsInterval =>
           correctNum(Option(1), 3)
         case Andr | Orr | Xorr | Neg =>
-          correctNum(None, 0)
+          correctNum(Option(1), 0)
       }
     }
 


### PR DESCRIPTION
Fix an OG bug where Andr, Orr, and Xorr would accept an arbitrary number
of operands.  Verilog emission doesn't support this and will silently
drop all operands after the first.  E.g., "andr(a, b)" would emit as
"&a".  After this commit, "andr(a, b)" will be rejected by checking
passes.

For archaeological purposes, this appears to have been the behavior
dating back to when this was added in d2d3260a.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

### Example

Start with:

```scala
circuit Foo :
  module Foo :
    input a: UInt<1>
    input b: UInt<1>
    output c: UInt<1>

    c <= orr(a, b)
```

If you compile this you get:

```verilog
module Foo(
  input   a,
  input   b,
  output  c
);
  assign c = |a;
endmodule
```

This patch causes:

```verilog
Exception in thread "main" firrtl.passes.CheckHighFormLike$IncorrectNumArgsException: : [module Foo] Primop orr requires 1 expression arguments.
```