### PR TITLE
Enable memory initialization in synthesis for FPGA targets

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlCompilerTargets.scala
+++ b/src/main/scala/firrtl/stage/FirrtlCompilerTargets.scala
@@ -5,6 +5,7 @@ package firrtl.stage
 import firrtl.transforms._
 import firrtl.passes.memlib._
 import firrtl.options.{HasShellOptions, ShellOption}
+import firrtl.annotations.MemorySynthInit
 
 /**
   * This flag enables a set of options that guide the FIRRTL compilation flow to ultimately generate Verilog that is
@@ -31,6 +32,8 @@ import firrtl.options.{HasShellOptions, ShellOption}
   * 5) Add a [[firrtl.passes.memlib.PassthroughSimpleSyncReadMemsAnnotation]] to allow some synchronous-read memories
   *    and readwrite ports to pass through [[firrtl.passes.memlib.VerilogMemDelays]] without introducing explicit
   *    pipeline registers or splitting ports.
+  *
+  * 6) Add a [[firrtl.annotations.MemorySynthInit]] to enable memory initialization values to be synthesized.
   */
 object OptimizeForFPGA extends HasShellOptions {
   private val fpgaAnnos = Seq(
@@ -40,7 +43,8 @@ object OptimizeForFPGA extends HasShellOptions {
     DefaultReadFirstAnnotation,
     RunFirrtlTransformAnnotation(new SetDefaultReadUnderWrite),
     RunFirrtlTransformAnnotation(new SimplifyMems),
-    PassthroughSimpleSyncReadMemsAnnotation
+    PassthroughSimpleSyncReadMemsAnnotation,
+    MemorySynthInit
   )
   val options = Seq(
     new ShellOption[Unit](


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- new feature/API

#### API Impact

This PR extends the `--target:fpga` to enable memory initialization on synthesis by default.

#### Backend Code Generation Impact

Verilog code generated for FPGA targets will have `readmem[hb]` statements outside the `ifndef SYNTHESIS` block enabling memory initialization with provided file.

#### Desired Merge Strategy

 - Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

Code generated for FPGA targets (with `--target:fpga` command line argument) enables memory initialization with `readmem[hb]` statements at synthesis by default .

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
