### PR TITLE
BlackBoxSourceHelper: ensure trailing newline in .f file

### DIFF
--- a/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -135,7 +135,7 @@ class BlackBoxSourceHelper extends Transform with DependencyAPIMigration {
     //  make[1]: *** No rule to make target `test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/AccumBlackBox.v', needed by `.../chisel-testers/test_run_dir/examples.AccumBlackBox_PeekPokeTest_Verilator345491158/VAccumBlackBoxWrapper.h'.  Stop.
     //  or we end up including the same file multiple times.
     if (verilogSourcesOnly.nonEmpty) {
-      writeTextToFile(verilogSourcesOnly.map(_.getCanonicalPath).mkString("\n"), filelistFile)
+      writeTextToFile(verilogSourcesOnly.map(_.getCanonicalPath).mkString("\n") + "\n", filelistFile)
     }
 
     state

--- a/src/test/scala/firrtlTests/transforms/BlackBoxSourceHelperSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/BlackBoxSourceHelperSpec.scala
@@ -193,4 +193,19 @@ class BlacklBoxSourceHelperTransformSpec extends LowTransformSpec {
     new File(subdir, filename) should exist
     new File(dir, filename) shouldNot exist
   }
+
+  "verilog file list" should "end with a newline" in {
+    val annos = Seq(
+      BlackBoxTargetDirAnno("test_run_dir"),
+      BlackBoxResourceAnno(moduleName, "/blackboxes/AdderExtModule.v")
+    )
+
+    execute(input, output, annos)
+
+    val filename = os.pwd / "test_run_dir" / BlackBoxSourceHelper.defaultFileListName
+    assert(os.exists(filename), "verilog file list should exist")
+    val content = os.read(filename)
+    assert(content.contains("AdderExtModule.v"))
+    assert(content.last == '\n', "Some simulators like Icarus Verilog seem to expect a trailing new line character")
+  }
 }


### PR DESCRIPTION
It seems like some simulators require a trailing newline in every `.f` file: https://github.com/ucb-bar/chisel-testers2/pull/429#discussion_r738883945

### Contributor Checklist
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?

#### Type of Improvement

- bug fix

#### API Impact

- none

#### Backend Code Generation Impact

- none

#### Desired Merge Strategy

- squash


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
