### PR TITLE
disable random should not contain useInitAsPreset.

### DIFF
--- a/src/main/scala/firrtl/Emitter.scala
+++ b/src/main/scala/firrtl/Emitter.scala
@@ -200,7 +200,7 @@ object EmitAllModulesAnnotation extends HasShellOptions {
         s.split(",")
           .map {
             case "disableMemRandomization" =>
-              CustomDefaultRegisterEmission(useInitAsPreset = true, disableRandomization = true)
+              CustomDefaultRegisterEmission(useInitAsPreset = false, disableRandomization = true)
             case "disableRegisterRandomization" => CustomDefaultMemoryEmission(MemoryNoInit)
             case a                              => throw new PhaseException(s"Unknown emission options '$a'! (Did you misspell it?)")
           }


### PR DESCRIPTION
My bad, I mistakenly introduced `useInitAsPreset = true` in `disableMemRandomization` console option.
This will introduce a critical bug:
https://scastie.scala-lang.org/ZRHZGEs1TsGoIdku7niUog

This is because use `useInitAsPreset` for `reg b`, while no init logic.
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- bug fix

#### API Impact
none

#### Backend Code Generation Impact
bug fix for Verilog with `disableMemRandomization` option.

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
None

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
