### PR TITLE
Remove BlackBoxSourceHelper from ReplaceMemTransform

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -9,7 +9,6 @@ import firrtl.annotations._
 import firrtl.options.{CustomFileEmission, Dependency, HasShellOptions, ShellOption}
 import firrtl.passes.wiring._
 import firrtl.stage.{Forms, RunFirrtlTransformAnnotation}
-import firrtl.transforms.BlackBoxSourceHelper
 
 import java.io.{CharArrayWriter, PrintWriter}
 
@@ -161,7 +160,6 @@ class ReplSeqMem extends SeqTransform with HasShellOptions with DependencyAPIMig
       new ResolveMemoryReference,
       new ReplaceMemMacros,
       new WiringTransform,
-      new DumpMemoryAnnotations,
-      new BlackBoxSourceHelper
+      new DumpMemoryAnnotations
     )
 }

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -39,7 +39,8 @@ class ReplSeqMemSpec extends SimpleTransformSpec {
       def outputForm = LowForm
       def transforms =
         Seq(new ConstantPropagation, CommonSubexpressionElimination, new DeadCodeElimination, RemoveEmpty)
-    }
+    },
+    new BlackBoxSourceHelper
   )
 
   def checkMemConf(circuitState: CircuitState, mems: Set[MemConf]) {


### PR DESCRIPTION
BlackBoxSourceHelper should only run late in compilation to allow
transforms to tweak its behavior (eg. changing BlackBoxTargetDirAnno).

Reverts a subtle behavior change in https://github.com/chipsalliance/firrtl/pull/2202, see test that captures the functionality I am trying to maintain. SiFive hit this in our internal flow where we emit different BlackBoxes to different directories so we need `BlackBoxSourceHelper` to only run during or after Verilog emission.

This really falls out of the fact that `BlackBoxSourceHelper` exists at all rather than using `CustomFileEmission` to emit the various files.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

Fixes unreleased bug

#### Type of Improvement

  - bug fix     

#### API Impact

This enshrines the FIRRTL 1.4.x behavior of letting late running transforms tweak the behavior of `BlackBoxSourceHelper`.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash:

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
