### PR TITLE
TopWiring: don't try to wire Print, etc statements

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -69,7 +69,7 @@ class TopWiringTransform extends Transform with DependencyAPIMigration {
   )(s:             Statement
   ): Statement = s match {
     // If target wire, add name and size to to sourceMap
-    case w: IsDeclaration =>
+    case w: IsDeclaration with CanBeReferenced =>
       if (sourceList.keys.toSeq.contains(ComponentName(w.name, currentmodule))) {
         val (isport, tpe, prefix) = w match {
           case d: DefWire     => (false, d.tpe, sourceList(ComponentName(w.name, currentmodule)))


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix   
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

Prints and other non-`CanBeReferenced` statements will not try to be top-wired. They can't be because they generally do not have `.name`s (`""` is not a valid name).

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->

This makes some verilog work that currently would not be able to be generated.
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference. 
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Fix bug in TopWiringTransform for handling new Printf, Verif, Stop etc statements.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
