### PR TITLE
Deprecate all mutable methods on RenameMap and add MutableRenameMap

### DIFF
--- a/src/main/scala/firrtl/annotations/transforms/CleanupNamedTargets.scala
+++ b/src/main/scala/firrtl/annotations/transforms/CleanupNamedTargets.scala
@@ -7,6 +7,7 @@ import firrtl.annotations.{CircuitTarget, ModuleTarget, MultiTargetAnnotation, R
 import firrtl.ir
 import firrtl.options.{Dependency, PreservesAll}
 import firrtl.traversals.Foreachers._
+import firrtl.renamemap.MutableRenameMap
 
 import scala.collection.immutable.{Set => ISet}
 
@@ -31,7 +32,7 @@ class CleanupNamedTargets extends Transform with DependencyAPIMigration {
     statement: ir.Statement
   )(
     implicit references: ISet[ReferenceTarget],
-    renameMap:           RenameMap,
+    renameMap:           MutableRenameMap,
     module:              ModuleTarget
   ): Unit = statement match {
     case ir.DefInstance(_, a, b, _) if references(module.instOf(a, b).asReference) =>
@@ -43,7 +44,7 @@ class CleanupNamedTargets extends Transform with DependencyAPIMigration {
     module: ir.DefModule
   )(
     implicit references: ISet[ReferenceTarget],
-    renameMap:           RenameMap,
+    renameMap:           MutableRenameMap,
     circuit:             CircuitTarget
   ): Unit = {
     implicit val mTarget = circuit.module(module.name)
@@ -60,7 +61,7 @@ class CleanupNamedTargets extends Transform with DependencyAPIMigration {
       case a: ReferenceTarget => a
     }.toSet
 
-    implicit val renameMap = RenameMap()
+    implicit val renameMap = MutableRenameMap()
 
     implicit val cTarget = CircuitTarget(state.circuit.main)
 

--- a/src/main/scala/firrtl/backends/experimental/smt/StutteringClockTransform.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/StutteringClockTransform.scala
@@ -11,6 +11,7 @@ import firrtl.passes.PassException
 import firrtl.stage.Forms
 import firrtl.stage.TransformManager.TransformDependency
 import firrtl.transforms.PropagatePresetAnnotations
+import firrtl.renamemap.MutableRenameMap
 
 import scala.collection.mutable
 
@@ -94,7 +95,7 @@ class StutteringClockTransform extends Transform with DependencyAPIMigration {
 
     // rename clocks to clock enable signals
     val mRef = CircuitTarget(state.circuit.main).module(main.name)
-    val renameMap = RenameMap()
+    val renameMap = MutableRenameMap()
     scan.clockToEnable.foreach {
       case (clk, en) =>
         renameMap.record(mRef.ref(clk), mRef.ref(en.name))

--- a/src/main/scala/firrtl/passes/Inline.scala
+++ b/src/main/scala/firrtl/passes/Inline.scala
@@ -11,6 +11,7 @@ import firrtl.analyses.InstanceKeyGraph
 import firrtl.graph.{DiGraph, MutableDiGraph}
 import firrtl.stage.{Forms, RunFirrtlTransformAnnotation}
 import firrtl.options.{RegisteredTransform, ShellOption}
+import firrtl.renamemap.MutableRenameMap
 
 // Datastructures
 import scala.collection.mutable
@@ -184,7 +185,7 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
       prefix:        String,
       ns:            Namespace,
       renames:       mutable.HashMap[String, String],
-      renameMap:     RenameMap
+      renameMap:     MutableRenameMap
     )(s:             Statement
     ): Statement = {
       def onName(ofModuleOpt: Option[String])(name: String): String = {
@@ -276,10 +277,10 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
 
       indexMap match {
         case a if a.isEmpty =>
-          (Map.empty[(OfModule, Instance), RenameMap], Seq.empty[RenameMap])
+          (Map.empty[(OfModule, Instance), MutableRenameMap], Seq.empty[MutableRenameMap])
         case a =>
           val maxIdx = indexMap.values.max
-          val resultSeq = Seq.fill(maxIdx + 1)(RenameMap())
+          val resultSeq = Seq.fill(maxIdx + 1)(MutableRenameMap())
           val resultMap = indexMap.mapValues(idx => resultSeq(maxIdx - idx))
           (resultMap, resultSeq)
       }
@@ -367,7 +368,8 @@ class InlineInstances extends Transform with DependencyAPIMigration with Registe
         Some(m.map(onStmt(ModuleName(m.name, CircuitName(c.main)))))
     })
 
-    val renames = renamesSeq.reduceLeftOption(_ andThen _)
+    // Upcast so reduce works (andThen returns RenameMap)
+    val renames = (renamesSeq: Seq[RenameMap]).reduceLeftOption(_ andThen _)
 
     val cleanedAnnos = annos.filterNot {
       case InlineAnnotation(_) => true

--- a/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
+++ b/src/main/scala/firrtl/passes/memlib/ReplaceMemMacros.scala
@@ -12,6 +12,7 @@ import firrtl.passes.MemPortUtils.{MemPortMap, Modules}
 import firrtl.passes.memlib.MemTransformUtils._
 import firrtl.passes.wiring._
 import firrtl.stage.Forms
+import firrtl.renamemap.MutableRenameMap
 
 import scala.collection.mutable.ListBuffer
 
@@ -244,7 +245,7 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     memPortMap:              MemPortMap,
     memMods:                 Modules,
     annotatedMemoriesBuffer: ListBuffer[DefAnnotatedMemory],
-    renameMap:               RenameMap,
+    renameMap:               MutableRenameMap,
     circuit:                 String
   )(s:                       Statement
   ): Statement = s match {
@@ -282,7 +283,7 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     nameMap:                 NameMap,
     memMods:                 Modules,
     annotatedMemoriesBuffer: ListBuffer[DefAnnotatedMemory],
-    renameMap:               RenameMap,
+    renameMap:               MutableRenameMap,
     circuit:                 String
   )(m:                       DefModule
   ) = {
@@ -299,7 +300,7 @@ class ReplaceMemMacros extends Transform with DependencyAPIMigration {
     val memMods = new Modules
     val nameMap = new NameMap
     c.modules.map(m => m.map(constructNameMap(namespace, nameMap, m.name)))
-    val renameMap = RenameMap()
+    val renameMap = MutableRenameMap()
     val modules = c.modules.map(updateMemMods(namespace, nameMap, memMods, annotatedMemoriesBuffer, renameMap, c.main))
     state.copy(
       circuit = c.copy(modules = modules ++ memMods),

--- a/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
+++ b/src/main/scala/firrtl/transforms/DeadCodeElimination.scala
@@ -11,6 +11,7 @@ import firrtl.analyses.InstanceKeyGraph
 import firrtl.Mappers._
 import firrtl.Utils.{kind, throwInternalError}
 import firrtl.MemoizedHash._
+import firrtl.renamemap.MutableRenameMap
 import firrtl.backends.experimental.smt.random.DefRandom
 import firrtl.options.{Dependency, RegisteredTransform, ShellOption}
 
@@ -213,7 +214,7 @@ class DeadCodeElimination extends Transform with RegisteredTransform with Depend
     instMap:        collection.Map[String, String],
     deadNodes:      collection.Set[LogicNode],
     moduleMap:      collection.Map[String, DefModule],
-    renames:        RenameMap,
+    renames:        MutableRenameMap,
     topName:        String,
     doTouchExtMods: Set[String]
   )(mod:            DefModule
@@ -346,7 +347,7 @@ class DeadCodeElimination extends Transform with RegisteredTransform with Depend
 
     val liveNodes = depGraph.reachableFrom(circuitSink) + circuitSink
     val deadNodes = depGraph.getVertices -- liveNodes
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.setCircuit(c.main)
 
     // As we delete deadCode, we will delete ports from Modules and somtimes complete modules

--- a/src/test/scala/firrtl/passes/LowerTypesSpec.scala
+++ b/src/test/scala/firrtl/passes/LowerTypesSpec.scala
@@ -5,6 +5,7 @@ import firrtl.annotations.{CircuitTarget, IsMember}
 import firrtl.annotations.TargetToken.{Instance, OfModule}
 import firrtl.analyses.InstanceKeyGraph
 import firrtl.{CircuitState, RenameMap, Utils}
+import firrtl.renamemap.MutableRenameMap
 import firrtl.options.Dependency
 import firrtl.stage.TransformManager
 import firrtl.stage.TransformManager.TransformDependency
@@ -252,7 +253,7 @@ class LowerTypesOfInstancesSpec extends AnyFlatSpec with FirrtlMatchers {
     tpe:          String,
     module:       String,
     namespace:    Set[String],
-    otherRenames: RenameMap = RenameMap()
+    otherRenames: MutableRenameMap = MutableRenameMap()
   ): Lower = {
     val ref = firrtl.ir.DefInstance(firrtl.ir.NoInfo, n, module, parseType(tpe))
     val mutableSet = scala.collection.mutable.HashSet[String]() ++ namespace
@@ -298,8 +299,8 @@ class LowerTypesOfInstancesSpec extends AnyFlatSpec with FirrtlMatchers {
       // This is to accommodate the use-case where a port as well as an instance needs to be renames
       // thus requiring a two-stage translation process for reference to the port of the instance.
       // This two-stage translation is only supported through chaining rename maps.
-      val portRenames = RenameMap()
-      val otherRenames = RenameMap()
+      val portRenames = MutableRenameMap()
+      val otherRenames = MutableRenameMap()
 
       // The child module "c" which we assume has the following ports: b : { c : UInt<1>} and b_c : UInt<1>
       val c = CircuitTarget("m").module("c")
@@ -362,7 +363,7 @@ class LowerTypesOfMemorySpec extends AnyFlatSpec {
       writers = w,
       readwriters = rw
     )
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val mutableSet = scala.collection.mutable.HashSet[String]() ++ namespace
     val (mems, refs) = DestructTypes.destructMemory(m, mem, mutableSet, renames, Set())
     Lower(mems, refs, renames)
@@ -655,10 +656,10 @@ private object LowerTypesSpecUtils {
     val c = CircuitState(firrtl.Parser.parse(src), Seq())
     typedCompiler.execute(c).circuit.modules.head.ports.head.tpe
   }
-  case class DestructResult(fields: Seq[String], renameMap: RenameMap)
+  case class DestructResult(fields: Seq[String], renameMap: MutableRenameMap)
   def destruct(n: String, tpe: String, namespace: Set[String]): DestructResult = {
     val ref = firrtl.ir.Field(n, firrtl.ir.Default, parseType(tpe))
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     val mutableSet = scala.collection.mutable.HashSet[String]() ++ namespace
     val res = DestructTypes.destruct(m, ref, mutableSet, renames, Set())
     DestructResult(resultToFieldSeq(res), renames)

--- a/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -19,6 +19,7 @@ import firrtl.stage.{FirrtlFileAnnotation, InfoModeAnnotation, RunFirrtlTransfor
 import firrtl.analyses.{GetNamespace, ModuleNamespaceAnnotation}
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation, RenameModules}
+import firrtl.renamemap.MutableRenameMap
 import firrtl.util.BackendCompilationUtilities
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -64,7 +65,7 @@ object RenameTop extends Transform {
       case m => m
     }
 
-    val renames = RenameMap()
+    val renames = MutableRenameMap()
     renames.record(CircuitTarget(c.main), CircuitTarget(newTopName))
     state.copy(circuit = c.copy(main = newTopName, modules = modulesx), renames = Some(renames))
   }

--- a/src/test/scala/firrtlTests/transforms/ManipulateNamesSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/ManipulateNamesSpec.scala
@@ -12,6 +12,7 @@ import firrtl.transforms.{
   ManipulateNamesAllowlistResultAnnotation,
   ManipulateNamesBlocklistAnnotation
 }
+import firrtl.renamemap.MutableRenameMap
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -210,7 +211,7 @@ class ManipulateNamesSpec extends AnyFlatSpec with Matchers {
       oldTargets = Seq(Seq(`~Foo|Bar`))
     )
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
     r.delete(`~Foo|prefix_Bar`)
 
     a.update(r) should be(empty)
@@ -228,7 +229,7 @@ class ManipulateNamesSpec extends AnyFlatSpec with Matchers {
       oldTargets = Seq(Seq(`~Foo|Bar`), Seq(`~Foo|Baz`))
     )
 
-    val r = RenameMap()
+    val r = MutableRenameMap()
     r.delete(`~Foo|prefix_Bar`)
 
     val ax = a.update(r).collect {


### PR DESCRIPTION
* Add renamemap.MutableRenameMap which includes these methods without
  deprecation
* Deprecate Stringly typed RenameMap APIs which were accidentally
  undeprecated a while ago

Much friendlier version of https://github.com/chipsalliance/firrtl/pull/2318

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code refactoring   
 - code cleanup     

#### API Impact

This deprecates all mutable methods on `RenameMap`, the exact same functionality is maintained on the new `firrtl.renamemap.MutableRenameMap`. `RenameMap` is also now a [sealed] trait which will enable alternative (optimized) implementations in the future.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Deprecate all mutable methods on `RenameMap`. For constructing `RenameMaps`, use `firrtl.renamemap.MutableRenameMap`. 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
