### PR TITLE
TopWiring: filter out unnamed declarations when building source lists

### DIFF
--- a/src/main/scala/firrtl/transforms/TopWiring.scala
+++ b/src/main/scala/firrtl/transforms/TopWiring.scala
@@ -68,8 +68,11 @@ class TopWiringTransform extends Transform with DependencyAPIMigration {
     state:         CircuitState
   )(s:             Statement
   ): Statement = s match {
-    // If target wire, add name and size to to sourceMap
-    case w: IsDeclaration =>
+    // Declarations with non-empty names can be sources. However, some
+    // side-affecting statements may given the empty string as name. Filter
+    // these out before they are rejected by ComponentName's constructor, since
+    // they cannot be named as a source in a TopWiring annotation anyways.
+    case w: IsDeclaration if w.name != "" =>
       if (sourceList.keys.toSeq.contains(ComponentName(w.name, currentmodule))) {
         val (isport, tpe, prefix) = w match {
           case d: DefWire     => (false, d.tpe, sourceList(ComponentName(w.name, currentmodule)))

--- a/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
+++ b/src/test/scala/firrtlTests/transforms/TopWiringTest.scala
@@ -635,6 +635,17 @@ class TopWiringTests extends MiddleTransformSpec with TopWiringTestsCommon {
     outputState.circuit.serialize should include("output bar_foo")
     outputState.annotations.toSeq should be(empty)
   }
+
+  "Unnamed side-affecting statements" should s"not be included as potential sources" in {
+    val input =
+      """circuit Top :
+        |  module Top :
+        |    input clock : Clock
+        |    printf(clock, UInt<1>(1), "")
+        |    stop(clock, UInt<1>(1), 1)
+        |""".stripMargin
+    execute(input, input, Seq())
+  }
 }
 
 class AggregateTopWiringTests extends MiddleTransformSpec with TopWiringTestsCommon {


### PR DESCRIPTION
TopWiring croaks when building up a potential source list because it tries to generate a `ComponentName` for declarations whose name is the empty string. Since unnamed declarations cannot be targeted anyways (i think?) simply filter them out. This will give a slightly better error message when trying to wire an unsupported declaration. 

Subsumes #2372.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix 


#### API Impact

No change. 

#### Backend Code Generation Impact

No change.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash

#### Release Notes
TopWiring: filter out unnamed declarations when building source lists

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you mark as `Please Merge`?
