### PR TITLE
[smt] PropagatePresetAnnotations is now a real prereq

### DIFF
--- a/src/test/scala/firrtl/backends/experimental/smt/end2end/EndToEndSMTSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/end2end/EndToEndSMTSpec.scala
@@ -3,8 +3,9 @@
 package firrtl.backends.experimental.smt.end2end
 
 import firrtl.annotations.{Annotation, CircuitTarget, PresetAnnotation}
+import firrtl.backends.experimental.smt.random.{InvalidToRandomPass, UndefinedMemoryBehaviorPass}
 import firrtl.backends.experimental.smt.{Btor2Emitter, SMTLibEmitter}
-import firrtl.options.TargetDirAnnotation
+import firrtl.options.{Dependency, TargetDirAnnotation}
 import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlStage, OutputFileAnnotation, RunFirrtlTransformAnnotation}
 import firrtl.util.BackendCompilationUtilities.timeStamp
 import logger.{LazyLogging, LogLevel, LogLevelAnnotation}
@@ -155,6 +156,9 @@ abstract class EndToEndSMTBaseSpec extends AnyFlatSpec with Matchers {
     val r = Z3ModelChecker.bmc(testDir, name, kmax)
     assert(r == expected, clue + "\n" + s"$testDir")
   }
+
+  val UndefinedMemAnnos = Seq(RunFirrtlTransformAnnotation(Dependency(UndefinedMemoryBehaviorPass)))
+  val InvalidToRandomAnnos = Seq(RunFirrtlTransformAnnotation(Dependency(InvalidToRandomPass)))
 }
 
 /** Minimal implementation of a Z3 based bounded model checker.

--- a/src/test/scala/firrtl/backends/experimental/smt/end2end/MemorySpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/end2end/MemorySpec.scala
@@ -190,10 +190,10 @@ class MemorySpec extends EndToEndSMTBaseSpec {
                                              |    assert(c, eq(m.r.data, prevData), and(pastValid, prevEn), "")
                                              |""".stripMargin
   "memory with two write ports" should "not have collisions when enables are mutually exclusive" taggedAs (RequiresZ3) in {
-    test(collisionTest("not(and(aEn, bEn))"), MCSuccess, kmax = 4)
+    test(collisionTest("not(and(aEn, bEn))"), MCSuccess, kmax = 4, annos = UndefinedMemAnnos)
   }
   "memory with two write ports" should "can have collisions when enables are unconstrained" taggedAs (RequiresZ3) in {
-    test(collisionTest("UInt(1)"), MCFail(1), kmax = 1)
+    test(collisionTest("UInt(1)"), MCFail(1), kmax = 1, annos = UndefinedMemAnnos)
   }
 
   private def readEnableSrc(pred: String, num: Int) =
@@ -229,12 +229,22 @@ class MemorySpec extends EndToEndSMTBaseSpec {
   "a memory with read enable" should "supply valid data one cycle after en=1" in {
     val init = Seq(MemoryScalarInitAnnotation(CircuitTarget(s"ReadEnableTest1").module(s"ReadEnableTest1").ref("m"), 0))
     // the read port is enabled on even cycles, so on odd cycles we should reliably get zeros
-    test(readEnableSrc("or(not(odd), eq(m.r.data, UInt(0)))", 1), MCSuccess, kmax = 3, annos = init)
+    test(
+      readEnableSrc("or(not(odd), eq(m.r.data, UInt(0)))", 1),
+      MCSuccess,
+      kmax = 3,
+      annos = init ++ UndefinedMemAnnos
+    )
   }
 
   "a memory with read enable" should "supply invalid data one cycle after en=0" in {
     val init = Seq(MemoryScalarInitAnnotation(CircuitTarget(s"ReadEnableTest2").module(s"ReadEnableTest2").ref("m"), 0))
     // the read port is disabled on odd cycles, so on even cycles we should *NOT* reliably get zeros
-    test(readEnableSrc("or(not(even), eq(m.r.data, UInt(0)))", 2), MCFail(1), kmax = 1, annos = init)
+    test(
+      readEnableSrc("or(not(even), eq(m.r.data, UInt(0)))", 2),
+      MCFail(1),
+      kmax = 1,
+      annos = init ++ UndefinedMemAnnos
+    )
   }
 }

--- a/src/test/scala/firrtl/backends/experimental/smt/end2end/UndefinedFirrtlSpec.scala
+++ b/src/test/scala/firrtl/backends/experimental/smt/end2end/UndefinedFirrtlSpec.scala
@@ -19,7 +19,7 @@ class UndefinedFirrtlSpec extends EndToEndSMTBaseSpec {
          |    assert(c, eq(d, UInt($dEq)), UInt(1), "d = $dEq")
          |""".stripMargin
     // we try to assert that (d = a / 0) is any fixed value which should be false
-    (0 until 4).foreach { ii => test(in(ii), MCFail(0), 0, s"d = a / 0 = $ii") }
+    (0 until 4).foreach { ii => test(in(ii), MCFail(0), 0, s"d = a / 0 = $ii", annos = InvalidToRandomAnnos) }
   }
 
   // TODO: rem should probably also be undefined, but the spec isn't 100% clear here
@@ -34,6 +34,6 @@ class UndefinedFirrtlSpec extends EndToEndSMTBaseSpec {
          |    assert(c, eq(a, UInt($aEq)), UInt(1), "a = $aEq")
          |""".stripMargin
     // a should not be equivalent to any fixed value (0, 1, 2 or 3)
-    (0 until 4).foreach { ii => test(in(ii), MCFail(0), 0, s"a = $ii") }
+    (0 until 4).foreach { ii => test(in(ii), MCFail(0), 0, s"a = $ii", annos = InvalidToRandomAnnos) }
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?


#### Type of Improvement
 - code cleanup

#### API Impact

- the experimental smt/btor2 emitters now won't run the passes that model invalid + undefined memory behavior

#### Backend Code Generation Impact
- SMT: no invalid modelling by default

#### Desired Merge Strategy
- squash 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
