### PR TITLE
Favor os-lib write.over in WriteEmitted

### DIFF
--- a/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
+++ b/src/main/scala/firrtl/stage/phases/WriteEmitted.scala
@@ -45,13 +45,13 @@ class WriteEmitted extends Phase {
     annotations.flatMap {
       case a: EmittedModuleAnnotation[_] =>
         val target = FileUtils.getPath(sopts.getBuildFileName(a.value.name, Some(a.value.outputSuffix)))
-        os.write(target, a.value.value)
+        os.write.over(target, a.value.value)
         None
       case a: EmittedCircuitAnnotation[_] =>
         val target = FileUtils.getPath(
           sopts.getBuildFileName(fopts.outputFileName.getOrElse(a.value.name), Some(a.value.outputSuffix))
         )
-        os.write(target, a.value.value)
+        os.write.over(target, a.value.value)
         None
       case a => Some(a)
     }


### PR DESCRIPTION
#2275 changed the semantics of the soon-to-be-removed WriteEmitted phase, which would cause the phase to croak when attempting to overwrite an existing file. This uses the correct os-lib equivalent of the java.io call we used previously. 

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

Returns 3.4.x behavior to what it was before.

#### Backend Code Generation Impact

None

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
- Squash
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
