### PR TITLE
Bump Scala to 2.12.14 and 2.13.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala: [2.13.4, 2.12.13]
+        scala: [2.13.6, 2.12.14]
     container:
       image: ucbbar/chisel3-tools
       options: --user github --entrypoint /bin/bash
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala: [2.13.4, 2.12.13]
+        scala: [2.13.6, 2.12.14]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ enablePlugins(SiteScaladocPlugin)
 
 lazy val commonSettings = Seq(
   organization := "edu.berkeley.cs",
-  scalaVersion := "2.12.13",
-  crossScalaVersions := Seq("2.13.4", "2.12.13")
+  scalaVersion := "2.12.14",
+  crossScalaVersions := Seq("2.13.6", "2.12.14")
 )
 
 lazy val isAtLeastScala213 = Def.setting {

--- a/build.sc
+++ b/build.sc
@@ -10,7 +10,7 @@ import mill.contrib.buildinfo.BuildInfo
 
 import java.io.IOException
 
-object firrtl extends mill.Cross[firrtlCrossModule]("2.12.13", "2.13.4")
+object firrtl extends mill.Cross[firrtlCrossModule]("2.12.14", "2.13.6")
 
 class firrtlCrossModule(val crossScalaVersion: String) extends CrossSbtModule with ScalafmtModule with PublishModule with BuildInfo {
   override def millSourcePath = super.millSourcePath / os.up

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-protobuf" % "0.7.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.30")
 
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 

--- a/src/main/scala/firrtl/backends/experimental/smt/SMTLibSerializer.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/SMTLibSerializer.scala
@@ -145,7 +145,7 @@ object SMTLibSerializer {
     else { s"(ite ${serialize(e)} $bvOne $bvZero)" }
 
   // See <simple_symbol> definition in the Concrete Syntax Appendix of the SMTLib Spec
-  private val simple: Regex = raw"[a-zA-Z\+-/\*\=%\?!\.\$$_~&\^<>@][a-zA-Z0-9\+-/\*\=%\?!\.\$$_~&\^<>@]*".r
+  private val simple: Regex = raw"[a-zA-Z\+-/\*\=%\?!\.$$_~&\^<>@][a-zA-Z0-9\+-/\*\=%\?!\.$$_~&\^<>@]*".r
   def escapeIdentifier(name: String): String = name match {
     case simple() => name
     case _        => if (name.startsWith("|") && name.endsWith("|")) name else s"|$name|"


### PR DESCRIPTION
This required also bumping sbt-scalafix to bring in a newer version of
semanticdb. The new version of semanticdb had an issue with a regex in
SMTLib, fixed by fixing the way '$' is escaped in the regex.

Closes #2330 #2259 #2230

Tagging @ekiwi to check my regex, I think you were escaping the dollar sign wrong but please correct me if I'm incorrect. The diff isn't the most clear but it had been `\$$_` which was making the new semanticdb choke, thinking `$_` was an attempted variable substitution (no clue why this wasn't erroring before, but maybe `$_` is like newly supported or something). So I changed `\$$_` to just `$$_`, that is, an escaped `$` and an `_`.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Scala version bump
- bug fix


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Bump to Scala 2.12.14 and 2.13.6

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
