### PR TITLE
Revert "Deprecate DependencyAPIMigration. (#2303)"

### DIFF
--- a/src/main/scala/firrtl/DependencyAPIMigration.scala
+++ b/src/main/scala/firrtl/DependencyAPIMigration.scala
@@ -15,10 +15,6 @@ import firrtl.stage.TransformManager.TransformDependency
   *
   * For more information, see: https://bit.ly/2Voppre
   */
-@deprecated(
-  "Please remove DependencyAPIMigration from your Transform to be compatible with FIRRTL 1.6.",
-  "FIRRTL 1.5"
-)
 trait DependencyAPIMigration { this: Transform =>
 
   @deprecated("Use Dependency API methods for equivalent functionality. See: https://bit.ly/2Voppre", "FIRRTL 1.3")


### PR DESCRIPTION
This reverts PR https://github.com/chipsalliance/firrtl/pull/2303 which was merged prematurely without a migration strategy in place.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
