### PR TITLE
Turn RenameMap into a trait and add MutableRenameMap

### DIFF
--- a/fuzzer/src/main/scala/firrtl/FirrtlEquivalenceTest.scala
+++ b/fuzzer/src/main/scala/firrtl/FirrtlEquivalenceTest.scala
@@ -13,6 +13,7 @@ import firrtl.annotations.{Annotation, CircuitTarget, ModuleTarget, Target}
 import firrtl.ir.Circuit
 import firrtl.options.Dependency
 import firrtl.options.phases.WriteOutputAnnotations
+import firrtl.renamemap.MutableRenameMap
 import firrtl.stage.{FirrtlCircuitAnnotation, InfoModeAnnotation, OutputFileAnnotation, TransformManager}
 import firrtl.stage.Forms.{VerilogMinimumOptimized, VerilogOptimized}
 import firrtl.transforms.{InlineBooleanExpressions, ManipulateNames}
@@ -36,7 +37,7 @@ object FirrtlEquivalenceTestUtils {
         case _: CircuitTarget => true
         case _: Target => false
       }
-      val renames = RenameMap()
+      val renames = MutableRenameMap()
       val circuitx = run(state.circuit, renames, block, allow)
       state.copy(circuit = circuitx, renames = Some(renames))
     }

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -13,6 +13,7 @@ import firrtl.ir.Circuit
 import firrtl.Utils.throwInternalError
 import firrtl.annotations.transforms.{EliminateTargetPaths, ResolvePaths}
 import firrtl.options.{Dependency, DependencyAPI, StageUtils, TransformLike}
+import firrtl.renamemap.MutableRenameMap
 import firrtl.stage.Forms
 import firrtl.transforms.DedupAnnotationsTransform
 
@@ -249,7 +250,7 @@ private[firrtl] object Transform {
     }
 
     // For each annotation, rename all annotations.
-    val renames = renameOpt.getOrElse(RenameMap())
+    val renames = renameOpt.getOrElse(MutableRenameMap())
     val remapped2original = mutable.LinkedHashMap[Annotation, mutable.LinkedHashSet[Annotation]]()
     val keysOfNote = mutable.LinkedHashSet[Annotation]()
     val finalAnnotations = newAnnotations.flatMap { anno =>

--- a/src/main/scala/firrtl/RenameMap.scala
+++ b/src/main/scala/firrtl/RenameMap.scala
@@ -7,18 +7,19 @@ import firrtl.RenameMap.IllegalRenameException
 import firrtl.analyses.InstanceKeyGraph
 import firrtl.annotations.TargetToken.{Field, Index, Instance, OfModule}
 import TargetUtils.{instKeyPathToTarget, unfoldInstanceTargets}
+import firrtl.renamemap._
 
 import scala.collection.mutable
 
 object RenameMap {
   def apply(map: collection.Map[Named, Seq[Named]]): RenameMap = {
-    val rm = new RenameMap
+    val rm = new MutableRenameMap
     rm.addMap(map)
     rm
   }
 
   def create(map: collection.Map[CompleteTarget, Seq[CompleteTarget]]): RenameMap = {
-    val rm = new RenameMap
+    val rm = new MutableRenameMap
     rm.recordAll(map)
     rm
   }
@@ -72,16 +73,8 @@ object RenameMap {
         underlying(fromx) = List(tox)
       }
     }
-    new RenameMap(underlying)
+    new MutableRenameMap(underlying)
   }
-
-  /** Initialize a new RenameMap */
-  def apply(): RenameMap = new RenameMap
-
-  // This is a private internal API for transforms where the .distinct operation is very expensive
-  // (eg. LowerTypes). The onus is on the user of this API to be very careful and not inject
-  // duplicates. This is a bad, hacky API that no one should use
-  private[firrtl] def noDistinct(): RenameMap = new RenameMap(doDistinct = false)
 
   abstract class RenameTargetException(reason: String) extends Exception(reason)
   case class IllegalRenameException(reason: String) extends RenameTargetException(reason)
@@ -90,20 +83,14 @@ object RenameMap {
 
 /** Map old names to new names
   *
-  * Transforms that modify names should return a [[RenameMap]] with the [[CircuitState]]
-  * These are mutable datastructures for convenience
+  * Transforms that modify names should return a [[RenameMap]] with the [[CircuitState]].
+  * Transform writers should use [[firrtl.renamemap.MutableRenameMap MutableRenameMap]] which is the
+  * only concrete subclass at the moment.
+  * Annotation writers **must not** rely on the concrete type of the [[RenameMap]] passed to `update`.
   * @define noteSelfRename @note Self renames *will* be recorded
   * @define noteDistinct @note Rename to/tos will be made distinct
   */
-// TODO This should probably be refactored into immutable and mutable versions
-final class RenameMap private (
-  val underlying: mutable.HashMap[CompleteTarget, Seq[CompleteTarget]] =
-    mutable.HashMap[CompleteTarget, Seq[CompleteTarget]](),
-  val chained: Option[RenameMap] = None,
-  // This is a private internal API for transforms where the .distinct operation is very expensive
-  // (eg. LowerTypes). The onus is on the user of this API to be very careful and not inject
-  // duplicates. This is a bad, hacky API that no one should use
-  doDistinct: Boolean = true) {
+sealed trait RenameMap {
 
   /** Chain a [[RenameMap]] with this [[RenameMap]]
     * @param next the map to chain with this map
@@ -111,69 +98,46 @@ final class RenameMap private (
     * $noteDistinct
     */
   def andThen(next: RenameMap): RenameMap = {
-    if (next.chained.isEmpty) {
-      new RenameMap(next.underlying, chained = Some(this))
-    } else {
-      new RenameMap(next.underlying, chained = next.chained.map(this.andThen(_)))
-    }
+    val self = this
+    if (self.isEmpty) next
+    else if (next.isEmpty) self
+    else
+      new RenameMap {
+        // We know this isn't empty because we have checked
+        override def isEmpty: Boolean = false
+
+        override def serialize: String = s"${self.serialize} andThen ${next.serialize}"
+
+        override protected def completeGet(key: CompleteTarget): Option[Seq[CompleteTarget]] = {
+          self
+            .get(key)
+            .map(_.flatMap(ct => next(ct)))
+            .orElse(next.get(key))
+        }
+      }
   }
 
-  /** Record that the from [[firrtl.annotations.CircuitTarget CircuitTarget]] is renamed to another
-    * [[firrtl.annotations.CircuitTarget CircuitTarget]]
-    * @param from
-    * @param to
-    * $noteSelfRename
-    * $noteDistinct
+  /** Create new [[RenameMap]] that merges this and renameMap
+    * @param renameMap
+    * @return
     */
-  def record(from: CircuitTarget, to: CircuitTarget): Unit = completeRename(from, Seq(to))
+  def ++(renameMap: RenameMap): RenameMap = {
+    val self = this
+    if (self.isEmpty) renameMap
+    else if (renameMap.isEmpty) self
+    else
+      new RenameMap {
+        // We know this isn't empty because we have checked
+        override def isEmpty: Boolean = false
 
-  /** Record that the from [[firrtl.annotations.CircuitTarget CircuitTarget]] is renamed to another sequence of
-    * [[firrtl.annotations.CircuitTarget CircuitTarget]]s
-    * @param from
-    * @param tos
-    * $noteSelfRename
-    * $noteDistinct
-    */
-  def record(from: CircuitTarget, tos: Seq[CircuitTarget]): Unit = completeRename(from, tos)
+        override def serialize: String = s"${self.serialize} ++ ${renameMap.serialize}"
 
-  /** Record that the from [[firrtl.annotations.IsMember Member]] is renamed to another [[firrtl.annotations.IsMember
-    * IsMember]]
-    * @param from
-    * @param to
-    * $noteSelfRename
-    * $noteDistinct
-    */
-  def record(from: IsMember, to: IsMember): Unit = completeRename(from, Seq(to))
-
-  /** Record that the from [[firrtl.annotations.IsMember IsMember]] is renamed to another sequence of
-    * [[firrtl.annotations.IsMember IsMember]]s
-    * @param from
-    * @param tos
-    * $noteSelfRename
-    * $noteDistinct
-    */
-  def record(from: IsMember, tos: Seq[IsMember]): Unit = completeRename(from, tos)
-
-  /** Records that the keys in map are also renamed to their corresponding value seqs. Only
-    * ([[firrtl.annotations.CircuitTarget CircuitTarget]] -> Seq[ [[firrtl.annotations.CircuitTarget CircuitTarget]] ])
-    * and ([[firrtl.annotations.IsMember IsMember]] -> Seq[ [[firrtl.annotations.IsMember IsMember]] ]) key/value
-    * allowed
-    * @param map
-    * $noteSelfRename
-    * $noteDistinct
-    */
-  def recordAll(map: collection.Map[CompleteTarget, Seq[CompleteTarget]]): Unit =
-    map.foreach {
-      case (from: IsComponent, tos: Seq[_]) => completeRename(from, tos)
-      case (from: IsModule, tos: Seq[_]) => completeRename(from, tos)
-      case (from: CircuitTarget, tos: Seq[_]) => completeRename(from, tos)
-      case other => Utils.throwInternalError(s"Illegal rename: ${other._1} -> ${other._2}")
-    }
-
-  /** Records that a [[firrtl.annotations.CompleteTarget CompleteTarget]] is deleted
-    * @param name
-    */
-  def delete(name: CompleteTarget): Unit = underlying(name) = Seq.empty
+        override protected def completeGet(key: CompleteTarget): Option[Seq[CompleteTarget]] =
+          renameMap
+            .get(key)
+            .orElse(self.get(key))
+      }
+  }
 
   /** Renames a [[firrtl.annotations.CompleteTarget CompleteTarget]]
     * @param t target to rename
@@ -199,510 +163,6 @@ final class RenameMap private (
     */
   def get(key: IsMember): Option[Seq[IsMember]] = completeGet(key).map { _.map { case x: IsMember => x } }
 
-  /** Create new [[RenameMap]] that merges this and renameMap
-    * @param renameMap
-    * @return
-    */
-  def ++(renameMap: RenameMap): RenameMap = {
-    val newChained = if (chained.nonEmpty && renameMap.chained.nonEmpty) {
-      Some(chained.get ++ renameMap.chained.get)
-    } else {
-      chained.map(_.copy())
-    }
-    new RenameMap(underlying = underlying ++ renameMap.getUnderlying, chained = newChained)
-  }
-
-  /** Creates a deep copy of this [[RenameMap]]
-    */
-  def copy(chained: Option[RenameMap] = chained): RenameMap = {
-    val ret = new RenameMap(chained = chained.map(_.copy()))
-    ret.recordAll(underlying)
-    ret
-  }
-
-  /** Returns the underlying map of rename information
-    * @return
-    */
-  def getUnderlying: collection.Map[CompleteTarget, Seq[CompleteTarget]] = underlying
-
-  /** @return Whether this [[RenameMap]] has collected any changes */
-  def hasChanges: Boolean = underlying.nonEmpty
-
-  def getReverseRenameMap: RenameMap = {
-    val reverseMap = mutable.HashMap[CompleteTarget, Seq[CompleteTarget]]()
-    underlying.keysIterator.foreach { key =>
-      apply(key).foreach { v =>
-        reverseMap(v) = key +: reverseMap.getOrElse(v, Nil)
-      }
-    }
-    RenameMap.create(reverseMap)
-  }
-
-  def keys: Iterator[CompleteTarget] = underlying.keysIterator
-
-  /** Serialize the underlying remapping of keys to new targets
-    * @return
-    */
-  def serialize: String = underlying.map {
-    case (k, v) =>
-      k.serialize + "=>" + v.map(_.serialize).mkString(", ")
-  }.mkString("\n")
-
-  /** Records which local InstanceTargets will require modification.
-    * Used to reduce time to rename nonlocal targets who's path does not require renaming
-    */
-  private val sensitivity = mutable.HashSet[IsComponent]()
-
-  /** Caches results of referenceGet. Is cleared any time a new rename target is added
-    */
-  private val traverseTokensCache = mutable.HashMap[ReferenceTarget, Option[Seq[IsComponent]]]()
-  private val traverseHierarchyCache = mutable.HashMap[ReferenceTarget, Option[Seq[IsComponent]]]()
-  private val traverseLeftCache = mutable.HashMap[InstanceTarget, Option[Seq[IsModule]]]()
-  private val traverseRightCache = mutable.HashMap[InstanceTarget, Option[Seq[IsModule]]]()
-
-  /** Updates [[sensitivity]]
-    * @param from original target
-    * @param to new target
-    */
-  private def recordSensitivity(from: CompleteTarget, to: CompleteTarget): Unit = {
-    (from, to) match {
-      case (f: IsMember, t: IsMember) =>
-        val fromSet = f.pathAsTargets.toSet
-        val toSet = t.pathAsTargets
-        sensitivity ++= (fromSet -- toSet)
-        sensitivity ++= (fromSet.map(_.asReference) -- toSet.map(_.asReference))
-      case other =>
-    }
-  }
-
-  /** Get renames of a [[firrtl.annotations.CompleteTarget CompleteTarget]]
-    * @param key Target referencing the original circuit
-    * @return Optionally return sequence of targets that key remaps to
-    */
-  private def completeGet(key: CompleteTarget): Option[Seq[CompleteTarget]] = {
-    if (chained.nonEmpty) {
-      val chainedRet = chained.get.completeGet(key).getOrElse(Seq(key))
-      if (chainedRet.isEmpty) {
-        Some(chainedRet)
-      } else {
-        val hereRet = (chainedRet.flatMap { target =>
-          hereCompleteGet(target).getOrElse(Seq(target))
-        }).distinct
-        if (hereRet.size == 1 && hereRet.head == key) { None }
-        else { Some(hereRet) }
-      }
-    } else {
-      hereCompleteGet(key)
-    }
-  }
-
-  private def hereCompleteGet(key: CompleteTarget): Option[Seq[CompleteTarget]] = {
-    val errors = mutable.ArrayBuffer[String]()
-    val ret = if (hasChanges) {
-      val ret = recursiveGet(errors)(key)
-      if (errors.nonEmpty) { throw IllegalRenameException(errors.mkString("\n")) }
-      if (ret.size == 1 && ret.head == key) { None }
-      else { Some(ret) }
-    } else { None }
-    ret
-  }
-
-  /** Checks for renames of only the component portion of a [[ReferenceTarget]]
-    * Recursively checks parent [[ReferenceTarget]]s until a match is found
-    * Parents with longer paths/components are checked first. longer paths take
-    * priority over longer components.
-    *
-    * For example, the order that targets are checked for ~Top|Top/a:A/b:B/c:C>f.g is:
-    * ~Top|Top/a:A/b:B/c:C>f.g
-    * ~Top|Top/a:A/b:B/c:C>f
-    * ~Top|A/b:B/c:C>f.g
-    * ~Top|A/b:B/c:C>f
-    * ~Top|B/c:C>f.g
-    * ~Top|B/c:C>f
-    * ~Top|C>f.g
-    * ~Top|C>f
-    *
-    * @param errors Used to record illegal renames
-    * @param key Target to rename
-    * @return Renamed targets if a match is found, otherwise None
-    */
-  private def referenceGet(errors: mutable.ArrayBuffer[String])(key: ReferenceTarget): Option[Seq[IsComponent]] = {
-    def traverseTokens(key: ReferenceTarget): Option[Seq[IsComponent]] = traverseTokensCache.getOrElseUpdate(
-      key, {
-        if (underlying.contains(key)) {
-          Some(underlying(key).flatMap {
-            case comp: IsComponent => Some(comp)
-            case other =>
-              errors += s"reference ${key.targetParent} cannot be renamed to a non-component ${other}"
-              None
-          })
-        } else {
-          key match {
-            case t: ReferenceTarget if t.component.nonEmpty =>
-              val last = t.component.last
-              val parent = t.copy(component = t.component.dropRight(1))
-              traverseTokens(parent).map(_.flatMap { x =>
-                (x, last) match {
-                  case (t2: InstanceTarget, Field(f)) => Some(t2.ref(f))
-                  case (t2: ReferenceTarget, Field(f)) => Some(t2.field(f))
-                  case (t2: ReferenceTarget, Index(i)) => Some(t2.index(i))
-                  case other =>
-                    errors += s"Illegal rename: ${key.targetParent} cannot be renamed to ${other._1} - must rename $key directly"
-                    None
-                }
-              })
-            case t: ReferenceTarget => None
-          }
-        }
-      }
-    )
-
-    def traverseHierarchy(key: ReferenceTarget): Option[Seq[IsComponent]] = traverseHierarchyCache.getOrElseUpdate(
-      key, {
-        val tokenRenamed = traverseTokens(key)
-        if (tokenRenamed.nonEmpty) {
-          tokenRenamed
-        } else {
-          key match {
-            case t: ReferenceTarget if t.isLocal => None
-            case t: ReferenceTarget =>
-              val encapsulatingInstance = t.path.head._1.value
-              val stripped = t.stripHierarchy(1)
-              traverseHierarchy(stripped).map(_.map {
-                _.addHierarchy(t.module, encapsulatingInstance)
-              })
-          }
-        }
-      }
-    )
-
-    traverseHierarchy(key)
-  }
-
-  /** Checks for renames of only the path portion of an [[InstanceTarget]]
-    * Recursively checks parent [[IsModule]]s until a match is found. First
-    * checks all parent paths from longest to shortest. Then recursively checks
-    * paths leading to the encapsulating module.  Stops on the first match
-    * found. When a match is found the parent instances that were stripped off
-    * are added back unless the child is renamed to an absolute instance target
-    * (target.module == target.circuit).
-    *
-    * For example, the order that targets are checked for ~Top|Top/a:A/b:B/c:C is:
-    * ~Top|Top/a:A/b:B/c:C
-    * ~Top|A/b:B/c:C
-    * ~Top|B/c:C
-    * ~Top|Top/a:A/b:B
-    * ~Top|A/b:B
-    * ~Top|Top/a:A
-    *
-    * @param errors Used to record illegal renames
-    * @param key Target to rename
-    * @return Renamed targets if a match is found, otherwise None
-    */
-  private def instanceGet(errors: mutable.ArrayBuffer[String])(key: InstanceTarget): Option[Seq[IsModule]] = {
-    def traverseLeft(key: InstanceTarget): Option[Seq[IsModule]] = traverseLeftCache.getOrElseUpdate(
-      key, {
-        val getOpt = underlying.get(key)
-
-        if (getOpt.nonEmpty) {
-          getOpt.map(_.flatMap {
-            case isMod: IsModule => Some(isMod)
-            case other =>
-              errors += s"IsModule: $key cannot be renamed to non-IsModule $other"
-              None
-          })
-        } else {
-          key match {
-            case t: InstanceTarget if t.isLocal => None
-            case t: InstanceTarget =>
-              val (Instance(outerInst), OfModule(outerMod)) = t.path.head
-              val stripped = t.copy(path = t.path.tail, module = outerMod)
-              traverseLeft(stripped).map(_.map {
-                case absolute if absolute.circuit == absolute.module => absolute
-                case relative                                        => relative.addHierarchy(t.module, outerInst)
-              })
-          }
-        }
-      }
-    )
-
-    def traverseRight(key: InstanceTarget): Option[Seq[IsModule]] = traverseRightCache.getOrElseUpdate(
-      key, {
-        val findLeft = traverseLeft(key)
-        if (findLeft.isDefined) {
-          findLeft
-        } else {
-          key match {
-            case t: InstanceTarget if t.isLocal => None
-            case t: InstanceTarget =>
-              val (Instance(i), OfModule(m)) = t.path.last
-              val parent = t.copy(path = t.path.dropRight(1), instance = i, ofModule = m)
-              traverseRight(parent).map(_.map(_.instOf(t.instance, t.ofModule)))
-          }
-        }
-      }
-    )
-
-    traverseRight(key)
-  }
-
-  private def circuitGet(errors: mutable.ArrayBuffer[String])(key: CircuitTarget): Seq[CircuitTarget] = {
-    underlying
-      .get(key)
-      .map(_.flatMap {
-        case c: CircuitTarget => Some(c)
-        case other =>
-          errors += s"Illegal rename: $key cannot be renamed to non-circuit target: $other"
-          None
-      })
-      .getOrElse(Seq(key))
-  }
-
-  private def moduleGet(errors: mutable.ArrayBuffer[String])(key: ModuleTarget): Option[Seq[IsModule]] = {
-    underlying
-      .get(key)
-      .map(_.flatMap {
-        case mod: IsModule => Some(mod)
-        case other =>
-          errors += s"Illegal rename: $key cannot be renamed to non-module target: $other"
-          None
-      })
-  }
-
-  // the possible results returned by ofModuleGet
-  private sealed trait OfModuleRenameResult
-
-  // an OfModule was renamed to an absolute module (t.module == t.circuit) and parent OfModules were not renamed
-  private case class AbsoluteOfModule(isMod: IsModule) extends OfModuleRenameResult
-
-  // all OfModules were renamed to relative modules, and their paths are concatenated together
-  private case class RenamedOfModules(children: Seq[(Instance, OfModule)]) extends OfModuleRenameResult
-
-  // an OfModule was deleted, thus the entire target was deleted
-  private case object DeletedOfModule extends OfModuleRenameResult
-
-  // no renamed of OfModules were found
-  private case object NoOfModuleRenames extends OfModuleRenameResult
-
-  /** Checks for renames of [[OfModule]]s in the path of and [[IsComponent]]
-    * from right to left.  Renamed [[OfModule]]s must all have the same circuit
-    * name and cannot be renamed to more than one target. [[OfModule]]s that
-    * are renamed to relative targets are inlined into the path of the original
-    * target. If it is renamed to an absolute target, then it becomes the
-    * parent path of the original target and renaming stops.
-    *
-    * Examples:
-    *
-    * RenameMap(~Top|A -> ~Top|Foo/bar:Bar):
-    * ofModuleGet(~Top|Top/a:A/b:B) == RenamedOfModules(a:Foo, bar:Bar, b:B)
-    *
-    * RenameMap(~Top|B -> ~Top|Top/foo:Foo/bar:Bar, ~Top|A -> ~Top|C):
-    * ofModuleGet(~Top|Top/a:A/b:B) == AbsoluteOfModule(~Top|Top/foo:Foo/bar:Bar/b:B)
-    *
-    * RenameMap(~Top|B -> deleted, ~Top|A -> ~Top|C):
-    * ofModuleGet(~Top|Top/a:A/b:B) == DeletedOfModule
-    *
-    * RenameMap.empty
-    * ofModuleGet(~Top|Top/a:A/b:B) == NoOfModuleRenames
-    *
-    * @param errors Used to record illegal renames
-    * @param key Target to rename
-    * @return rename results (see examples)
-    */
-  private def ofModuleGet(errors: mutable.ArrayBuffer[String])(key: IsComponent): OfModuleRenameResult = {
-    val circuit = key.circuit
-    def renameOfModules(
-      path:          Seq[(Instance, OfModule)],
-      foundRename:   Boolean,
-      newCircuitOpt: Option[String],
-      children:      Seq[(Instance, OfModule)]
-    ): OfModuleRenameResult = {
-      if (path.isEmpty && foundRename) {
-        RenamedOfModules(children)
-      } else if (path.isEmpty) {
-        NoOfModuleRenames
-      } else {
-        val pair = path.head
-        val pathMod = ModuleTarget(circuit, pair._2.value)
-        moduleGet(errors)(pathMod) match {
-          case None => renameOfModules(path.tail, foundRename, newCircuitOpt, pair +: children)
-          case Some(rename) =>
-            if (newCircuitOpt.isDefined && rename.exists(_.circuit != newCircuitOpt.get)) {
-              val error = s"ofModule ${pathMod} of target ${key.serialize} cannot be renamed to $rename " +
-                s"- renamed ofModules must have the same circuit name, expected circuit ${newCircuitOpt.get}"
-              errors += error
-            }
-            rename match {
-              case Seq(absolute: IsModule) if absolute.module == absolute.circuit =>
-                val withChildren = children.foldLeft(absolute) {
-                  case (target, (inst, ofMod)) => target.instOf(inst.value, ofMod.value)
-                }
-                AbsoluteOfModule(withChildren)
-              case Seq(isMod: ModuleTarget) =>
-                val newPair = pair.copy(_2 = OfModule(isMod.module))
-                renameOfModules(path.tail, true, Some(isMod.circuit), newPair +: children)
-              case Seq(isMod: InstanceTarget) =>
-                val newPair = pair.copy(_2 = OfModule(isMod.module))
-                renameOfModules(path.tail, true, Some(isMod.circuit), newPair +: (isMod.asPath ++ children))
-              case Nil =>
-                DeletedOfModule
-              case other =>
-                val error = s"ofModule ${pathMod} of target ${key.serialize} cannot be renamed to $other " +
-                  "- an ofModule can only be deleted or renamed to a single IsModule"
-                errors += error
-                renameOfModules(path.tail, foundRename, newCircuitOpt, pair +: children)
-            }
-        }
-      }
-    }
-    renameOfModules(key.asPath.reverse, false, None, Nil)
-  }
-
-  /** Recursively renames a target so the returned targets are complete renamed
-    * @param errors Used to record illegal renames
-    * @param key Target to rename
-    * @return Renamed targets
-    */
-  private def recursiveGet(errors: mutable.ArrayBuffer[String])(key: CompleteTarget): Seq[CompleteTarget] = {
-    // rename just the component portion; path/ref/component for ReferenceTargets or path/instance for InstanceTargets
-    val componentRename = key match {
-      case t:   CircuitTarget                  => None
-      case t:   ModuleTarget                   => None
-      case t:   InstanceTarget                 => instanceGet(errors)(t)
-      case ref: ReferenceTarget if ref.isLocal => referenceGet(errors)(ref)
-      case ref @ ReferenceTarget(c, m, p, r, t) =>
-        val (Instance(inst), OfModule(ofMod)) = p.last
-        val refGet = referenceGet(errors)(ref)
-        if (refGet.isDefined) {
-          refGet
-        } else {
-          val parent = InstanceTarget(c, m, p.dropRight(1), inst, ofMod)
-          instanceGet(errors)(parent).map(_.map(ref.setPathTarget(_)))
-        }
-    }
-
-    // if no component rename was found, look for Module renames; root module/OfModules in path
-    val moduleRename = if (componentRename.isDefined) {
-      componentRename
-    } else {
-      key match {
-        case t: CircuitTarget => None
-        case t: ModuleTarget => moduleGet(errors)(t)
-        case t: IsComponent =>
-          ofModuleGet(errors)(t) match {
-            case AbsoluteOfModule(absolute) =>
-              t match {
-                case ref: ReferenceTarget =>
-                  Some(Seq(ref.copy(circuit = absolute.circuit, module = absolute.module, path = absolute.asPath)))
-                case inst: InstanceTarget => Some(Seq(absolute))
-              }
-            case RenamedOfModules(children) =>
-              // rename the root module and set the new path
-              val modTarget = ModuleTarget(t.circuit, t.module)
-              val result = moduleGet(errors)(modTarget).getOrElse(Seq(modTarget)).map { mod =>
-                val newPath = mod.asPath ++ children
-
-                t match {
-                  case ref:  ReferenceTarget => ref.copy(circuit = mod.circuit, module = mod.module, path = newPath)
-                  case inst: InstanceTarget =>
-                    val (Instance(newInst), OfModule(newOfMod)) = newPath.last
-                    inst.copy(
-                      circuit = mod.circuit,
-                      module = mod.module,
-                      path = newPath.dropRight(1),
-                      instance = newInst,
-                      ofModule = newOfMod
-                    )
-                }
-              }
-              Some(result)
-            case DeletedOfModule => Some(Nil)
-            case NoOfModuleRenames =>
-              val modTarget = ModuleTarget(t.circuit, t.module)
-              val children = t.asPath
-              moduleGet(errors)(modTarget).map(_.map { mod =>
-                val newPath = mod.asPath ++ children
-
-                t match {
-                  case ref:  ReferenceTarget => ref.copy(circuit = mod.circuit, module = mod.module, path = newPath)
-                  case inst: InstanceTarget =>
-                    val (Instance(newInst), OfModule(newOfMod)) = newPath.last
-                    inst.copy(
-                      circuit = mod.circuit,
-                      module = mod.module,
-                      path = newPath.dropRight(1),
-                      instance = newInst,
-                      ofModule = newOfMod
-                    )
-                }
-              })
-          }
-      }
-    }
-
-    // if no module renames were found, look for circuit renames;
-    val circuitRename = if (moduleRename.isDefined) {
-      moduleRename.get
-    } else {
-      key match {
-        case t: CircuitTarget => circuitGet(errors)(t)
-        case t: ModuleTarget =>
-          circuitGet(errors)(CircuitTarget(t.circuit)).map {
-            case CircuitTarget(c) => t.copy(circuit = c)
-          }
-        case t: IsComponent =>
-          circuitGet(errors)(CircuitTarget(t.circuit)).map {
-            case CircuitTarget(c) =>
-              t match {
-                case ref:  ReferenceTarget => ref.copy(circuit = c)
-                case inst: InstanceTarget  => inst.copy(circuit = c)
-              }
-          }
-      }
-    }
-
-    circuitRename
-  }
-
-  /** Fully rename `from` to `tos`
-    * @param from
-    * @param tos
-    */
-  private def completeRename(from: CompleteTarget, tos: Seq[CompleteTarget]): Unit = {
-    tos.foreach { recordSensitivity(from, _) }
-    val existing = underlying.getOrElse(from, Vector.empty)
-    val updated = {
-      val all = (existing ++ tos)
-      if (doDistinct) all.distinct else all
-    }
-    underlying(from) = updated
-    traverseTokensCache.clear()
-    traverseHierarchyCache.clear()
-    traverseLeftCache.clear()
-    traverseRightCache.clear()
-  }
-
-  /* DEPRECATED ACCESSOR/SETTOR METHODS WITH [[firrtl.ir.Named Named]] */
-
-  def rename(from: Named, to: Named): Unit = rename(from, Seq(to))
-
-  def rename(from: Named, tos: Seq[Named]): Unit = recordAll(Map(from.toTarget -> tos.map(_.toTarget)))
-
-  def rename(from: ComponentName, to: ComponentName): Unit = record(from, to)
-
-  def rename(from: ComponentName, tos: Seq[ComponentName]): Unit = record(from, tos.map(_.toTarget))
-
-  def delete(name: CircuitName): Unit = underlying(name) = Seq.empty
-
-  def delete(name: ModuleName): Unit = underlying(name) = Seq.empty
-
-  def delete(name: ComponentName): Unit = underlying(name) = Seq.empty
-
-  def addMap(map: collection.Map[Named, Seq[Named]]): Unit =
-    recordAll(map.map {
-      case (key, values) => (Target.convertNamed2Target(key), values.map(Target.convertNamed2Target))
-    })
-
   def get(key: CircuitName): Option[Seq[CircuitName]] = {
     get(Target.convertCircuitName2CircuitTarget(key)).map(_.collect { case c: CircuitTarget => c.toNamed })
   }
@@ -720,53 +180,683 @@ final class RenameMap private (
     case other => get(key.toTarget).map(_.collect { case c: IsComponent => c.toNamed })
   }
 
-  // Mutable helpers - APIs that set these are deprecated!
-  private var circuitName: String = ""
-  private var moduleName:  String = ""
+  /** @return True if this [[RenameMap]] will *not* rename any [[firrtl.annotations.Target Target]]s */
+  def isEmpty: Boolean
 
-  /** Sets mutable state to record current module we are visiting
-    * @param module
-    */
-  def setModule(module: String): Unit = moduleName = module
+  /** @return True if this [[RenameMap]] will *not* rename any [[firrtl.annotations.Target Target]]s */
+  final def nonEmpty: Boolean = !isEmpty
 
-  /** Sets mutable state to record current circuit we are visiting
-    * @param circuit
-    */
-  def setCircuit(circuit: String): Unit = circuitName = circuit
+  /** Provides a useful visualization of this [[RenameMap]] */
+  def serialize: String
 
-  /** Records how a reference maps to a new reference
-    * @param from
-    * @param to
+  /** Get renames of a [[firrtl.annotations.CompleteTarget CompleteTarget]]
+    * @param key Target referencing the original circuit
+    * @return Optionally return sequence of targets that key remaps to
     */
-  def rename(from: String, to: String): Unit = rename(from, Seq(to))
+  protected def completeGet(key: CompleteTarget): Option[Seq[CompleteTarget]]
+}
 
-  /** Records how a reference maps to a new reference
-    * The reference's root module and circuit are determined by whomever called setModule or setCircuit last
-    * @param from
-    * @param tos
-    */
-  def rename(from: String, tos: Seq[String]): Unit = {
-    val mn = ModuleName(moduleName, CircuitName(circuitName))
-    val fromName = ComponentName(from, mn).toTarget
-    val tosName = tos.map { to => ComponentName(to, mn).toTarget }
-    record(fromName, tosName)
-  }
-
-  /** Records named reference is deleted
-    * The reference's root module and circuit are determined by whomever called setModule or setCircuit last
-    * @param name
-    */
-  def delete(name: String): Unit = {
-    Target(Some(circuitName), Some(moduleName), AnnotationUtils.toSubComponents(name)).getComplete match {
-      case Some(t: CircuitTarget) => delete(t)
-      case Some(m: IsMember) => delete(m)
-      case other =>
+// This must be in same file as RenameMap because RenameMap is sealed
+package object renamemap {
+  object MutableRenameMap {
+    def fromNamed(map: collection.Map[Named, Seq[Named]]): MutableRenameMap = {
+      val rm = new MutableRenameMap
+      rm.addMap(map)
+      rm
     }
+
+    def apply(ts: Iterable[(CompleteTarget, Iterable[CompleteTarget])]): MutableRenameMap = {
+      val rm = new MutableRenameMap
+      rm.recordAll(ts)
+      rm
+    }
+
+    /** Initialize an empty [[MutableRenameMap]] */
+    def apply(): MutableRenameMap = new MutableRenameMap
+
+    // This is a private internal API for transforms where the .distinct operation is very expensive
+    // (eg. LowerTypes). The onus is on the user of this API to be very careful and not inject
+    // duplicates. This is a bad, hacky API that no one should use
+    private[firrtl] def noDistinct(): MutableRenameMap = new MutableRenameMap(doDistinct = false)
   }
 
-  /** Records that references in names are all deleted
-    * The reference's root module and circuit are determined by whomever called setModule or setCircuit last
-    * @param names
-    */
-  def delete(names: Seq[String]): Unit = names.foreach(delete(_))
+  /** Legacy implementation of [[RenameMap]], mutable jack of all trades for handling renaming */
+  final class MutableRenameMap private[firrtl] (
+    val underlying: mutable.HashMap[CompleteTarget, Seq[CompleteTarget]] =
+      mutable.HashMap[CompleteTarget, Seq[CompleteTarget]](),
+    val chained: Option[MutableRenameMap] = None,
+    // This is a private internal API for transforms where the .distinct operation is very expensive
+    // (eg. LowerTypes). The onus is on the user of this API to be very careful and not inject
+    // duplicates. This is a bad, hacky API that no one should use
+    doDistinct: Boolean = true)
+      extends RenameMap {
+
+    /** Chain a [[RenameMap]] with this [[RenameMap]]
+      * @param next the map to chain with this map
+      * $noteSelfRename
+      * $noteDistinct
+      */
+    def andThen(next: MutableRenameMap): MutableRenameMap = {
+      if (next.chained.isEmpty) {
+        new MutableRenameMap(next.underlying, chained = Some(this))
+      } else {
+        new MutableRenameMap(next.underlying, chained = next.chained.map(this.andThen(_)))
+      }
+    }
+
+    /** Record that the from [[firrtl.annotations.CircuitTarget CircuitTarget]] is renamed to another
+      * [[firrtl.annotations.CircuitTarget CircuitTarget]]
+      * @param from
+      * @param to
+      * $noteSelfRename
+      * $noteDistinct
+      */
+    def record(from: CircuitTarget, to: CircuitTarget): Unit = completeRename(from, Seq(to))
+
+    /** Record that the from [[firrtl.annotations.CircuitTarget CircuitTarget]] is renamed to another sequence of
+      * [[firrtl.annotations.CircuitTarget CircuitTarget]]s
+      * @param from
+      * @param tos
+      * $noteSelfRename
+      * $noteDistinct
+      */
+    def record(from: CircuitTarget, tos: Seq[CircuitTarget]): Unit = completeRename(from, tos)
+
+    /** Record that the from [[firrtl.annotations.IsMember Member]] is renamed to another [[firrtl.annotations.IsMember
+      * IsMember]]
+      * @param from
+      * @param to
+      * $noteSelfRename
+      * $noteDistinct
+      */
+    def record(from: IsMember, to: IsMember): Unit = completeRename(from, Seq(to))
+
+    /** Record that the from [[firrtl.annotations.IsMember IsMember]] is renamed to another sequence of
+      * [[firrtl.annotations.IsMember IsMember]]s
+      * @param from
+      * @param tos
+      * $noteSelfRename
+      * $noteDistinct
+      */
+    def record(from: IsMember, tos: Seq[IsMember]): Unit = completeRename(from, tos)
+
+    /** Records that the keys in map are also renamed to their corresponding value seqs. Only
+      * ([[firrtl.annotations.CircuitTarget CircuitTarget]] -> Seq[ [[firrtl.annotations.CircuitTarget CircuitTarget]] ])
+      * and ([[firrtl.annotations.IsMember IsMember]] -> Seq[ [[firrtl.annotations.IsMember IsMember]] ]) key/value
+      * allowed
+      * @param map
+      * $noteSelfRename
+      * $noteDistinct
+      */
+    def recordAll(map: Iterable[(CompleteTarget, Iterable[CompleteTarget])]): Unit =
+      map.foreach {
+        case (from: IsComponent, tos) => completeRename(from, tos)
+        case (from: IsModule, tos) => completeRename(from, tos)
+        case (from: CircuitTarget, tos) => completeRename(from, tos)
+        case other => Utils.throwInternalError(s"Illegal rename: ${other._1} -> ${other._2}")
+      }
+
+    /** Records that a [[firrtl.annotations.CompleteTarget CompleteTarget]] is deleted
+      * @param name
+      */
+    def delete(name: CompleteTarget): Unit = underlying(name) = Seq.empty
+
+    /** Create new [[RenameMap]] that merges this and renameMap
+      * @param renameMap
+      * @return
+      */
+    def ++(renameMap: MutableRenameMap): MutableRenameMap = {
+      val newChained = if (chained.nonEmpty && renameMap.chained.nonEmpty) {
+        Some(chained.get ++ renameMap.chained.get)
+      } else {
+        chained.map(_.copy())
+      }
+      new MutableRenameMap(underlying = underlying ++ renameMap.getUnderlying, chained = newChained)
+    }
+
+    /** Creates a deep copy of this [[RenameMap]]
+      */
+    def copy(chained: Option[MutableRenameMap] = chained): MutableRenameMap = {
+      val ret = new MutableRenameMap(chained = chained.map(_.copy()))
+      ret.recordAll(underlying)
+      ret
+    }
+
+    /** Returns the underlying map of rename information
+      * @return
+      */
+    def getUnderlying: collection.Map[CompleteTarget, Seq[CompleteTarget]] = underlying
+
+    /** @return Whether this [[RenameMap]] has collected any changes */
+    def hasChanges: Boolean = underlying.nonEmpty
+
+    def getReverseRenameMap: RenameMap = {
+      val reverseMap = mutable.HashMap[CompleteTarget, Seq[CompleteTarget]]()
+      underlying.keysIterator.foreach { key =>
+        apply(key).foreach { v =>
+          reverseMap(v) = key +: reverseMap.getOrElse(v, Nil)
+        }
+      }
+      RenameMap.create(reverseMap)
+    }
+
+    def keys: Iterator[CompleteTarget] = underlying.keysIterator
+
+    /** Serialize the underlying remapping of keys to new targets
+      * @return
+      */
+    def serialize: String = underlying.map {
+      case (k, v) =>
+        k.serialize + "=>" + v.map(_.serialize).mkString(", ")
+    }.mkString("\n")
+
+    /** Records which local InstanceTargets will require modification.
+      * Used to reduce time to rename nonlocal targets who's path does not require renaming
+      */
+    private val sensitivity = mutable.HashSet[IsComponent]()
+
+    /** Caches results of referenceGet. Is cleared any time a new rename target is added
+      */
+    private val traverseTokensCache = mutable.HashMap[ReferenceTarget, Option[Seq[IsComponent]]]()
+    private val traverseHierarchyCache = mutable.HashMap[ReferenceTarget, Option[Seq[IsComponent]]]()
+    private val traverseLeftCache = mutable.HashMap[InstanceTarget, Option[Seq[IsModule]]]()
+    private val traverseRightCache = mutable.HashMap[InstanceTarget, Option[Seq[IsModule]]]()
+
+    /** Updates [[sensitivity]]
+      * @param from original target
+      * @param to new target
+      */
+    private def recordSensitivity(from: CompleteTarget, to: CompleteTarget): Unit = {
+      (from, to) match {
+        case (f: IsMember, t: IsMember) =>
+          val fromSet = f.pathAsTargets.toSet
+          val toSet = t.pathAsTargets
+          sensitivity ++= (fromSet -- toSet)
+          sensitivity ++= (fromSet.map(_.asReference) -- toSet.map(_.asReference))
+        case other =>
+      }
+    }
+
+    /** Get renames of a [[firrtl.annotations.CompleteTarget CompleteTarget]]
+      * @param key Target referencing the original circuit
+      * @return Optionally return sequence of targets that key remaps to
+      */
+    protected def completeGet(key: CompleteTarget): Option[Seq[CompleteTarget]] = {
+      if (chained.nonEmpty) {
+        val chainedRet = chained.get.completeGet(key).getOrElse(Seq(key))
+        if (chainedRet.isEmpty) {
+          Some(chainedRet)
+        } else {
+          val hereRet = (chainedRet.flatMap { target =>
+            hereCompleteGet(target).getOrElse(Seq(target))
+          }).distinct
+          if (hereRet.size == 1 && hereRet.head == key) { None }
+          else { Some(hereRet) }
+        }
+      } else {
+        hereCompleteGet(key)
+      }
+    }
+
+    private def hereCompleteGet(key: CompleteTarget): Option[Seq[CompleteTarget]] = {
+      val errors = mutable.ArrayBuffer[String]()
+      val ret = if (hasChanges) {
+        val ret = recursiveGet(errors)(key)
+        if (errors.nonEmpty) { throw IllegalRenameException(errors.mkString("\n")) }
+        if (ret.size == 1 && ret.head == key) { None }
+        else { Some(ret) }
+      } else { None }
+      ret
+    }
+
+    /** Checks for renames of only the component portion of a [[ReferenceTarget]]
+      * Recursively checks parent [[ReferenceTarget]]s until a match is found
+      * Parents with longer paths/components are checked first. longer paths take
+      * priority over longer components.
+      *
+      * For example, the order that targets are checked for ~Top|Top/a:A/b:B/c:C>f.g is:
+      * ~Top|Top/a:A/b:B/c:C>f.g
+      * ~Top|Top/a:A/b:B/c:C>f
+      * ~Top|A/b:B/c:C>f.g
+      * ~Top|A/b:B/c:C>f
+      * ~Top|B/c:C>f.g
+      * ~Top|B/c:C>f
+      * ~Top|C>f.g
+      * ~Top|C>f
+      *
+      * @param errors Used to record illegal renames
+      * @param key Target to rename
+      * @return Renamed targets if a match is found, otherwise None
+      */
+    private def referenceGet(errors: mutable.ArrayBuffer[String])(key: ReferenceTarget): Option[Seq[IsComponent]] = {
+      def traverseTokens(key: ReferenceTarget): Option[Seq[IsComponent]] = traverseTokensCache.getOrElseUpdate(
+        key, {
+          if (underlying.contains(key)) {
+            Some(underlying(key).flatMap {
+              case comp: IsComponent => Some(comp)
+              case other =>
+                errors += s"reference ${key.targetParent} cannot be renamed to a non-component ${other}"
+                None
+            })
+          } else {
+            key match {
+              case t: ReferenceTarget if t.component.nonEmpty =>
+                val last = t.component.last
+                val parent = t.copy(component = t.component.dropRight(1))
+                traverseTokens(parent).map(_.flatMap { x =>
+                  (x, last) match {
+                    case (t2: InstanceTarget, Field(f)) => Some(t2.ref(f))
+                    case (t2: ReferenceTarget, Field(f)) => Some(t2.field(f))
+                    case (t2: ReferenceTarget, Index(i)) => Some(t2.index(i))
+                    case other =>
+                      errors += s"Illegal rename: ${key.targetParent} cannot be renamed to ${other._1} - must rename $key directly"
+                      None
+                  }
+                })
+              case t: ReferenceTarget => None
+            }
+          }
+        }
+      )
+
+      def traverseHierarchy(key: ReferenceTarget): Option[Seq[IsComponent]] = traverseHierarchyCache.getOrElseUpdate(
+        key, {
+          val tokenRenamed = traverseTokens(key)
+          if (tokenRenamed.nonEmpty) {
+            tokenRenamed
+          } else {
+            key match {
+              case t: ReferenceTarget if t.isLocal => None
+              case t: ReferenceTarget =>
+                val encapsulatingInstance = t.path.head._1.value
+                val stripped = t.stripHierarchy(1)
+                traverseHierarchy(stripped).map(_.map {
+                  _.addHierarchy(t.module, encapsulatingInstance)
+                })
+            }
+          }
+        }
+      )
+
+      traverseHierarchy(key)
+    }
+
+    /** Checks for renames of only the path portion of an [[InstanceTarget]]
+      * Recursively checks parent [[IsModule]]s until a match is found. First
+      * checks all parent paths from longest to shortest. Then recursively checks
+      * paths leading to the encapsulating module.  Stops on the first match
+      * found. When a match is found the parent instances that were stripped off
+      * are added back unless the child is renamed to an absolute instance target
+      * (target.module == target.circuit).
+      *
+      * For example, the order that targets are checked for ~Top|Top/a:A/b:B/c:C is:
+      * ~Top|Top/a:A/b:B/c:C
+      * ~Top|A/b:B/c:C
+      * ~Top|B/c:C
+      * ~Top|Top/a:A/b:B
+      * ~Top|A/b:B
+      * ~Top|Top/a:A
+      *
+      * @param errors Used to record illegal renames
+      * @param key Target to rename
+      * @return Renamed targets if a match is found, otherwise None
+      */
+    private def instanceGet(errors: mutable.ArrayBuffer[String])(key: InstanceTarget): Option[Seq[IsModule]] = {
+      def traverseLeft(key: InstanceTarget): Option[Seq[IsModule]] = traverseLeftCache.getOrElseUpdate(
+        key, {
+          val getOpt = underlying.get(key)
+
+          if (getOpt.nonEmpty) {
+            getOpt.map(_.flatMap {
+              case isMod: IsModule => Some(isMod)
+              case other =>
+                errors += s"IsModule: $key cannot be renamed to non-IsModule $other"
+                None
+            })
+          } else {
+            key match {
+              case t: InstanceTarget if t.isLocal => None
+              case t: InstanceTarget =>
+                val (Instance(outerInst), OfModule(outerMod)) = t.path.head
+                val stripped = t.copy(path = t.path.tail, module = outerMod)
+                traverseLeft(stripped).map(_.map {
+                  case absolute if absolute.circuit == absolute.module => absolute
+                  case relative                                        => relative.addHierarchy(t.module, outerInst)
+                })
+            }
+          }
+        }
+      )
+
+      def traverseRight(key: InstanceTarget): Option[Seq[IsModule]] = traverseRightCache.getOrElseUpdate(
+        key, {
+          val findLeft = traverseLeft(key)
+          if (findLeft.isDefined) {
+            findLeft
+          } else {
+            key match {
+              case t: InstanceTarget if t.isLocal => None
+              case t: InstanceTarget =>
+                val (Instance(i), OfModule(m)) = t.path.last
+                val parent = t.copy(path = t.path.dropRight(1), instance = i, ofModule = m)
+                traverseRight(parent).map(_.map(_.instOf(t.instance, t.ofModule)))
+            }
+          }
+        }
+      )
+
+      traverseRight(key)
+    }
+
+    private def circuitGet(errors: mutable.ArrayBuffer[String])(key: CircuitTarget): Seq[CircuitTarget] = {
+      underlying
+        .get(key)
+        .map(_.flatMap {
+          case c: CircuitTarget => Some(c)
+          case other =>
+            errors += s"Illegal rename: $key cannot be renamed to non-circuit target: $other"
+            None
+        })
+        .getOrElse(Seq(key))
+    }
+
+    private def moduleGet(errors: mutable.ArrayBuffer[String])(key: ModuleTarget): Option[Seq[IsModule]] = {
+      underlying
+        .get(key)
+        .map(_.flatMap {
+          case mod: IsModule => Some(mod)
+          case other =>
+            errors += s"Illegal rename: $key cannot be renamed to non-module target: $other"
+            None
+        })
+    }
+
+    // the possible results returned by ofModuleGet
+    private sealed trait OfModuleRenameResult
+
+    // an OfModule was renamed to an absolute module (t.module == t.circuit) and parent OfModules were not renamed
+    private case class AbsoluteOfModule(isMod: IsModule) extends OfModuleRenameResult
+
+    // all OfModules were renamed to relative modules, and their paths are concatenated together
+    private case class RenamedOfModules(children: Seq[(Instance, OfModule)]) extends OfModuleRenameResult
+
+    // an OfModule was deleted, thus the entire target was deleted
+    private case object DeletedOfModule extends OfModuleRenameResult
+
+    // no renamed of OfModules were found
+    private case object NoOfModuleRenames extends OfModuleRenameResult
+
+    /** Checks for renames of [[OfModule]]s in the path of and [[IsComponent]]
+      * from right to left.  Renamed [[OfModule]]s must all have the same circuit
+      * name and cannot be renamed to more than one target. [[OfModule]]s that
+      * are renamed to relative targets are inlined into the path of the original
+      * target. If it is renamed to an absolute target, then it becomes the
+      * parent path of the original target and renaming stops.
+      *
+      * Examples:
+      *
+      * RenameMap(~Top|A -> ~Top|Foo/bar:Bar):
+      * ofModuleGet(~Top|Top/a:A/b:B) == RenamedOfModules(a:Foo, bar:Bar, b:B)
+      *
+      * RenameMap(~Top|B -> ~Top|Top/foo:Foo/bar:Bar, ~Top|A -> ~Top|C):
+      * ofModuleGet(~Top|Top/a:A/b:B) == AbsoluteOfModule(~Top|Top/foo:Foo/bar:Bar/b:B)
+      *
+      * RenameMap(~Top|B -> deleted, ~Top|A -> ~Top|C):
+      * ofModuleGet(~Top|Top/a:A/b:B) == DeletedOfModule
+      *
+      * RenameMap.empty
+      * ofModuleGet(~Top|Top/a:A/b:B) == NoOfModuleRenames
+      *
+      * @param errors Used to record illegal renames
+      * @param key Target to rename
+      * @return rename results (see examples)
+      */
+    private def ofModuleGet(errors: mutable.ArrayBuffer[String])(key: IsComponent): OfModuleRenameResult = {
+      val circuit = key.circuit
+      def renameOfModules(
+        path:          Seq[(Instance, OfModule)],
+        foundRename:   Boolean,
+        newCircuitOpt: Option[String],
+        children:      Seq[(Instance, OfModule)]
+      ): OfModuleRenameResult = {
+        if (path.isEmpty && foundRename) {
+          RenamedOfModules(children)
+        } else if (path.isEmpty) {
+          NoOfModuleRenames
+        } else {
+          val pair = path.head
+          val pathMod = ModuleTarget(circuit, pair._2.value)
+          moduleGet(errors)(pathMod) match {
+            case None => renameOfModules(path.tail, foundRename, newCircuitOpt, pair +: children)
+            case Some(rename) =>
+              if (newCircuitOpt.isDefined && rename.exists(_.circuit != newCircuitOpt.get)) {
+                val error = s"ofModule ${pathMod} of target ${key.serialize} cannot be renamed to $rename " +
+                  s"- renamed ofModules must have the same circuit name, expected circuit ${newCircuitOpt.get}"
+                errors += error
+              }
+              rename match {
+                case Seq(absolute: IsModule) if absolute.module == absolute.circuit =>
+                  val withChildren = children.foldLeft(absolute) {
+                    case (target, (inst, ofMod)) => target.instOf(inst.value, ofMod.value)
+                  }
+                  AbsoluteOfModule(withChildren)
+                case Seq(isMod: ModuleTarget) =>
+                  val newPair = pair.copy(_2 = OfModule(isMod.module))
+                  renameOfModules(path.tail, true, Some(isMod.circuit), newPair +: children)
+                case Seq(isMod: InstanceTarget) =>
+                  val newPair = pair.copy(_2 = OfModule(isMod.module))
+                  renameOfModules(path.tail, true, Some(isMod.circuit), newPair +: (isMod.asPath ++ children))
+                case Nil =>
+                  DeletedOfModule
+                case other =>
+                  val error = s"ofModule ${pathMod} of target ${key.serialize} cannot be renamed to $other " +
+                    "- an ofModule can only be deleted or renamed to a single IsModule"
+                  errors += error
+                  renameOfModules(path.tail, foundRename, newCircuitOpt, pair +: children)
+              }
+          }
+        }
+      }
+      renameOfModules(key.asPath.reverse, false, None, Nil)
+    }
+
+    /** Recursively renames a target so the returned targets are complete renamed
+      * @param errors Used to record illegal renames
+      * @param key Target to rename
+      * @return Renamed targets
+      */
+    private def recursiveGet(errors: mutable.ArrayBuffer[String])(key: CompleteTarget): Seq[CompleteTarget] = {
+      // rename just the component portion; path/ref/component for ReferenceTargets or path/instance for InstanceTargets
+      val componentRename = key match {
+        case t:   CircuitTarget                  => None
+        case t:   ModuleTarget                   => None
+        case t:   InstanceTarget                 => instanceGet(errors)(t)
+        case ref: ReferenceTarget if ref.isLocal => referenceGet(errors)(ref)
+        case ref @ ReferenceTarget(c, m, p, r, t) =>
+          val (Instance(inst), OfModule(ofMod)) = p.last
+          val refGet = referenceGet(errors)(ref)
+          if (refGet.isDefined) {
+            refGet
+          } else {
+            val parent = InstanceTarget(c, m, p.dropRight(1), inst, ofMod)
+            instanceGet(errors)(parent).map(_.map(ref.setPathTarget(_)))
+          }
+      }
+
+      // if no component rename was found, look for Module renames; root module/OfModules in path
+      val moduleRename = if (componentRename.isDefined) {
+        componentRename
+      } else {
+        key match {
+          case t: CircuitTarget => None
+          case t: ModuleTarget => moduleGet(errors)(t)
+          case t: IsComponent =>
+            ofModuleGet(errors)(t) match {
+              case AbsoluteOfModule(absolute) =>
+                t match {
+                  case ref: ReferenceTarget =>
+                    Some(Seq(ref.copy(circuit = absolute.circuit, module = absolute.module, path = absolute.asPath)))
+                  case inst: InstanceTarget => Some(Seq(absolute))
+                }
+              case RenamedOfModules(children) =>
+                // rename the root module and set the new path
+                val modTarget = ModuleTarget(t.circuit, t.module)
+                val result = moduleGet(errors)(modTarget).getOrElse(Seq(modTarget)).map { mod =>
+                  val newPath = mod.asPath ++ children
+
+                  t match {
+                    case ref:  ReferenceTarget => ref.copy(circuit = mod.circuit, module = mod.module, path = newPath)
+                    case inst: InstanceTarget =>
+                      val (Instance(newInst), OfModule(newOfMod)) = newPath.last
+                      inst.copy(
+                        circuit = mod.circuit,
+                        module = mod.module,
+                        path = newPath.dropRight(1),
+                        instance = newInst,
+                        ofModule = newOfMod
+                      )
+                  }
+                }
+                Some(result)
+              case DeletedOfModule => Some(Nil)
+              case NoOfModuleRenames =>
+                val modTarget = ModuleTarget(t.circuit, t.module)
+                val children = t.asPath
+                moduleGet(errors)(modTarget).map(_.map { mod =>
+                  val newPath = mod.asPath ++ children
+
+                  t match {
+                    case ref:  ReferenceTarget => ref.copy(circuit = mod.circuit, module = mod.module, path = newPath)
+                    case inst: InstanceTarget =>
+                      val (Instance(newInst), OfModule(newOfMod)) = newPath.last
+                      inst.copy(
+                        circuit = mod.circuit,
+                        module = mod.module,
+                        path = newPath.dropRight(1),
+                        instance = newInst,
+                        ofModule = newOfMod
+                      )
+                  }
+                })
+            }
+        }
+      }
+
+      // if no module renames were found, look for circuit renames;
+      val circuitRename = if (moduleRename.isDefined) {
+        moduleRename.get
+      } else {
+        key match {
+          case t: CircuitTarget => circuitGet(errors)(t)
+          case t: ModuleTarget =>
+            circuitGet(errors)(CircuitTarget(t.circuit)).map {
+              case CircuitTarget(c) => t.copy(circuit = c)
+            }
+          case t: IsComponent =>
+            circuitGet(errors)(CircuitTarget(t.circuit)).map {
+              case CircuitTarget(c) =>
+                t match {
+                  case ref:  ReferenceTarget => ref.copy(circuit = c)
+                  case inst: InstanceTarget  => inst.copy(circuit = c)
+                }
+            }
+        }
+      }
+
+      circuitRename
+    }
+
+    /** Fully rename `from` to `tos`
+      * @param from
+      * @param tos
+      */
+    private def completeRename(from: CompleteTarget, tos: Iterable[CompleteTarget]): Unit = {
+      tos.foreach { recordSensitivity(from, _) }
+      val existing = underlying.getOrElse(from, Vector.empty)
+      val updated = {
+        val all = (existing ++ tos)
+        if (doDistinct) all.distinct else all
+      }
+      underlying(from) = updated
+      traverseTokensCache.clear()
+      traverseHierarchyCache.clear()
+      traverseLeftCache.clear()
+      traverseRightCache.clear()
+    }
+
+    /* DEPRECATED ACCESSOR/SETTOR METHODS WITH [[firrtl.ir.Named Named]] */
+
+    def rename(from: Named, to: Named): Unit = rename(from, Seq(to))
+
+    def rename(from: Named, tos: Seq[Named]): Unit = recordAll(Map(from.toTarget -> tos.map(_.toTarget)))
+
+    def rename(from: ComponentName, to: ComponentName): Unit = record(from, to)
+
+    def rename(from: ComponentName, tos: Seq[ComponentName]): Unit = record(from, tos.map(_.toTarget))
+
+    def delete(name: CircuitName): Unit = underlying(name) = Seq.empty
+
+    def delete(name: ModuleName): Unit = underlying(name) = Seq.empty
+
+    def delete(name: ComponentName): Unit = underlying(name) = Seq.empty
+
+    def addMap(map: collection.Map[Named, Seq[Named]]): Unit =
+      recordAll(map.map {
+        case (key, values) => (Target.convertNamed2Target(key), values.map(Target.convertNamed2Target))
+      })
+
+    // Mutable helpers - APIs that set these are deprecated!
+    private var circuitName: String = ""
+    private var moduleName:  String = ""
+
+    /** Sets mutable state to record current module we are visiting
+      * @param module
+      */
+    def setModule(module: String): Unit = moduleName = module
+
+    /** Sets mutable state to record current circuit we are visiting
+      * @param circuit
+      */
+    def setCircuit(circuit: String): Unit = circuitName = circuit
+
+    /** Records how a reference maps to a new reference
+      * @param from
+      * @param to
+      */
+    def rename(from: String, to: String): Unit = rename(from, Seq(to))
+
+    /** Records how a reference maps to a new reference
+      * The reference's root module and circuit are determined by whomever called setModule or setCircuit last
+      * @param from
+      * @param tos
+      */
+    def rename(from: String, tos: Seq[String]): Unit = {
+      val mn = ModuleName(moduleName, CircuitName(circuitName))
+      val fromName = ComponentName(from, mn).toTarget
+      val tosName = tos.map { to => ComponentName(to, mn).toTarget }
+      record(fromName, tosName)
+    }
+
+    /** Records named reference is deleted
+      * The reference's root module and circuit are determined by whomever called setModule or setCircuit last
+      * @param name
+      */
+    def delete(name: String): Unit = {
+      Target(Some(circuitName), Some(moduleName), AnnotationUtils.toSubComponents(name)).getComplete match {
+        case Some(t: CircuitTarget) => delete(t)
+        case Some(m: IsMember) => delete(m)
+        case other =>
+      }
+    }
+
+    /** Records that references in names are all deleted
+      * The reference's root module and circuit are determined by whomever called setModule or setCircuit last
+      * @param names
+      */
+    def delete(names: Seq[String]): Unit = names.foreach(delete(_))
+
+    /** @return True if this [[RenameMap]] will *not* rename any [[firrtl.annotations.Target Target]]s */
+    override def isEmpty: Boolean = !hasChanges
+  }
+
 }

--- a/src/main/scala/firrtl/annotations/transforms/CleanupNamedTargets.scala
+++ b/src/main/scala/firrtl/annotations/transforms/CleanupNamedTargets.scala
@@ -7,6 +7,7 @@ import firrtl.annotations.{CircuitTarget, ModuleTarget, MultiTargetAnnotation, R
 import firrtl.ir
 import firrtl.options.{Dependency, PreservesAll}
 import firrtl.traversals.Foreachers._
+import firrtl.renamemap.MutableRenameMap
 
 import scala.collection.immutable.{Set => ISet}
 
@@ -31,7 +32,7 @@ class CleanupNamedTargets extends Transform with DependencyAPIMigration {
     statement: ir.Statement
   )(
     implicit references: ISet[ReferenceTarget],
-    renameMap:           RenameMap,
+    renameMap:           MutableRenameMap,
     module:              ModuleTarget
   ): Unit = statement match {
     case ir.DefInstance(_, a, b, _) if references(module.instOf(a, b).asReference) =>
@@ -43,7 +44,7 @@ class CleanupNamedTargets extends Transform with DependencyAPIMigration {
     module: ir.DefModule
   )(
     implicit references: ISet[ReferenceTarget],
-    renameMap:           RenameMap,
+    renameMap:           MutableRenameMap,
     circuit:             CircuitTarget
   ): Unit = {
     implicit val mTarget = circuit.module(module.name)
@@ -60,7 +61,7 @@ class CleanupNamedTargets extends Transform with DependencyAPIMigration {
       case a: ReferenceTarget => a
     }.toSet
 
-    implicit val renameMap = RenameMap()
+    implicit val renameMap = MutableRenameMap()
 
     implicit val cTarget = CircuitTarget(state.circuit.main)
 

--- a/src/main/scala/firrtl/backends/experimental/smt/StutteringClockTransform.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/StutteringClockTransform.scala
@@ -11,6 +11,7 @@ import firrtl.passes.PassException
 import firrtl.stage.Forms
 import firrtl.stage.TransformManager.TransformDependency
 import firrtl.transforms.PropagatePresetAnnotations
+import firrtl.renamemap.MutableRenameMap
 
 import scala.collection.mutable
 
@@ -94,7 +95,7 @@ class StutteringClockTransform extends Transform with DependencyAPIMigration {
 
     // rename clocks to clock enable signals
     val mRef = CircuitTarget(state.circuit.main).module(main.name)
-    val renameMap = RenameMap()
+    val renameMap = MutableRenameMap()
     scan.clockToEnable.foreach {
       case (clk, en) =>
         renameMap.record(mRef.ref(clk), mRef.ref(en.name))

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -11,6 +11,7 @@ import firrtl.analyses.InstanceKeyGraph
 import firrtl.graph.{DiGraph, MutableDiGraph}
 import firrtl.stage.{Forms, RunFirrtlTransformAnnotation}
 import firrtl.options.{RegisteredTransform, ShellOption}
+import firrtl.renamemap.MutableRenameMap
 
 // Datastructures
 import scala.collection.mutable
@@ -184,7 +185,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
       prefix:        String,
       ns:            Namespace,
       renames:       mutable.HashMap[String, String],
-      renameMap:     RenameMap
+      renameMap:     MutableRenameMap
     )(s:             Statement
     ): Statement = {
       def onName(ofModuleOpt: Option[String])(name: String): String = {
@@ -276,10 +277,10 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
 
       indexMap match {
         case a if a.isEmpty =>
-          (Map.empty[(OfModule, Instance), RenameMap], Seq.empty[RenameMap])
+          (Map.empty[(OfModule, Instance), MutableRenameMap], Seq.empty[RenameMap])
         case a =>
           val maxIdx = indexMap.values.max
-          val resultSeq = Seq.fill(maxIdx + 1)(RenameMap())
+          val resultSeq = Seq.fill(maxIdx + 1)(MutableRenameMap())
           val resultMap = indexMap.mapValues(idx => resultSeq(maxIdx - idx))
           (resultMap, resultSeq)
       }

--- a/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
+++ b/src/main/scala/firrtl/passes/RemoveCHIRRTL.scala
@@ -9,6 +9,7 @@ import firrtl.ir._
 import firrtl.Utils._
 import firrtl.Mappers._
 import firrtl.options.Dependency
+import firrtl.renamemap.MutableRenameMap
 
 case class MPort(name: String, clk: Expression)
 case class MPorts(readers: ArrayBuffer[MPort], writers: ArrayBuffer[MPort], readwriters: ArrayBuffer[MPort])
@@ -84,7 +85,7 @@ object RemoveCHIRRTL extends Transform with DependencyAPIMigration {
     types:   MPortTypeMap,
     refs:    DataRefMap,
     raddrs:  AddrMap,
-    renames: RenameMap
+    renames: MutableRenameMap
   )(s:       Statement
   ): Statement = s match {
     case sx: CDefMemory =>
@@ -285,7 +286,7 @@ object RemoveCHIRRTL extends Transform with DependencyAPIMigration {
     }
   }
 
-  def remove_chirrtl_m(renames: RenameMap)(m: DefModule): DefModule = {
+  def remove_chirrtl_m(renames: MutableRenameMap)(m: DefModule): DefModule = {
     val mports = new MPortMap
     val smems = new SeqMemSet
     val types = new MPortTypeMap
@@ -299,7 +300,7 @@ object RemoveCHIRRTL extends Transform with DependencyAPIMigration {
 
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.setCircuit(c.main)
     val result = c.copy(modules = c.modules.map(remove_chirrtl_m(renames)))
     state.copy(circuit = result, renames = Some(renames))

--- a/src/main/scala/firrtl/passes/Uniquify.scala
+++ b/src/main/scala/firrtl/passes/Uniquify.scala
@@ -10,6 +10,7 @@ import firrtl.Mappers._
 import firrtl.options.Dependency
 
 import MemPortUtils.memType
+import firrtl.renamemap.MutableRenameMap
 
 /** Resolve name collisions that would occur in the old [[LowerTypes]] pass
   *
@@ -217,7 +218,7 @@ object Uniquify extends Transform with DependencyAPIMigration {
   )
   def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.setCircuit(c.main)
     // Debug state
     implicit var mname: String = ""
@@ -226,7 +227,7 @@ object Uniquify extends Transform with DependencyAPIMigration {
     val portNameMap = collection.mutable.HashMap[String, Map[String, NameMapNode]]()
     val portTypeMap = collection.mutable.HashMap[String, Type]()
 
-    def uniquifyModule(renames: RenameMap)(m: DefModule): DefModule = {
+    def uniquifyModule(renames: MutableRenameMap)(m: DefModule): DefModule = {
       renames.setModule(m.name)
       val namespace = collection.mutable.HashSet[String]()
       val nameMap = collection.mutable.HashMap[String, NameMapNode]()
@@ -334,7 +335,7 @@ object Uniquify extends Transform with DependencyAPIMigration {
       }
     }
 
-    def uniquifyPorts(renames: RenameMap)(m: DefModule): DefModule = {
+    def uniquifyPorts(renames: MutableRenameMap)(m: DefModule): DefModule = {
       renames.setModule(m.name)
       def uniquifyPorts(ports: Seq[Port]): Seq[Port] = {
         val portsType = BundleType(ports.map {

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -7,6 +7,7 @@ import firrtl.ir._
 import firrtl._
 import firrtl.Mappers._
 import firrtl.options.Dependency
+import firrtl.renamemap.MutableRenameMap
 
 object ZeroWidth extends Transform with DependencyAPIMigration {
 
@@ -143,7 +144,7 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
         case _                        => e.map(onExp)
       }
   }
-  private def onStmt(renames: RenameMap)(s: Statement): Statement = s match {
+  private def onStmt(renames: MutableRenameMap)(s: Statement): Statement = s match {
     case d @ DefWire(info, name, tpe) =>
       renames.delete(getRemoved(d))
       removeZero(tpe) match {
@@ -181,7 +182,7 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
       }
     case sx => sx.map(onStmt(renames)).map(onExp)
   }
-  private def onModule(renames: RenameMap)(m: DefModule): DefModule = {
+  private def onModule(renames: MutableRenameMap)(m: DefModule): DefModule = {
     renames.setModule(m.name)
     // For each port, record deleted subcomponents
     m.ports.foreach { p => renames.delete(getRemoved(p)) }
@@ -200,7 +201,7 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
     // run executeEmptyMemStmt first to remove zero-width memories
     // then run InferTypes to update widths for addr, en, clk, etc
     val c = InferTypes.run(executeEmptyMemStmt(state).circuit)
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.setCircuit(c.main)
     val result = c.copy(modules = c.modules.map(onModule(renames)))
     CircuitState(result, outputForm, state.annotations, Some(renames))

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -11,6 +11,7 @@ import firrtl.ir._
 import firrtl.passes.MemPortUtils.{MemPortMap, Modules}
 import firrtl.passes.memlib.MemTransformUtils._
 import firrtl.passes.wiring._
+import firrtl.renamemap.MutableRenameMap
 import firrtl.stage.Forms
 
 import scala.collection.mutable.ListBuffer
@@ -244,7 +245,7 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     memPortMap:              MemPortMap,
     memMods:                 Modules,
     annotatedMemoriesBuffer: ListBuffer[DefAnnotatedMemory],
-    renameMap:               RenameMap,
+    renameMap:               MutableRenameMap,
     circuit:                 String
   )(s:                       Statement
   ): Statement = s match {
@@ -282,7 +283,7 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     nameMap:                 NameMap,
     memMods:                 Modules,
     annotatedMemoriesBuffer: ListBuffer[DefAnnotatedMemory],
-    renameMap:               RenameMap,
+    renameMap:               MutableRenameMap,
     circuit:                 String
   )(m:                       DefModule
   ) = {
@@ -299,7 +300,7 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     val memMods = new Modules
     val nameMap = new NameMap
     c.modules.map(m => m.map(constructNameMap(namespace, nameMap, m.name)))
-    val renameMap = RenameMap()
+    val renameMap = MutableRenameMap()
     val modules = c.modules.map(updateMemMods(namespace, nameMap, memMods, annotatedMemoriesBuffer, renameMap, c.main))
     state.copy(
       circuit = c.copy(modules = modules ++ memMods),

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -13,6 +13,7 @@ import firrtl.Utils.{kind, throwInternalError}
 import firrtl.MemoizedHash._
 import firrtl.backends.experimental.smt.random.DefRandom
 import firrtl.options.{Dependency, RegisteredTransform, ShellOption}
+import firrtl.renamemap.MutableRenameMap
 
 import collection.mutable
 
@@ -213,7 +214,7 @@ class DeadCodeElimination extends Transform with RegisteredTransform with Depend
     instMap:        collection.Map[String, String],
     deadNodes:      collection.Set[LogicNode],
     moduleMap:      collection.Map[String, DefModule],
-    renames:        RenameMap,
+    renames:        MutableRenameMap,
     topName:        String,
     doTouchExtMods: Set[String]
   )(mod:            DefModule
@@ -346,7 +347,7 @@ class DeadCodeElimination extends Transform with RegisteredTransform with Depend
 
     val liveNodes = depGraph.reachableFrom(circuitSink) + circuitSink
     val deadNodes = depGraph.getVertices -- liveNodes
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.setCircuit(c.main)
 
     // As we delete deadCode, we will delete ports from Modules and somtimes complete modules

--- a/src/main/scala/firrtl/transforms/ManipulateNames.scala
+++ b/src/main/scala/firrtl/transforms/ManipulateNames.scala
@@ -17,6 +17,7 @@ import firrtl.annotations.{
   TargetToken
 }
 import firrtl.options.Dependency
+import firrtl.renamemap.MutableRenameMap
 import firrtl.stage.Forms
 import firrtl.stage.TransformManager.TransformDependency
 
@@ -141,7 +142,7 @@ case class ManipulateNamesAllowlistResultAnnotation[A <: ManipulateNames[_]](
   */
 private class RenameDataStructure(
   circuit:     ir.Circuit,
-  val renames: RenameMap,
+  val renames: MutableRenameMap,
   val block:   Target => Boolean,
   val allow:   Target => Boolean) {
 
@@ -409,7 +410,7 @@ abstract class ManipulateNames[A <: ManipulateNames[_]: ClassTag] extends Transf
     */
   def run(
     c:       ir.Circuit,
-    renames: RenameMap,
+    renames: MutableRenameMap,
     block:   Target => Boolean,
     allow:   Target => Boolean
   ): ir.Circuit = {
@@ -485,7 +486,7 @@ abstract class ManipulateNames[A <: ManipulateNames[_]: ClassTag] extends Transf
       }
     }
 
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val circuitx = run(state.circuit, renames, block, allow)
 
     val annotationsx = state.annotations.flatMap {

--- a/src/main/scala/firrtl/transforms/SimplifyMems.scala
+++ b/src/main/scala/firrtl/transforms/SimplifyMems.scala
@@ -15,6 +15,7 @@ import scala.collection.mutable
 import AnalysisUtils._
 import MemPortUtils._
 import ResolveMaskGranularity._
+import firrtl.renamemap.MutableRenameMap
 
 /**
   * Lowers memories without splitting them, but without the complexity of ReplaceMemMacros
@@ -29,7 +30,7 @@ class SimplifyMems extends Transform with DependencyAPIMigration {
     case _          => false
   }
 
-  def onModule(c: Circuit, renames: RenameMap)(m: DefModule): DefModule = {
+  def onModule(c: Circuit, renames: MutableRenameMap)(m: DefModule): DefModule = {
     val moduleNS = Namespace(m)
     val connects = getConnects(m)
     val memAdapters = new mutable.LinkedHashMap[String, DefWire]
@@ -86,7 +87,7 @@ class SimplifyMems extends Transform with DependencyAPIMigration {
 
   override def execute(state: CircuitState): CircuitState = {
     val c = state.circuit
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     state.copy(circuit = c.map(onModule(c, renames)), renames = Some(renames))
   }
 }

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -19,6 +19,7 @@ import firrtl.stage.{FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransfor
 import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation, RenameModules}
+import firrtl.renamemap.MutableRenameMap
 import firrtl.util.BackendCompilationUtilities
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -64,7 +65,7 @@ object RenameTop extends Transform {
       case m => m
     }
 
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(CircuitTarget(c.main), CircuitTarget(newTopName))
     state.copy(circuit = c.copy(main = newTopName, modules = modulesx), renames = Some(renames))
   }

--- a/src/test/scala/firrtlTests/RenameMapSpec.scala
+++ b/src/test/scala/firrtlTests/RenameMapSpec.scala
@@ -7,6 +7,7 @@ import firrtl.RenameMap.IllegalRenameException
 import firrtl.annotations._
 import firrtl.annotations.TargetToken.{Instance, OfModule}
 import firrtl.analyses.InstanceKeyGraph
+import firrtl.renamemap.MutableRenameMap
 import firrtl.testutils._
 
 class RenameMapSpec extends FirrtlFlatSpec {
@@ -31,64 +32,64 @@ class RenameMapSpec extends FirrtlFlatSpec {
   behavior.of("RenameMap")
 
   it should "return None if it does not rename something" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.get(modA) should be(None)
     renames.get(foo) should be(None)
   }
 
   it should "return a Seq of renamed things if it does rename something" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(foo, bar)
     renames.get(foo) should be(Some(Seq(bar)))
   }
 
   it should "allow something to be renamed to multiple things" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(foo, bar)
     renames.record(foo, fizz)
     renames.get(foo) should be(Some(Seq(bar, fizz)))
   }
 
   it should "allow something to be renamed to nothing (ie. deleted)" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(foo, Seq())
     renames.get(foo) should be(Some(Seq()))
   }
 
   it should "return None if something is renamed to itself" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(foo, foo)
     renames.get(foo) should be(None)
   }
 
   it should "allow targets to change module" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(foo, fooB)
     renames.get(foo) should be(Some(Seq(fooB)))
   }
 
   it should "rename targets if their module is renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(modA, modB)
     renames.get(foo) should be(Some(Seq(fooB)))
     renames.get(bar) should be(Some(Seq(barB)))
   }
 
   it should "not rename already renamed targets if the module of the target is renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(modA, modB)
     renames.record(foo, bar)
     renames.get(foo) should be(Some(Seq(bar)))
   }
 
   it should "rename modules if their circuit is renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(cir, cir2)
     renames.get(modA) should be(Some(Seq(modA2)))
   }
 
   it should "rename targets if their circuit is renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(cir, cir2)
     renames.get(foo) should be(Some(Seq(foo2)))
   }
@@ -105,50 +106,50 @@ class RenameMapSpec extends FirrtlFlatSpec {
   val Middle_l_a = Middle.instOf("l", "Leaf").ref("a")
 
   it should "rename targets if modules in the path are renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Middle, Middle2)
     renames.get(Top_m) should be(Some(Seq(Top.instOf("m", "Middle2"))))
   }
 
   it should "rename only the instance if instance and module in the path are renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Middle, Middle2)
     renames.record(Top.instOf("m", "Middle"), Top.instOf("m2", "Middle"))
     renames.get(Top_m) should be(Some(Seq(Top.instOf("m2", "Middle"))))
   }
 
   it should "rename targets if instance in the path are renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Top.instOf("m", "Middle"), Top.instOf("m2", "Middle"))
     renames.get(Top_m) should be(Some(Seq(Top.instOf("m2", "Middle"))))
   }
 
   it should "rename targets if instance and ofmodule in the path are renamed" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val Top_m2 = Top.instOf("m2", "Middle2")
     renames.record(Top_m, Top_m2)
     renames.get(Top_m) should be(Some(Seq(Top_m2)))
   }
 
   it should "properly do nothing if no remaps" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.get(Top_m_l_a) should be(None)
   }
 
   it should "properly rename if leaf is inlined" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Middle_l_a, Middle_la)
     renames.get(Top_m_l_a) should be(Some(Seq(Top_m_la)))
   }
 
   it should "properly rename if middle is inlined" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Top_m_l, Top.instOf("m_l", "Leaf"))
     renames.get(Top_m_l_a) should be(Some(Seq(Top.instOf("m_l", "Leaf").ref("a"))))
   }
 
   it should "properly rename if leaf and middle are inlined" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val inlined = Top.ref("m_l_a")
     renames.record(Top_m_l_a, inlined)
     renames.record(Top_m_l, Nil)
@@ -158,7 +159,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
 
   it should "quickly rename a target with a long path" in {
     (0 until 50 by 10).foreach { endIdx =>
-      val renames = RenameMap()
+      val renames = MutableRenameMap()
       renames.record(TopCircuit.module("Y0"), TopCircuit.module("X0"))
       val deepTarget = (0 until endIdx)
         .foldLeft(Top: IsModule) { (t, idx) =>
@@ -171,7 +172,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   }
 
   it should "rename only once with multiple renames" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val Middle2 = cir.module("Middle2")
     renames.record(Middle, Middle2)
     renames.record(Middle.ref("l"), Middle.ref("lx"))
@@ -183,7 +184,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val Middle_i = Middle.ref("i")
     val Middle_o_f = Middle.ref("o").field("f")
     val Middle_i_f = Middle.ref("i").field("f")
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Middle_o, Middle_i)
     renames.get(Middle_o_f) should be(Some(Seq(Middle_i_f)))
   }
@@ -191,7 +192,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   it should "rename instances with same ofModule" in {
     val Middle_o = Middle.instOf("o", "O")
     val Middle_i = Middle.instOf("i", "O")
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Middle_o, Middle_i)
     renames.get(Middle.instOf("o", "O")) should be(Some(Seq(Middle.instOf("i", "O"))))
   }
@@ -199,7 +200,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   it should "not treat references as instances targets" in {
     val Middle_o = Middle.ref("o")
     val Middle_i = Middle.ref("i")
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(Middle_o, Middle_i)
     renames.get(Middle.instOf("o", "O")) should be(None)
   }
@@ -221,7 +222,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
       val fromN = from
       val tosN = tos.mkString(", ")
       //it should s"error if a $fromN is renamed to $tosN" in {
-      val renames = RenameMap()
+      val renames = MutableRenameMap()
       for (to <- tos) {
         (from, to) match {
           case (f: CircuitTarget, t: CircuitTarget) => renames.record(f, t)
@@ -237,7 +238,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   }
 
   it should "not error if a circular rename occurs" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val top = CircuitTarget("Top")
     renames.record(top.module("A"), top.module("B").instOf("c", "C"))
     renames.record(top.module("B"), top.module("A").instOf("c", "C"))
@@ -247,7 +248,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   }
 
   it should "not error if a swapping rename occurs" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val top = CircuitTarget("Top")
     renames.record(top.module("A"), top.module("B"))
     renames.record(top.module("B"), top.module("A"))
@@ -256,7 +257,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   }
 
   it should "error if a reference is renamed to a module and vice versa" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val top = CircuitTarget("Top")
     renames.record(top.module("A").ref("ref"), top.module("B"))
     renames.record(top.module("C"), top.module("D").ref("ref"))
@@ -270,7 +271,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   }
 
   it should "error if we rename an instance's ofModule into a non-module" in {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val top = CircuitTarget("Top")
 
     renames.record(top.module("C"), top.module("D").ref("x"))
@@ -280,7 +281,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
   }
 
   it should "error if path is renamed into a non-path" ignore {
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val top = CircuitTarget("Top")
 
     renames.record(top.module("E").instOf("f", "F"), top.module("E").ref("g"))
@@ -303,7 +304,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val lowered2 = aggregate.copy(ref = "agg_field2")
 
     // simulating LowerTypes transform
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(subField1, lowered1)
     renames.record(subField2, lowered2)
     renames.record(aggregate, Seq(lowered1, lowered2))
@@ -326,7 +327,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val oldAgg = mod.ref("foo").setPathTarget(path)
     val newAgg = mod.ref("bar").setPathTarget(path)
 
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(oldAgg, newAgg)
 
     val testRef = oldAgg.field("field")
@@ -345,7 +346,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val oldRef = modA.ref("oldRef").setPathTarget(path)
     val newRef = modA.ref("newRef").setPathTarget(path)
 
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(oldRef, newRef)
 
     val testRef = oldRef.addHierarchy("B", "b")
@@ -364,7 +365,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val oldAgg = modA.ref("oldAgg").setPathTarget(path).field("field1")
     val newAgg = modA.ref("newAgg").setPathTarget(path)
 
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(oldAgg, newAgg)
 
     val testRef = oldAgg.addHierarchy("B", "b").field("field2")
@@ -432,7 +433,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val from4 = modC.ref("ref")
     val to4 = modC.ref("refref")
 
-    val renames1 = RenameMap()
+    val renames1 = MutableRenameMap()
     renames1.record(from1, to1)
     renames1.record(from2, to2)
     renames1.record(from3, to3)
@@ -452,7 +453,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
       )
     }
 
-    val renames2 = RenameMap()
+    val renames2 = MutableRenameMap()
     renames2.record(from2, to2)
     renames2.record(from3, to3)
     renames2.record(from4, to4)
@@ -471,7 +472,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
       )
     }
 
-    val renames3 = RenameMap()
+    val renames3 = MutableRenameMap()
     renames3.record(from3, to3)
     renames3.record(from4, to4)
 
@@ -492,7 +493,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
 
   it should "correctly handle renaming of modules to instances" in {
     val cir = CircuitTarget("Top")
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val from = cir.module("C")
     val to = cir.module("D").instOf("e", "E").instOf("f", "F")
     renames.record(from, to)
@@ -506,7 +507,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
 
   it should "correctly handle renaming of paths and components at the same time" in {
     val cir = CircuitTarget("Top")
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val from = cir.module("C").ref("foo").field("bar")
     val to = cir.module("D").instOf("e", "E").instOf("f", "F").ref("foo").field("foo")
     renames.record(from, to)
@@ -528,7 +529,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
 
   it should "error if an instance is renamed to a ReferenceTarget" in {
     val top = CircuitTarget("Top").module("Top")
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val from = top.instOf("a", "A")
     val to = top.ref("b")
     renames.record(from, to)
@@ -539,7 +540,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
 
   it should "not allow renaming of instances even if there is a matching reference rename" in {
     val top = CircuitTarget("Top").module("Top")
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val from = top.ref("a")
     val to = top.ref("b")
     renames.record(from, to)
@@ -549,12 +550,12 @@ class RenameMapSpec extends FirrtlFlatSpec {
   it should "correctly chain renames together" in {
     val top = CircuitTarget("Top")
 
-    val renames1 = RenameMap()
+    val renames1 = MutableRenameMap()
     val from1 = top.module("A")
     val to1 = top.module("Top").instOf("b", "B")
     renames1.record(from1, to1)
 
-    val renames2 = RenameMap()
+    val renames2 = MutableRenameMap()
     val from2 = top.module("B")
     val to2 = top.module("B1")
     renames2.record(from2, to2)
@@ -577,11 +578,11 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val modB = top.module("B")
     val modB1 = top.module("B1")
 
-    val renames1 = RenameMap()
+    val renames1 = MutableRenameMap()
     renames1.delete(modA)
     renames1.record(modB, modB1)
 
-    val renames2 = RenameMap()
+    val renames2 = MutableRenameMap()
     renames2.record(modA, modA1)
     renames2.delete(modB1)
 
@@ -595,7 +596,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     }
   }
 
-  it should "correctly ++ renameMaps" in {
+  it should "correctly ++ renameMaps (both mutable and immutable)" in {
     val top = CircuitTarget("Top")
     val modA = top.module("A")
     val modA1 = top.module("A1")
@@ -605,24 +606,37 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val modC = top.module("C")
     val modC1 = top.module("C1")
 
-    val renames1 = RenameMap()
+    val renames1 = MutableRenameMap()
     renames1.record(modA, modA1)
     renames1.record(modC, modC1)
 
-    val renames2 = RenameMap()
+    val renames2 = MutableRenameMap()
     renames2.record(modA, modA2)
     renames2.record(modB, modB1)
 
-    val renames = renames1 ++ renames2
-    renames.get(modA) should be {
+    val mutableRenames: MutableRenameMap = renames1 ++ renames2
+    mutableRenames.get(modA) should be {
       Some(Seq(modA2))
     }
-    renames.get(modB) should be {
+    mutableRenames.get(modB) should be {
       Some(Seq(modB1))
     }
-    renames.get(modC) should be {
+    mutableRenames.get(modC) should be {
       Some(Seq(modC1))
     }
+
+    // Upcast to use RenameMap.++ instead of MutableRenameMap.++
+    val immutableRenames: RenameMap = (renames1: RenameMap) ++ renames2
+    immutableRenames.get(modA) should be {
+      Some(Seq(modA2))
+    }
+    immutableRenames.get(modB) should be {
+      Some(Seq(modB1))
+    }
+    immutableRenames.get(modC) should be {
+      Some(Seq(modC1))
+    }
+
   }
 
   it should "be able to inline instances" in {
@@ -633,10 +647,10 @@ class RenameMapSpec extends FirrtlFlatSpec {
       val oldRef = inlineMod.ref("bar")
       val prefixRef = inlineMod.ref("foo")
 
-      val renames1 = RenameMap()
+      val renames1 = MutableRenameMap()
       renames1.record(inlineInst, inlineMod)
 
-      val renames2 = RenameMap()
+      val renames2 = MutableRenameMap()
       renames2.record(oldRef, prefixRef)
 
       renames1.andThen(renames2)
@@ -648,10 +662,10 @@ class RenameMapSpec extends FirrtlFlatSpec {
       val oldRef = inlineMod.ref("bar")
       val prefixRef = inlineMod.ref("foo")
 
-      val renames1 = RenameMap()
+      val renames1 = MutableRenameMap()
       renames1.record(inlineInst, inlineMod)
 
-      val renames2 = RenameMap()
+      val renames2 = MutableRenameMap()
       renames2.record(oldRef, prefixRef)
 
       renames1.andThen(renames2)
@@ -680,13 +694,13 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val absPath1 = relPath1.addHierarchy("Top", "foo")
     val absPath2 = relPath2.addHierarchy("Top", "foo")
 
-    val renames1 = RenameMap()
+    val renames1 = MutableRenameMap()
     renames1.record(dupMod1, absPath1)
     renames1.record(dupMod2, absPath2)
     renames1.record(relPath1, absPath1)
     renames1.record(relPath2, absPath2)
 
-    val renames2 = RenameMap()
+    val renames2 = MutableRenameMap()
     renames2.record(dupMod1, dedupedMod)
     renames2.record(dupMod2, dedupedMod)
 
@@ -705,45 +719,49 @@ class RenameMapSpec extends FirrtlFlatSpec {
     }
   }
 
-  it should "should able to chain many rename maps" in {
+  it should "should able to chain many rename maps (both mutable and immutable)" in {
     val top = CircuitTarget("Top")
-    val inlineRename1 = {
+    val (inlineRename1: MutableRenameMap, inlineRename1Immutable: RenameMap) = {
       val inlineMod = top.module("A")
       val inlineInst = top.module("A").instOf("b", "B")
       val oldRef = inlineMod.ref("bar")
       val prefixRef = inlineMod.ref("foo")
 
-      val renames1 = RenameMap()
+      val renames1 = MutableRenameMap()
       renames1.record(inlineInst, inlineMod)
 
-      val renames2 = RenameMap()
+      val renames2 = MutableRenameMap()
       renames2.record(oldRef, prefixRef)
 
-      renames1.andThen(renames2)
+      (renames1.andThen(renames2), (renames1: RenameMap).andThen(renames2))
     }
 
-    val inlineRename2 = {
+    val (inlineRename2: MutableRenameMap, inlineRename2Immutable: RenameMap) = {
       val inlineMod = top.module("A1")
       val inlineInst = top.module("A1").instOf("b", "B1")
       val oldRef = inlineMod.ref("bar")
       val prefixRef = inlineMod.ref("foo")
 
-      val renames1 = RenameMap()
+      val renames1 = MutableRenameMap()
       renames1.record(inlineInst, inlineMod)
 
-      val renames2 = RenameMap()
+      val renames2 = MutableRenameMap()
       renames2.record(oldRef, prefixRef)
 
-      inlineRename1.andThen(renames1).andThen(renames2)
+      (
+        inlineRename1.andThen(renames1).andThen(renames2),
+        inlineRename1Immutable.andThen(renames1).andThen(renames2)
+      )
     }
 
-    val renames = inlineRename2
-    renames.get(top.module("A").instOf("b", "B").ref("bar")) should be {
-      Some(Seq(top.module("A").ref("foo")))
-    }
+    for (renames <- Seq(inlineRename2, inlineRename2Immutable)) {
+      renames.get(top.module("A").instOf("b", "B").ref("bar")) should be {
+        Some(Seq(top.module("A").ref("foo")))
+      }
 
-    renames.get(top.module("A1").instOf("b", "B1").ref("bar")) should be {
-      Some(Seq(top.module("A1").ref("foo")))
+      renames.get(top.module("A1").instOf("b", "B1").ref("bar")) should be {
+        Some(Seq(top.module("A1").ref("foo")))
+      }
     }
   }
 
@@ -756,11 +774,11 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val bar1 = top.instOf("bar1", "Mod")
     val bar2 = top.instOf("bar2", "Mod")
 
-    val foo1Rename = RenameMap()
-    val foo2Rename = RenameMap()
+    val foo1Rename = MutableRenameMap()
+    val foo2Rename = MutableRenameMap()
 
-    val bar1Rename = RenameMap()
-    val bar2Rename = RenameMap()
+    val bar1Rename = MutableRenameMap()
+    val bar2Rename = MutableRenameMap()
 
     foo1Rename.record(foo1, foo2)
     foo2Rename.record(foo2, foo3)
@@ -783,7 +801,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val foo = top.instOf("foo", "Mod")
     val bar = top.instOf("bar", "Mod")
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
 
     r.record(foo, bar)
     r.record(foo, foo)
@@ -797,7 +815,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val foo = top.instOf("foo", "Mod")
     val bar = top.instOf("bar", "Mod")
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
 
     r.record(foo, bar)
     r.record(foo, bar)
@@ -812,7 +830,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val Mod = CircuitTarget("Top").module("Mod")
     val Mod2 = CircuitTarget("Top").module("Mod2")
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
 
     r.record(foo, Mod)
     r.record(Mod, Mod2)
@@ -827,7 +845,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val foo = top.instOf("foo", "Mod")
     val Mod = CircuitTarget("Top").module("Mod")
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
 
     r.delete(Mod)
     r.get(foo) should be(Some(Nil))
@@ -837,7 +855,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     // this could happen if the instance name needed to be uniquified to avoid clashes in LowerTypes
     val top = CircuitTarget("top").module("top")
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
     val i = top.instOf("i", "child")
     val i_ = top.instOf("i_", "child")
     r.record(i, i_)
@@ -850,7 +868,7 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val top = CircuitTarget("top").module("top")
     val child = CircuitTarget("top").module("child")
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
     r.record(child.ref("a"), Seq(child.ref("a_0"), child.ref("a_1")))
     val i = top.instOf("i", "child")
     r.get(i.ref("a")) should be(Some(Seq(i.ref("a_0"), i.ref("a_1"))))
@@ -861,10 +879,10 @@ class RenameMapSpec extends FirrtlFlatSpec {
     val top = CircuitTarget("top").module("top")
     val child = CircuitTarget("top").module("child")
 
-    val portRenames = RenameMap()
+    val portRenames = MutableRenameMap()
     portRenames.record(child.ref("a"), Seq(child.ref("a_0"), child.ref("a_1")))
 
-    val instanceRenames = RenameMap()
+    val instanceRenames = MutableRenameMap()
     val i = top.instOf("i", "child")
     val i_ = top.instOf("i_", "child")
     instanceRenames.record(i, i_)

--- a/src/test/scala/firrtlTests/transforms/ManipulateNamesSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/ManipulateNamesSpec.scala
@@ -5,6 +5,7 @@ package firrtlTests.transforms
 import firrtl.{ir, CircuitState, FirrtlUserException, Namespace, Parser, RenameMap}
 import firrtl.annotations.CircuitTarget
 import firrtl.options.Dependency
+import firrtl.renamemap.MutableRenameMap
 import firrtl.testutils.FirrtlCheckers._
 import firrtl.transforms.{
   ManipulateNames,
@@ -210,7 +211,7 @@ class ManipulateNamesSpec extends AnyFlatSpec with Matchers {
       oldTargets = Seq(Seq(`~Foo|Bar`))
     )
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
     r.delete(`~Foo|prefix_Bar`)
 
     a.update(r) should be(empty)
@@ -228,7 +229,7 @@ class ManipulateNamesSpec extends AnyFlatSpec with Matchers {
       oldTargets = Seq(Seq(`~Foo|Bar`), Seq(`~Foo|Baz`))
     )
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
     r.delete(`~Foo|prefix_Bar`)
 
     val ax = a.update(r).collect {
@@ -237,10 +238,9 @@ class ManipulateNamesSpec extends AnyFlatSpec with Matchers {
 
     ax should not be length(1)
 
-    val keys = ax.head.toRenameMap.getUnderlying.keys
-
-    keys should not contain (`~Foo|Bar`)
-    keys should contain(`~Foo|Baz`)
+    val renameMap = ax.head.toRenameMap
+    renameMap.get(`~Foo|Bar`) should be(None)
+    renameMap.get(`~Foo|Baz`) shouldBe an[Some[_]] // using `an` because `a` is a val above
   }
 
 }


### PR DESCRIPTION
The mutability of the RenameMap API has long been a wart. It also has
made it impossible to provide alternative implementations that do not
have a underlying map. By changing RenameMap to a [sealed] trait, it
will become possible to provide optimized implementations for different
purposes.

Possible optimized `RenameMaps`:
* `LowerTypesRenameMap` (not having to expand out every possible rename)
* `ModuleRenameMap` -- See `RenameMap. fromInstanceRenames`, a new version could lazily expand instead of having to create a Map
* `ComponentRenameMap` -- Maybe a simplified `RenameMap` that only allows for renaming within modules, could have much simpler logic than the current `RenameMap`

**Important Note for Backporting**

My plan for making this binary compatible in the backport (prototyped in [this branch](https://github.com/chipsalliance/firrtl/tree/renamemap-deprecations)) is to provide deprecated versions of public transform methods that currently take a `RenameMap` argument and then call the new version that takes a `MutableRenameMap` (doing an `.asInstanceOf` cast). For this to work, `MutableRenameMap` must be the only concrete implementation of `RenameMap`, so I must change the implementations of `RenameMap.++` and `.andThen` back to how they work for `MutableRenameMap`. I'm only noting this because it might be easy to forget but is very important.


### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


- code refactoring  
 - code cleanup  
 - new feature/API    

#### API Impact

This breaks the `RenameMap` API. Most transform writers should do a search and replace `RenameMap` for `MutableRenameMap` (and import `firrtl.renamemap.MutableRenameMap`).

Any annotations taking advantage of the mutable methods on `RenameMap` will break.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Turn `firrtl.RenameMap` into a trait with an immutable API. Transform writers using the mutable methods should instead us `firrtl.renamemap.MutableRenameMap`. Annotations that use the mutable `RenameMap` methods in their `update` methods can no longer do that.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
