### PR TITLE
Fix width of signed addition when input to mux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,10 @@ jobs:
         # By having this "if" here, this job returns success so that all_tests_passed will succeed too
         if: github.event_name == 'pull_request' &&
             ! contains(github.event.pull_request.labels.*.name, 'Skip Formal CI')
-        run: ./.run_formal_checks.sh ${{ matrix.design }}
+        run: |
+          echo ${{ github.event_name }}
+          echo ${{ github.event.pull_request.labels }}
+          ./.run_formal_checks.sh ${{ matrix.design }}
 
   # Sentinel job to simplify how we specify which checks need to pass in branch
   # protection and in Mergify

--- a/src/test/scala/firrtlTests/VerilogEquivalenceSpec.scala
+++ b/src/test/scala/firrtlTests/VerilogEquivalenceSpec.scala
@@ -120,4 +120,125 @@ class VerilogEquivalenceSpec extends FirrtlFlatSpec {
     firrtlEquivalenceWithVerilog(input1, expected)
     firrtlEquivalenceWithVerilog(input2, expected)
   }
+
+  case class SignedMuxTest(
+    operatorFIRRTL:  String,
+    operatorVerilog: String,
+    inputWidth:      Int,
+    outputWidth:     Int,
+    secondArgSigned: Boolean) {
+    private val moduleName = s"Signed${operatorFIRRTL.capitalize}Mux"
+    private val headerFIRRTL =
+      s"""|circuit $moduleName :
+          |  module $moduleName :
+          |    input sel : UInt<1>
+          |    input is0 : SInt<$inputWidth>
+          |    input is1 : ${if (secondArgSigned) "S" else "U"}Int<$inputWidth>
+          |    output os : SInt<$outputWidth>""".stripMargin
+    private val expressionFIRRTL = s"$operatorFIRRTL(is0, is1)"
+    private val headerVerilog =
+      s"""|module Reference(
+          |  input sel,
+          |  input signed [$inputWidth-1:0] is0,
+          |  input ${if (secondArgSigned) "signed" else ""}[$inputWidth-1:0] is1,
+          |  output signed [$outputWidth-1:0] os
+          |);""".stripMargin
+    private val expressionVerilog = s"is0 $operatorVerilog is1"
+
+    def firrtlWhen: String =
+      s"""|$headerFIRRTL
+          |    os <= SInt(0)
+          |    when sel :
+          |      os <= $expressionFIRRTL
+          |""".stripMargin
+
+    def firrtlTrue: String =
+      s"""|$headerFIRRTL
+          |    os <= mux(sel, $expressionFIRRTL, SInt(0))
+          |""".stripMargin
+
+    def firrtlFalse: String =
+      s"""|$headerFIRRTL
+          |    os <= mux(sel, SInt(0), $expressionFIRRTL)
+          |""".stripMargin
+
+    def verilogTrue: String =
+      s"""|$headerVerilog
+          |  assign os = sel ? $expressionVerilog : $outputWidth'sh0;
+          |endmodule
+          |""".stripMargin
+    def verilogFalse: String =
+      s"""|$headerVerilog
+          |  assign os = sel ? $outputWidth'sh0 : $expressionVerilog;
+          |endmodule
+          |""".stripMargin
+  }
+
+  Seq(
+    SignedMuxTest("add", "+", 2, 3, true),
+    SignedMuxTest("sub", "-", 2, 3, true),
+    SignedMuxTest("mul", "*", 2, 4, true),
+    SignedMuxTest("div", "/", 2, 3, true),
+    SignedMuxTest("rem", "%", 2, 2, true),
+    SignedMuxTest("dshl", "<<", 2, 3, false)
+  ).foreach {
+    case t =>
+      s"signed ${t.operatorFIRRTL} followed by a mux" should "be correct" in {
+        info(s"'when' where '${t.operatorFIRRTL}' used in the 'when' body okay")
+        firrtlEquivalenceWithVerilog(t.firrtlWhen, t.verilogTrue)
+        info(s"'mux' where '${t.operatorFIRRTL}' used in the true leg okay")
+        firrtlEquivalenceWithVerilog(t.firrtlTrue, t.verilogTrue)
+        info(s"'mux' where '${t.operatorFIRRTL}' used in the false leg okay")
+        firrtlEquivalenceWithVerilog(t.firrtlFalse, t.verilogFalse)
+      }
+  }
+
+  "signed shl followed by a mux" should "be correct" in {
+    val headerFIRRTL =
+      """|circuit SignedShlMux :
+         |  module SignedShlMux :
+         |    input sel : UInt<1>
+         |    input is0 : SInt<2>
+         |    output os : SInt<5>""".stripMargin
+    val headerVerilog =
+      """|module Reference(
+         |  input sel,
+         |  input signed [1:0] is0,
+         |  output signed [4:0] os
+         |);""".stripMargin
+
+    val firrtlWhen =
+      s"""|$headerFIRRTL
+          |    os <= SInt(0)
+          |    when sel :
+          |      os <= shl(is0, 2)
+          |""".stripMargin
+
+    val firrtlTrue =
+      s"""|$headerFIRRTL
+          |    os <= mux(sel, shl(is0, 2), SInt(0))
+          |""".stripMargin
+
+    val firrtlFalse =
+      s"""|$headerFIRRTL
+          |    os <= mux(sel, SInt(0), shl(is0, 2))
+          |""".stripMargin
+
+    val verilogTrue =
+      s"""|$headerVerilog
+          |  assign os = sel ? (is0 << 2'h2) : 5'sh0;
+          |endmodule
+          |""".stripMargin
+
+    val verilogFalse =
+      s"""|$headerVerilog
+          |  assign os = sel ? 5'sh0 : (is0 << 2'h2);
+          |endmodule
+          |""".stripMargin
+
+    firrtlEquivalenceWithVerilog(firrtlWhen, verilogTrue)
+    firrtlEquivalenceWithVerilog(firrtlTrue, verilogTrue)
+    firrtlEquivalenceWithVerilog(firrtlFalse, verilogFalse)
+  }
+
 }


### PR DESCRIPTION
Extremely focused fix for #2439. I'm not sure if this is the best fix but I think the test is pretty good at least so wanted to put this out there.

Fixes #2439

h/t to @youngar for finding an OG bug.

I'm wondering if it would be better to just remove the casts in the VerilogEmitter, do we ever actually need to cast the inputs to a mux? https://github.com/chipsalliance/firrtl/blob/4347f57b7ef201251fb2cd463124f2d7cea369f8/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala#L182
That's just a lot scarier of a change 😨 

I'm backporting this as far as it will go...

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - bug fix        

#### API Impact

No impact

#### Backend Code Generation Impact

Minimal, will split out signed addition into another Statement if it is a direct input to a mux

#### Desired Merge Strategy

 - Squash

#### Release Notes

Fix width of signed addition when it is an input to a mux.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
