### PR TITLE
Fix multi-protobuf test when run multiple times

### DIFF
--- a/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
+++ b/src/test/scala/firrtlTests/stage/FirrtlMainSpec.scala
@@ -342,7 +342,7 @@ class FirrtlMainSpec
 
       And("some input multi-module FIRRTL IR")
       val inputFile: Array[String] = {
-        val in = new File(td.dir, c.main)
+        val in = new File(td.dir, s"${c.main}.fir")
         val pw = new PrintWriter(in)
         pw.write(c.input)
         pw.close()
@@ -360,18 +360,20 @@ class FirrtlMainSpec
         out should (exist)
       }
 
+      // NOTE the .fir out needs to be a different directory than the multi proto out because
+      // reruns will pick up the .fir and try to parse as .pb
       When("the user compiles the Protobufs to a single FIRRTL IR")
       f.stage.main(
-        Array("-I", td.buildDir.toString, "-X", "none", "-E", "chirrtl", "-td", td.buildDir.toString, "-o", "Foo")
+        Array("-I", td.buildDir.toString, "-X", "none", "-E", "chirrtl", "-td", td.dir.toString, "-o", "Foo")
       )
 
       Then("one single FIRRTL file should be emitted")
-      val outFile = new File(td.buildDir + "/Foo.fir")
+      val outFile = new File(td.dir + "/Foo.fir")
       outFile should (exist)
       And("it should be the same as using FIRRTL input")
       firrtl.Utils.orderAgnosticEquality(
         firrtl.Parser.parse(c.input),
-        firrtl.Parser.parseFile(td.buildDir + "/Foo.fir", firrtl.Parser.IgnoreInfo)
+        firrtl.Parser.parseFile(td.dir + "/Foo.fir", firrtl.Parser.IgnoreInfo)
       ) should be(true)
     }
 


### PR DESCRIPTION
The test was leaving the test directory in a dirty state that would fail
on a rerun. Fix the test so that it can be run multiple times in a row.

This is just a fix to the tests.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

   - test bug fix 

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
