### PR TITLE
Have Flatten & InlineInstances remove their annotations

### DIFF
--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -371,7 +371,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
 
     val cleanedAnnos = annos.filterNot {
       case InlineAnnotation(_) => true
-      case _ => false
+      case _                   => false
     }
 
     CircuitState(flatCircuit, LowForm, cleanedAnnos, renames)

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -369,6 +369,11 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
 
     val renames = renamesSeq.reduceLeftOption(_ andThen _)
 
-    CircuitState(flatCircuit, LowForm, annos, renames)
+    val cleanedAnnos = annos.filterNot {
+      case InlineAnnotation(_) => true
+      case _ => false
+    }
+
+    CircuitState(flatCircuit, LowForm, cleanedAnnos, renames)
   }
 }

--- a/src/main/scala/firrtl/transforms/Flatten.scala
+++ b/src/main/scala/firrtl/transforms/Flatten.scala
@@ -132,7 +132,14 @@ class Flatten extends Transform with DependencyAPIMigration {
         val (modNames, instNames) = collectAnns(state.circuit, myAnnotations)
         // take incoming annotation and produce annotations for InlineInstances, i.e. traverse circuit down to find all instances to inline
         val (newc, modsToInline) = duplicateSubCircuitsFromAnno(state.circuit, modNames, instNames)
-        inlineTransform.run(newc, modsToInline.toSet, Set.empty[ComponentName], state.annotations)
+        val flattenedState = inlineTransform.run(newc, modsToInline.toSet, Set.empty[ComponentName], state.annotations)
+
+        val cleanedAnnos = flattenedState.annotations.filterNot {
+          case FlattenAnnotation(_) => true
+          case _ => false
+        }
+
+        flattenedState.copy(annotations = cleanedAnnos)
     }
   }
 }

--- a/src/main/scala/firrtl/transforms/Flatten.scala
+++ b/src/main/scala/firrtl/transforms/Flatten.scala
@@ -136,7 +136,7 @@ class Flatten extends Transform with DependencyAPIMigration {
 
         val cleanedAnnos = flattenedState.annotations.filterNot {
           case FlattenAnnotation(_) => true
-          case _ => false
+          case _                    => false
         }
 
         flattenedState.copy(annotations = cleanedAnnos)


### PR DESCRIPTION
Compilers that run `InlineInstances` multiple times would attempt to re-inline modules that no longer exist. It's possible that something may depend on these annotations after they've run -- if that's the case, I can define a new output annotation to avoid this problem. 

Should i add tests to check these passes remove their annotations, or is this sufficient?

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix                 

#### API Impact

No change.

#### Backend Code Generation Impact

No change.

#### Desired Merge Strategy

Squash.

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
Have Flatten & InlineInstances remove their annotations after invocation.
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
