### PR TITLE
Remove some printlns in tests

### DIFF
--- a/src/test/scala/firrtl/backends/experimental/rtlil/end2end/RtlilEquivalenceTest.scala
+++ b/src/test/scala/firrtl/backends/experimental/rtlil/end2end/RtlilEquivalenceTest.scala
@@ -40,10 +40,8 @@ class RtlilEquivalenceTest extends AnyFlatSpec with LazyLogging {
     val verilogFile = testDir.toString + "/" + fileName + ".v"
 
     val log = ProcessLogger(
-      msg => {
-        println(msg)
-      },
-      logger.error(_)
+      logger.info(_),
+      logger.warn(_)
     )
 
     val yosysArgs = Array(
@@ -67,7 +65,6 @@ class RtlilEquivalenceTest extends AnyFlatSpec with LazyLogging {
       "equiv_induct -seq 1 -undef;",
       "equiv_status -assert"
     )
-    println(yosysArgs.mkString(" "))
     val yosysRet = Process(Seq("yosys", "-p", yosysArgs.mkString(" "))).run(log).exitValue()
     assert(yosysRet == 0, s"Unable to prove equivalence of design ${name}.")
   }

--- a/src/test/scala/firrtlTests/SeparateWriteClocksSpec.scala
+++ b/src/test/scala/firrtlTests/SeparateWriteClocksSpec.scala
@@ -58,7 +58,6 @@ class SeparateWriteClocksSpec extends FirrtlFlatSpec {
                               |    m.w_b.mask <= UInt(1)
                               |    m.w_b.data <= wdata_b""".stripMargin)
 
-    println(result.circuit.serialize)
     result should containLine("m.r.clk <= clk")
     result should containLine("m.w_a.clk <= m_w_a_clk")
     result should containLine("m.w_b.clk <= m_w_b_clk")


### PR DESCRIPTION
Some of the tests were unnecessarily noisy.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] **Did you delete any extraneous printlns/debugging code?**
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - code cleanup    

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
