### PR TITLE
Support parsing missing keywords as ids

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -225,8 +225,11 @@ keywordAsId
   | 'UInt'
   | 'SInt'
   | 'Clock'
+  | 'Reset'
+  | 'AsyncReset'
   | 'Analog'
   | 'Fixed'
+  | 'Interval'
   | 'flip'
   | 'wire'
   | 'reg'
@@ -259,6 +262,10 @@ keywordAsId
   | 'read'
   | 'write'
   | 'rdwr'
+  | 'attach'
+  | 'assert'
+  | 'assume'
+  | 'cover'
   ;
 
 // Parentheses are added as part of name because semantics require no space between primop and open parentheses

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -48,8 +48,11 @@ class ParserSpec extends FirrtlFlatSpec {
       "SInt",
       "Analog",
       "Fixed",
+      "Interval",
       "flip",
       "Clock",
+      "Reset",
+      "AsyncReset",
       "wire",
       "reg",
       "reset",
@@ -80,7 +83,11 @@ class ParserSpec extends FirrtlFlatSpec {
       "infer",
       "read",
       "write",
-      "rdwr"
+      "rdwr",
+      "attach",
+      "assert",
+      "assume",
+      "cover"
     ) ++ PrimOps.listing
   }
 
@@ -180,6 +187,15 @@ class ParserSpec extends FirrtlFlatSpec {
     import KeywordTests._
     keywords.foreach { keyword =>
       firrtl.Parser.parse((prelude ++ Seq(s"      wire ${keyword} : UInt", s"      ${keyword} <= ${keyword}")))
+    }
+  }
+
+  they should "be allowed as names for side effecting statements" in {
+    import KeywordTests._
+    keywords.foreach { keyword =>
+      firrtl.Parser.parse {
+        prelude :+ s"""    assert($keyword, UInt(1), UInt(1), "") : $keyword"""
+      }
     }
   }
 


### PR DESCRIPTION
Reset, AsyncReset, Interval, attach, assert, assume, and cover have all
been added as keywords but not added to the allowlist for parsing as
ids.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix 

#### API Impact

Accept more keywords as ids in parsing

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Support parsing more keywords as identifiers: Reset, AsyncReset, Interval, attach, assert, assume, and cover

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [x] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
