### PR TITLE
PropagatePresetAnnotations: remove false prerequisites

### DIFF
--- a/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
@@ -40,12 +40,7 @@ object PropagatePresetAnnotations {
   */
 class PropagatePresetAnnotations extends Transform with DependencyAPIMigration {
 
-  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
-    Seq(
-      Dependency[BlackBoxSourceHelper],
-      Dependency[FixAddingNegativeLiterals],
-      Dependency[ReplaceTruncatingArithmetic]
-    )
+  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 


### PR DESCRIPTION
The SMT backend actually needs to run PropagatePresetAnnotations
(as will treadle at some point).
None of the Verilog specific passes were actually required!

### Contributor Checklist

- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?


#### Type of Improvement
 - bug fix (remove false dependencies)

#### API Impact

- this will allow backends to require `PropagatePresetAnnotations` without pulling in Verilog specific dependencies.

#### Backend Code Generation Impact

- ideally none, but could change pass order

#### Desired Merge Strategy
-squash

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
