### PR TITLE
Remove some warnings

### DIFF
--- a/src/main/scala/firrtl/AddDescriptionNodes.scala
+++ b/src/main/scala/firrtl/AddDescriptionNodes.scala
@@ -151,7 +151,7 @@ class AddDescriptionNodes extends Transform with DependencyAPIMigration {
       Dependency[firrtl.transforms.InlineBitExtractionsTransform],
       Dependency[firrtl.transforms.PropagatePresetAnnotations],
       Dependency[firrtl.transforms.InlineAcrossCastsTransform],
-      Dependency[firrtl.transforms.LegalizeClocksTransform],
+      Dependency[firrtl.transforms.LegalizeClocksAndAsyncResetsTransform],
       Dependency[firrtl.transforms.FlattenRegUpdate],
       Dependency(passes.VerilogModulusCleanup),
       Dependency[firrtl.transforms.VerilogRename],

--- a/src/main/scala/firrtl/backends/experimental/rtlil/RtlilEmitter.scala
+++ b/src/main/scala/firrtl/backends/experimental/rtlil/RtlilEmitter.scala
@@ -880,6 +880,8 @@ private[firrtl] class RtlilEmitter extends SeqTransform with Emitter with Depend
               println("Leaving memory uninitialized.")
             case MemoryFileInlineInit(_, _) =>
               throw EmitterException(s"Memory $name cannot be initialized from a file, RTLIL cannot express this.")
+            case MemoryNoInit =>
+            // No initialization to emit
           }
           for (r <- rd) {
             val data = memPortField(x, r, "data")

--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -33,7 +33,7 @@ object VerilogModulusCleanup extends Pass {
       Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
       Dependency[firrtl.transforms.InlineBitExtractionsTransform],
       Dependency[firrtl.transforms.InlineAcrossCastsTransform],
-      Dependency[firrtl.transforms.LegalizeClocksTransform],
+      Dependency[firrtl.transforms.LegalizeClocksAndAsyncResetsTransform],
       Dependency[firrtl.transforms.FlattenRegUpdate]
     )
 

--- a/src/main/scala/firrtl/passes/VerilogPrep.scala
+++ b/src/main/scala/firrtl/passes/VerilogPrep.scala
@@ -29,7 +29,7 @@ object VerilogPrep extends Pass {
       Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
       Dependency[firrtl.transforms.InlineBitExtractionsTransform],
       Dependency[firrtl.transforms.InlineAcrossCastsTransform],
-      Dependency[firrtl.transforms.LegalizeClocksTransform],
+      Dependency[firrtl.transforms.LegalizeClocksAndAsyncResetsTransform],
       Dependency[firrtl.transforms.FlattenRegUpdate],
       Dependency(passes.VerilogModulusCleanup),
       Dependency[firrtl.transforms.VerilogRename]

--- a/src/main/scala/firrtl/passes/ZeroWidth.scala
+++ b/src/main/scala/firrtl/passes/ZeroWidth.scala
@@ -204,6 +204,6 @@ object ZeroWidth extends Transform with DependencyAPIMigration {
     val renames = MutableRenameMap()
     renames.setCircuit(c.main)
     val result = c.copy(modules = c.modules.map(onModule(renames)))
-    CircuitState(result, outputForm, state.annotations, Some(renames))
+    state.copy(circuit = result, renames = Some(renames))
   }
 }

--- a/src/main/scala/firrtl/stage/Forms.scala
+++ b/src/main/scala/firrtl/stage/Forms.scala
@@ -112,7 +112,7 @@ object Forms {
         Dependency[firrtl.transforms.ReplaceTruncatingArithmetic],
         Dependency[firrtl.transforms.InlineBitExtractionsTransform],
         Dependency[firrtl.transforms.InlineAcrossCastsTransform],
-        Dependency[firrtl.transforms.LegalizeClocksTransform],
+        Dependency[firrtl.transforms.LegalizeClocksAndAsyncResetsTransform],
         Dependency[firrtl.transforms.FlattenRegUpdate],
         Dependency(passes.VerilogModulusCleanup),
         Dependency[firrtl.transforms.VerilogRename],

--- a/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
+++ b/src/main/scala/firrtl/transforms/FlattenRegUpdate.scala
@@ -171,7 +171,7 @@ class FlattenRegUpdate extends Transform with DependencyAPIMigration {
       Dependency[ReplaceTruncatingArithmetic],
       Dependency[InlineBitExtractionsTransform],
       Dependency[InlineAcrossCastsTransform],
-      Dependency[LegalizeClocksTransform]
+      Dependency[LegalizeClocksAndAsyncResetsTransform]
     )
 
   override def optionalPrerequisites = firrtl.stage.Forms.LowFormOptimized

--- a/src/main/scala/firrtl/transforms/GroupComponents.scala
+++ b/src/main/scala/firrtl/transforms/GroupComponents.scala
@@ -336,13 +336,6 @@ class GroupComponents extends Transform with DependencyAPIMigration {
     }
     def onStmt(stmt: Statement): Unit = stmt match {
       case w: WDefInstance =>
-      case h: IsDeclaration =>
-        bidirGraph.addVertex(h.name)
-        h.map(onExpr(WRef(h.name)))
-      case Attach(_, exprs) => // Add edge between each expression
-        exprs.tail.map(onExpr(getWRef(exprs.head)))
-      case Connect(_, loc, expr) =>
-        onExpr(getWRef(loc))(expr)
       case q @ Stop(_, _, clk, en) =>
         val simName = simNamespace.newTemp
         simulations(simName) = q
@@ -351,6 +344,13 @@ class GroupComponents extends Transform with DependencyAPIMigration {
         val simName = simNamespace.newTemp
         simulations(simName) = q
         (args :+ clk :+ en).map(onExpr(WRef(simName)))
+      case h: IsDeclaration =>
+        bidirGraph.addVertex(h.name)
+        h.map(onExpr(WRef(h.name)))
+      case Attach(_, exprs) => // Add edge between each expression
+        exprs.tail.map(onExpr(getWRef(exprs.head)))
+      case Connect(_, loc, expr) =>
+        onExpr(getWRef(loc))(expr)
       case Block(stmts) => stmts.foreach(onStmt)
       case ignore @ (_: IsInvalid | EmptyStmt) => // do nothing
       case other => throw new Exception(s"Unexpected Statement $other")

--- a/src/main/scala/firrtl/transforms/InlineAcrossCastsTransform.scala
+++ b/src/main/scala/firrtl/transforms/InlineAcrossCastsTransform.scala
@@ -97,7 +97,7 @@ class InlineAcrossCastsTransform extends Transform with DependencyAPIMigration {
   override def optionalPrerequisiteOf = Seq.empty
 
   override def invalidates(a: Transform): Boolean = a match {
-    case _: LegalizeClocksTransform => true
+    case _: LegalizeClocksAndAsyncResetsTransform => true
     case _ => false
   }
 

--- a/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
+++ b/src/main/scala/firrtl/transforms/RemoveKeywordCollisions.scala
@@ -38,7 +38,7 @@ class VerilogRename extends RemoveKeywordCollisions(v_keywords) {
       Dependency[ReplaceTruncatingArithmetic],
       Dependency[InlineBitExtractionsTransform],
       Dependency[InlineAcrossCastsTransform],
-      Dependency[LegalizeClocksTransform],
+      Dependency[LegalizeClocksAndAsyncResetsTransform],
       Dependency[FlattenRegUpdate],
       Dependency(passes.VerilogModulusCleanup)
     )

--- a/src/main/scala/logger/LoggerOptions.scala
+++ b/src/main/scala/logger/LoggerOptions.scala
@@ -32,7 +32,7 @@ class LoggerOptions private[logger] (
   }
 
   /** Return the name of the log file, defaults to `a.log` if unspecified */
-  def getLogFileName(): Option[String] = if (!logToFile()) None else logFileName.orElse(Some("a.log"))
+  def getLogFileName(): Option[String] = logFileName.orElse(Some("a.log"))
 
   /** True if a [[Logger]] should be writing to a file */
   @deprecated("logToFile was removed, use logFileName.nonEmpty", "FIRRTL 1.2")


### PR DESCRIPTION
This PR reduces the number of warnings from 90 to 80 in the main compilation. Really bad but some progress.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - code cleanup    
  
#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
