### PR TITLE
Add SuggestSeqMemName annotation to rename replaced blackboxes

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -305,7 +305,7 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     val memMods = new Modules
     val nameMap = new NameMap
     val suggestNameMap: Map[String, String] = state.annotations.collect {
-      case m @ SuggestSeqMemNameAnnotation(target, name) => target.ref -> name
+      case SuggestSeqMemNameAnnotation(target, name) => target.ref -> name
     }.toMap[String, String]
     c.modules.map(m => m.map(constructNameMap(namespace, nameMap, m.name, suggestNameMap)))
     val renameMap = RenameMap()

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -310,17 +310,18 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     c.modules.map(m => m.map(constructNameMap(namespace, nameMap, m.name, suggestNameMap)))
     val renameMap = RenameMap()
     val modules = c.modules.map(updateMemMods(namespace, nameMap, memMods, annotatedMemoriesBuffer, renameMap, c.main))
-    val remainingAnnos: AnnotationSeq = state.annotations.filter(!_.isInstanceOf[SuggestSeqMemNameAnnotation]) ++
-      (state.annotations.collectFirst { case a: PinAnnotation => a } match {
-        case None => Nil
-        case Some(PinAnnotation(pins)) =>
-          pins.foldLeft(Seq[Annotation]()) { (seq, pin) =>
-            seq ++ memMods.collect {
-              case m: ExtModule => SinkAnnotation(ModuleName(m.name, CircuitName(c.main)), pin)
+    val remainingAnnos: AnnotationSeq =
+      state.annotations.filter(!_.isInstanceOf[SuggestSeqMemNameAnnotation]) ++
+        (state.annotations.collectFirst { case a: PinAnnotation => a } match {
+          case None => Nil
+          case Some(PinAnnotation(pins)) =>
+            pins.foldLeft(Seq[Annotation]()) { (seq, pin) =>
+              seq ++ memMods.collect {
+                case m: ExtModule => SinkAnnotation(ModuleName(m.name, CircuitName(c.main)), pin)
+              }
             }
-          }
-      }) :+
-      AnnotatedMemoriesAnnotation(annotatedMemoriesBuffer.toList)
+        }) :+
+        AnnotatedMemoriesAnnotation(annotatedMemoriesBuffer.toList)
     state.copy(
       circuit = c.copy(modules = modules ++ memMods),
       annotations = remainingAnnos,

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemTransform.scala
@@ -44,6 +44,11 @@ object PassConfigUtil {
   }
 }
 
+case class SuggestSeqMemNameAnnotation(target: ReferenceTarget, desiredName: String)
+    extends SingleTargetAnnotation[ReferenceTarget] {
+  def duplicate(n: ReferenceTarget): SuggestSeqMemNameAnnotation = new SuggestSeqMemNameAnnotation(n, desiredName)
+}
+
 case class ReplSeqMemAnnotation(inputFileName: String, outputConfig: String) extends NoTargetAnnotation
 
 case class GenVerilogMemBehaviorModelAnno(genBlackBox: Boolean) extends NoTargetAnnotation

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -693,4 +693,37 @@ circuit Top :
          |""".stripMargin
     compileAndEmit(CircuitState(parse(input), ChirrtlForm))
   }
+
+  "ReplSeqMem" should "rename blackbox instances to suggested names" in {
+    val input =
+      """
+        |circuit CustomMemory :
+        |  module CustomMemory :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output io : {flip rClk : Clock, flip rAddr : UInt<3>, dO : UInt<16>, flip wClk : Clock, flip wAddr : UInt<3>, flip wEn : UInt<1>, flip dI : UInt<16>}
+        |    io is invalid
+        |    smem mem_0 : UInt<16>[7]
+        |    read mport _T_17 = mem_0[io.rAddr], clock
+        |    io.dO <= _T_17
+        |    when io.wEn :
+        |      write mport _T_18 = mem_0[io.wAddr], clock
+        |      _T_18 <= io.dI
+        |""".stripMargin
+    val mems = Set(
+      MemConf("renamed_mem", 7, 16, Map(WritePort -> 1, ReadPort -> 1), None)
+    )
+    val confLoc = "ReplSeqMemTests.confTEMP"
+    val annos = Seq(
+      ReplSeqMemAnnotation.parse("-c:CustomMemory:-o:" + confLoc),
+      SuggestSeqMemNameAnnotation(
+        CircuitTarget("CustomMemory")
+          .module("CustomMemory")
+          .ref("mem_0"),
+        "renamed_mem"
+      )
+    )
+    val res = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
+    checkMemConf(res, mems)
+  }
 }

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -725,5 +725,13 @@ circuit Top :
     )
     val res = compileAndEmit(CircuitState(parse(input), ChirrtlForm, annos))
     checkMemConf(res, mems)
+    (new java.io.File(confLoc)).delete()
+
+    // blackbox
+    res should containLine("extmodule renamed_mem :")
+    res should containLine("inst renamed_mem of renamed_mem")
+    // wrapper
+    res should containLine("module mem_0 :")
+    res should containLine("inst mem_0 of mem_0")
   }
 }


### PR DESCRIPTION
This PR implements an annotation (`SuggestSeqMemNameAnnotation`) to rename a memory blackbox to a user-specified name instead of the default `{mem name}_ext`.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

No new API

#### Backend Code Generation Impact

Memory blackboxes get renamed with th

#### Desired Merge Strategy

Squash and merge

#### Release Notes
Implement a mechanism to rename blackboxes generated by `ReplSeqMems` with a user-specified name

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
