### PR TITLE
PropagatePresetAnnotations: remove dep. on SplitExpressions and PadWidths

### DIFF
--- a/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/PropagatePresetAnnotations.scala
@@ -40,7 +40,8 @@ object PropagatePresetAnnotations {
   */
 class PropagatePresetAnnotations extends Transform with DependencyAPIMigration {
 
-  override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized
+  override def prerequisites = firrtl.stage.Forms.LowForm :+
+    Dependency(firrtl.passes.RemoveValidIf)
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized
 


### PR DESCRIPTION
Both transforms are (most likely) not needed.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
