### PR TITLE
Modify and optimize performance of propagate annotations

### DIFF
--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -17,11 +17,11 @@ import firrtl.stage.Forms
 import firrtl.transforms.DedupAnnotationsTransform
 
 /** Container of all annotations for a Firrtl compiler */
-class AnnotationSeq private (private[firrtl] val underlying: List[Annotation]) {
-  def toSeq: Seq[Annotation] = underlying.toSeq
+class AnnotationSeq private (underlying: Seq[Annotation]) {
+  def toSeq: Seq[Annotation] = underlying
 }
 object AnnotationSeq {
-  def apply(xs: Seq[Annotation]): AnnotationSeq = new AnnotationSeq(xs.toList)
+  def apply(xs: Seq[Annotation]): AnnotationSeq = new AnnotationSeq(xs)
 }
 
 /** Current State of the Circuit

--- a/src/main/scala/firrtl/Compiler.scala
+++ b/src/main/scala/firrtl/Compiler.scala
@@ -6,6 +6,7 @@ import logger._
 import java.io.Writer
 
 import scala.collection.mutable
+import scala.collection.immutable.VectorBuilder
 import scala.util.Try
 import scala.util.control.NonFatal
 import firrtl.annotations._
@@ -211,8 +212,8 @@ final case object UnknownForm extends CircuitForm(-1) {
 // Internal utilities to keep code DRY, not a clean interface
 private[firrtl] object Transform {
 
-  def remapAnnotations(name: String, before: CircuitState, after: CircuitState, logger: Logger): CircuitState = {
-    val remappedAnnotations = propagateAnnotations(name, logger, before.annotations, after.annotations, after.renames)
+  def remapAnnotations(after: CircuitState, logger: Logger): CircuitState = {
+    val remappedAnnotations = propagateAnnotations(after.annotations, after.renames)
 
     logger.trace(s"Annotations:")
     logger.trace(JsonProtocol.serializeRecover(remappedAnnotations))
@@ -222,51 +223,34 @@ private[firrtl] object Transform {
     CircuitState(after.circuit, after.form, remappedAnnotations, None)
   }
 
-  /** Propagate annotations and update their names.
-    *
-    * @param inAnno input AnnotationSeq
-    * @param resAnno result AnnotationSeq
-    * @param renameOpt result RenameMap
-    * @return the updated annotations
-    */
+  // This function is *very* mutable but it is fairly performance critical
   def propagateAnnotations(
-    name:      String,
-    logger:    Logger,
-    inAnno:    AnnotationSeq,
     resAnno:   AnnotationSeq,
     renameOpt: Option[RenameMap]
   ): AnnotationSeq = {
-    val newAnnotations = {
-      val inSet = mutable.LinkedHashSet() ++ inAnno
-      val resSet = mutable.LinkedHashSet() ++ resAnno
-      val deleted = (inSet -- resSet).map {
-        case DeletedAnnotation(xFormName, delAnno) => DeletedAnnotation(s"$xFormName+$name", delAnno)
-        case anno                                  => DeletedAnnotation(name, anno)
-      }
-      val created = resSet -- inSet
-      val unchanged = resSet & inSet
-      (deleted ++ created ++ unchanged)
-    }
+    // We dedup/distinct the resulting annotations when renaming occurs
+    val seen = new mutable.HashSet[Annotation]
+    val result = new VectorBuilder[Annotation]
 
-    // For each annotation, rename all annotations.
-    val renames = renameOpt.getOrElse(RenameMap())
-    val remapped2original = mutable.LinkedHashMap[Annotation, mutable.LinkedHashSet[Annotation]]()
-    val keysOfNote = mutable.LinkedHashSet[Annotation]()
-    val finalAnnotations = newAnnotations.flatMap { anno =>
-      val remappedAnnos = anno.update(renames)
-      remappedAnnos.foreach { remapped =>
-        val set = remapped2original.getOrElseUpdate(remapped, mutable.LinkedHashSet.empty[Annotation])
-        set += anno
-        if (set.size > 1) keysOfNote += remapped
+    val hasRenames = renameOpt.isDefined
+    val renames = renameOpt.getOrElse(null) // Null is bad but saving the allocation is worth it
+
+    val it = resAnno.toSeq.iterator
+    while (it.hasNext) {
+      val anno = it.next()
+      if (hasRenames) {
+        val renamed = anno.update(renames)
+        for (annox <- renamed) {
+          if (!seen(annox)) {
+            seen += annox
+            result += annox
+          }
+        }
+      } else {
+        result += anno
       }
-      remappedAnnos
-    }.toSeq
-    keysOfNote.foreach { key =>
-      logger.debug(s"""The following original annotations are renamed to the same new annotation.""")
-      logger.debug(s"""Original Annotations:\n  ${remapped2original(key).mkString("\n  ")}""")
-      logger.debug(s"""New Annotation:\n  $key""")
     }
-    finalAnnotations
+    result.result()
   }
 }
 
@@ -363,7 +347,7 @@ trait Transform extends TransformLike[CircuitState] with DependencyAPI[Transform
     */
   final def runTransform(state: CircuitState): CircuitState = {
     val result = execute(prepare(state))
-    Transform.remapAnnotations(name, state, result, logger)
+    Transform.remapAnnotations(result, logger)
   }
 
 }

--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -7,7 +7,7 @@ package object firrtl {
   private val _dummyForms = firrtl.stage.Forms
 
   implicit def seqToAnnoSeq(xs: Seq[Annotation]) = AnnotationSeq(xs)
-  implicit def annoSeqToSeq(as: AnnotationSeq): Seq[Annotation] = as.underlying
+  implicit def annoSeqToSeq(as: AnnotationSeq): Seq[Annotation] = as.toSeq
 
   /* Options as annotations compatibility items */
   @deprecated("Use firrtl.stage.TargetDirAnnotation", "FIRRTL 1.2")

--- a/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
+++ b/src/main/scala/firrtl/stage/transforms/UpdateAnnotations.scala
@@ -15,7 +15,7 @@ class UpdateAnnotations(val underlying: Transform)
   def aToB(a: CircuitState): (CircuitState, CircuitState) = (a, a)
 
   def bToA(b: (CircuitState, CircuitState)): CircuitState = {
-    Transform.remapAnnotations(name, b._1, b._2, logger)
+    Transform.remapAnnotations(b._2, logger)
   }
 
   def internalTransform(b: (CircuitState, CircuitState)): (CircuitState, CircuitState) = {

--- a/src/main/scala/firrtl/transforms/DedupAnnotations.scala
+++ b/src/main/scala/firrtl/transforms/DedupAnnotations.scala
@@ -95,7 +95,7 @@ class DedupAnnotationsTransform extends Transform with DependencyAPIMigration {
   def execute(state: CircuitState): CircuitState = CircuitState(
     state.circuit,
     state.form,
-    DedupAnnotationsTransform.dedupAnnotations(state.annotations.underlying, InstanceKeyGraph(state.circuit)),
+    DedupAnnotationsTransform.dedupAnnotations(state.annotations.toSeq, InstanceKeyGraph(state.circuit)),
     state.renames
   )
 }

--- a/src/test/scala/firrtlTests/AnnotationTests.scala
+++ b/src/test/scala/firrtlTests/AnnotationTests.scala
@@ -45,7 +45,9 @@ abstract class AnnotationTests extends LowFirrtlTransformSpec with Matchers with
     r.annotations.toSeq should contain(ta)
   }
 
-  "Deleting annotations" should "create a DeletedAnnotation" in {
+  // This test is no longer true as of 1.5.0-RC2, see
+  // https://github.com/chipsalliance/firrtl/pull/2393
+  "Deleting annotations" should "create a DeletedAnnotation" ignore {
     val transform = Dependency[DeletingTransform]
     val compiler = makeVerilogCompiler(Seq(transform))
     val input =


### PR DESCRIPTION
This is basically just deletes all of the logic we had determining which annotations were added or deleted between transforms. This does not change any Scala APIs, but it very much changes what sorts of DeletedAnnotations are created. The deleted behavior could be useful for debugging and technically *could* be relied upon someone, but my hunch is that no one cares and we're harming performance and burning carbon for nothing. If it turns out someone relies on this, I think we should add it back under some sort of "debug" annotation.

This change only really affects annotation-heavy flows. I found that with small designs with moderate numbers of annotations, it improves performance ~2-7%. For large designs with tons of annotations however, it improved performance by **34%** (15m45 -> 10m20s)

This is a bit aggressive, but I think it's worth it.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
 - performance improvement            
 - code refactoring                   
 - code cleanup                    


#### API Impact

Annotations that are deleted between transforms are no longer automatically captured as `DeletedAnnotations`

#### Backend Code Generation Impact

No direct impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

When a transform deletes an `Annotation`, a `DeletedAnnotation` is no longer created. Furthermore, debug-mode logging no longer captures any information about annotation changes between transforms. If any of this behavior is desired, please file an issue to restore it under a debug flag.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
