### PR TITLE
Modify NoCommonSubexpressionElimination to NoCommonSubexpressionElimi…

### DIFF
--- a/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
+++ b/src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala
@@ -9,7 +9,7 @@ import firrtl.ir._
 import firrtl.options.{Dependency, HasShellOptions, RegisteredTransform, ShellOption}
 
 /** Indicate that CommonSubexpressionElimination should not be run */
-case object NoCommonSubexpressionElimination extends NoTargetAnnotation
+case object NoCommonSubexpressionEliminationAnnotation extends NoTargetAnnotation
 
 object CommonSubexpressionElimination extends Transform with HasShellOptions with DependencyAPIMigration {
 
@@ -22,7 +22,7 @@ object CommonSubexpressionElimination extends Transform with HasShellOptions wit
   val options = Seq(
     new ShellOption[Unit](
       longOption = "no-cse",
-      toAnnotationSeq = _ => Seq(NoCommonSubexpressionElimination),
+      toAnnotationSeq = _ => Seq(NoCommonSubexpressionEliminationAnnotation),
       helpText = "Disable common subexpression elimination"
     )
   )
@@ -59,7 +59,7 @@ object CommonSubexpressionElimination extends Transform with HasShellOptions wit
   }
 
   override def execute(state: CircuitState): CircuitState =
-    if (state.annotations.contains(NoCommonSubexpressionElimination))
+    if (state.annotations.contains(NoCommonSubexpressionEliminationAnnotation))
       state
     else
       state.copy(circuit = state.circuit.copy(modules = state.circuit.modules.map({


### PR DESCRIPTION
…nationAnnotation

* to make it has the same form with NoDCEAnnotation and NoConstantPropagationAnnotation

* Update src/main/scala/firrtl/passes/CommonSubexpressionElimination.scala

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!--   - code refactoring                   -->

#### API Impact

None.

#### Backend Code Generation Impact

None.

#### Desired Merge Strategy

None.

#### Release Notes

None.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
