### PR TITLE
[deprecation clean up] remove firrtl.FIRRTLException

### DIFF
--- a/src/main/scala/firrtl/FirrtlException.scala
+++ b/src/main/scala/firrtl/FirrtlException.scala
@@ -4,22 +4,6 @@ package firrtl
 
 import scala.util.control.NoStackTrace
 
-@deprecated("External users should use either FirrtlUserException or their own hierarchy", "FIRRTL 1.2")
-object FIRRTLException {
-  def defaultMessage(message: String, cause: Throwable) = {
-    if (message != null) {
-      message
-    } else if (cause != null) {
-      cause.toString
-    } else {
-      null
-    }
-  }
-}
-@deprecated("External users should use either FirrtlUserException or their own hierarchy", "FIRRTL 1.2")
-class FIRRTLException(val str: String, cause: Throwable = null)
-    extends RuntimeException(FIRRTLException.defaultMessage(str, cause), cause)
-
 /** Exception indicating user error
   *
   * These exceptions indicate a problem due to bad input and thus do not include a stack trace.

--- a/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
+++ b/src/main/scala/firrtl/stage/phases/CatchExceptions.scala
@@ -3,14 +3,7 @@
 package firrtl.stage.phases
 
 import firrtl.options.{DependencyManagerException, OptionsException, Phase, PhaseException}
-import firrtl.{
-  AnnotationSeq,
-  CustomTransformException,
-  FIRRTLException,
-  FirrtlInternalException,
-  FirrtlUserException,
-  Utils
-}
+import firrtl.{AnnotationSeq, CustomTransformException, FirrtlInternalException, FirrtlUserException, Utils}
 
 import scala.util.control.ControlThrowable
 
@@ -31,8 +24,8 @@ class CatchExceptions(val underlying: Phase) extends Phase {
   } catch {
     /* Rethrow the exceptions which are expected or due to the runtime environment (out of memory, stack overflow, etc.).
      * Any UNEXPECTED exceptions should be treated as internal errors. */
-    case p @ (_: ControlThrowable | _: FIRRTLException | _: OptionsException | _: FirrtlUserException |
-        _: FirrtlInternalException | _: PhaseException | _: DependencyManagerException) =>
+    case p @ (_: ControlThrowable | _: OptionsException | _: FirrtlUserException | _: FirrtlInternalException |
+        _: PhaseException | _: DependencyManagerException) =>
       throw p
     case CustomTransformException(cause) => throw cause
     case e: Exception => Utils.throwInternalError(exception = Some(e))


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
