### PR TITLE
Downgrade ScalaTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val firrtlSettings = Seq(
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    "org.scalatest" %% "scalatest" % "3.2.10" % "test",
+    "org.scalatest" %% "scalatest" % "3.1.4" % "test",
     "org.scalatestplus" %% "scalacheck-1-15" % "3.2.10.0" % "test",
     "com.github.scopt" %% "scopt" % "3.7.1",
     "net.jcazevedo" %% "moultingyaml" % "0.4.2",


### PR DESCRIPTION


#### Type of Improvement


  - bug fix                          

ScalaTest 3.2 breaks existing (ChiselTest) test code
