### PR TITLE
verilog: add comment to named statements

### DIFF
--- a/src/test/scala/firrtlTests/formal/VerificationSpec.scala
+++ b/src/test/scala/firrtlTests/formal/VerificationSpec.scala
@@ -29,7 +29,7 @@ class VerificationSpec extends FirrtlFlatSpec {
         |    outputEquals0xAA <= eq(out, UInt<8>("hAA"))
         |    node true = UInt("b1")
         |    assume(clock, inputEquals0xAA, true, "assume input is 0xAA")
-        |    assert(clock, areEqual, true, "assert that output equals input")
+        |    assert(clock, areEqual, true, "assert that output equals input") : are_equal
         |    cover(clock, outputEquals0xAA, true, "cover output is 0xAA")
         |""".stripMargin
     val expected =
@@ -48,7 +48,7 @@ class VerificationSpec extends FirrtlFlatSpec {
         |    end
         |    // assert that output equals input
         |    if (1'h1) begin
-        |      assert(areEqual);
+        |      assert(areEqual); // Asserting.are_equal
         |    end
         |    // cover output is 0xAA
         |    if (1'h1) begin


### PR DESCRIPTION
I need this feature in order to more easily translate a failing assertion in Verilator into a firrtl statement name.
Besides that, I think this will help developers map the generated Verilog to the input firrtl or Chisel code.

### Contributor Checklist
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### Type of Improvement
- backend code generation (non-functional!)

#### API Impact
- no API change

#### Backend Code Generation Impact

- if a statement has a name, it will be included as a comment in the generated Verilog

#### Desired Merge Strategy
- squash


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
