### PR TITLE
Fix Serializer for single indented DefModule emission

### DIFF
--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -240,24 +240,24 @@ object Serializer {
 
   private def s(node: DefModule)(implicit b: StringBuilder, indent: Int): Unit = node match {
     case Module(info, name, ports, body) =>
-      b ++= "module "; b ++= name; b ++= " :"; s(info)
+      doIndent(0); b ++= "module "; b ++= name; b ++= " :"; s(info)
       ports.foreach { p => newLineAndIndent(1); s(p) }
       newLineNoIndent() // add a new line between port declaration and body
       newLineAndIndent(1); s(body)(b, indent + 1)
     case ExtModule(info, name, ports, defname, params) =>
-      b ++= "extmodule "; b ++= name; b ++= " :"; s(info)
+      doIndent(0); b ++= "extmodule "; b ++= name; b ++= " :"; s(info)
       ports.foreach { p => newLineAndIndent(1); s(p) }
       newLineAndIndent(1); b ++= "defname = "; b ++= defname
       params.foreach { p => newLineAndIndent(1); s(p) }
-    case other => b ++= other.serialize // Handle user-defined nodes
+    case other => doIndent(0); b ++= other.serialize // Handle user-defined nodes
   }
 
   private def s(node: Circuit)(implicit b: StringBuilder, indent: Int): Unit = node match {
     case Circuit(info, modules, main) =>
       b ++= "circuit "; b ++= main; b ++= " :"; s(info)
       if (modules.nonEmpty) {
-        newLineAndIndent(1); s(modules.head)(b, indent + 1)
-        modules.drop(1).foreach { m => newLineNoIndent(); newLineAndIndent(1); s(m)(b, indent + 1) }
+        newLineNoIndent(); s(modules.head)(b, indent + 1)
+        modules.drop(1).foreach { m => newLineNoIndent(); newLineNoIndent(); s(m)(b, indent + 1) }
       }
       newLineNoIndent()
   }


### PR DESCRIPTION
### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix     

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Fix `ir.Serializer` when emitting individual indented modules

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
