### PR TITLE
transforms.formal: ensure named statements as output

### DIFF
--- a/src/main/scala/firrtl/transforms/formal/AssertSubmoduleAssumptions.scala
+++ b/src/main/scala/firrtl/transforms/formal/AssertSubmoduleAssumptions.scala
@@ -36,8 +36,7 @@ class AssertSubmoduleAssumptions
   )
 
   def assertAssumption(s: Statement): Statement = s match {
-    case Verification(Formal.Assume, info, clk, cond, en, msg) =>
-      Verification(Formal.Assert, info, clk, cond, en, msg)
+    case v: Verification if v.op == Formal.Assume => v.withOp(Formal.Assert)
     case t => t.mapStmt(assertAssumption)
   }
 

--- a/src/test/scala/firrtlTests/formal/ConvertAssertsSpec.scala
+++ b/src/test/scala/firrtlTests/formal/ConvertAssertsSpec.scala
@@ -24,11 +24,12 @@ class ConvertAssertsSpec extends FirrtlFlatSpec {
         |""".stripMargin
 
     val ref = preamble +
-      """    printf(clock, and(not(ne5), not(reset)), "x should not equal 5")
-        |    stop(clock, and(not(ne5), not(reset)), 1)
+      """    printf(clock, and(not(ne5), not(reset)), "x should not equal 5") : assert_0_print
+        |    stop(clock, and(not(ne5), not(reset)), 1) : assert_0
         |""".stripMargin
 
-    val outputCS = ConvertAsserts.execute(CircuitState(parse(input), Nil))
+    val state = CircuitState(parse(input), Nil)
+    val outputCS = ConvertAsserts.execute(state)
     (parse(outputCS.circuit.serialize)) should be(parse(ref))
   }
 
@@ -38,7 +39,7 @@ class ConvertAssertsSpec extends FirrtlFlatSpec {
         |""".stripMargin
 
     val ref = preamble +
-      """    stop(clock, and(not(ne5), not(reset)), 1)
+      """    stop(clock, and(not(ne5), not(reset)), 1) : assert_0
         |""".stripMargin
 
     val outputCS = ConvertAsserts.execute(CircuitState(parse(input), Nil))


### PR DESCRIPTION
This fixes a problem where an `assume` in a submodule would loose its name and thus treadle would fail.

### Contributor Checklist

- [x] Did you add at least one test demonstrating the PR?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### Type of Improvement
- bug fix

#### API Impact
- just makes sure that the output of these passes does not violate `EnsureNamedStatements`

#### Backend Code Generation Impact
- none, but the bug was messing with firrtl downstream consumers like treadle

#### Desired Merge Strategy
- squash


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
