### PR TITLE
Add FileInfo to asyncResetAlwaysBlocks

### DIFF
--- a/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
+++ b/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
@@ -787,13 +787,12 @@ class VerilogEmitter extends SeqTransform with Emitter {
       } else { // Asynchronous Reset
         assert(reset.tpe == AsyncResetType, "Error! Synchronous reset should have been removed!")
         val tv = init
-        val InfoExpr(finfo, fv) = netlist(r)
-        // TODO add register info argument and build a MultiInfo to pass
+        val InfoExpr(info, fv) = netlist(r)
         asyncResetAlwaysBlocks += (
           (
             clk,
             reset,
-            addUpdate(NoInfo, Mux(reset, tv, fv, mux_type_and_widths(tv, fv)), Seq.empty)
+            addUpdate(info, Mux(reset, tv, fv, mux_type_and_widths(tv, fv)), Seq.empty)
           )
         )
       }

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -89,6 +89,8 @@ object RemoveReset extends Transform with DependencyAPIMigration {
           Connect(infox, ref, Mux(reset.cond, reset.value, expr, muxType))
         case Connect(info, ref @ WRef(rname, _, RegKind, _), expr) if asyncResets.contains(rname) =>
           val reset = asyncResets(rname)
+          // The `muxType` for async always blocks is located in [[VerilogEmitter.VerilogRender.regUpdate]]:
+          // addUpdate(info, Mux(reset, tv, fv, mux_type_and_widths(tv, fv)), Seq.empty)
           val infox = MultiInfo(reset.info, reset.info, info)
           Connect(infox, ref, expr)
         case other => other.map(onStmt)

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -50,6 +50,7 @@ object RemoveReset extends Transform with DependencyAPIMigration {
 
   private def onModule(m: DefModule, isPreset: String => Boolean): DefModule = {
     val resets = mutable.HashMap.empty[String, Reset]
+    val asyncResets = mutable.HashMap.empty[String, Reset]
     val invalids = computeInvalids(m)
     def onStmt(stmt: Statement): Statement = {
       stmt match {
@@ -77,12 +78,19 @@ object RemoveReset extends Transform with DependencyAPIMigration {
           // Add register reset to map
           resets(rname) = Reset(reset, init, info)
           reg.copy(reset = Utils.zero, init = WRef(reg))
+        case reg @ DefRegister(info, rname, _, _, reset, init) if reset.tpe == AsyncResetType =>
+          asyncResets(rname) = Reset(reset, init, info)
+          reg
         case Connect(info, ref @ WRef(rname, _, RegKind, _), expr) if resets.contains(rname) =>
           val reset = resets(rname)
           val muxType = Utils.mux_type_and_widths(reset.value, expr)
           // Use reg source locator for mux enable and true value since that's where they're defined
           val infox = MultiInfo(reset.info, reset.info, info)
           Connect(infox, ref, Mux(reset.cond, reset.value, expr, muxType))
+        case Connect(info, ref @ WRef(rname, _, RegKind, _), expr) if asyncResets.contains(rname) =>
+          val reset = asyncResets(rname)
+          val infox = MultiInfo(reset.info, reset.info, info)
+          Connect(infox, ref, expr)
         case other => other.map(onStmt)
       }
     }

--- a/src/test/scala/firrtlTests/VerilogEmitterTests.scala
+++ b/src/test/scala/firrtlTests/VerilogEmitterTests.scala
@@ -717,6 +717,22 @@ class VerilogEmitterSpec extends FirrtlFlatSpec {
     result should containLine("assign z = x == y;")
   }
 
+  it should "show line numbers for AsyncReset regUpdate" in {
+    val result = compileBody(
+      """input clock : Clock
+        |input reset : AsyncReset
+        |output io : { flip in : UInt<1>, out : UInt<1>}
+        |
+        |reg valid : UInt<1>, clock with :
+        |  reset => (reset, UInt<1>("h0")) @[Playground.scala 11:22]
+        |valid <= io.in @[Playground.scala 12:9]
+        |io.out <= valid @[Playground.scala 13:10]""".stripMargin
+    )
+    result should containLine("if (reset) begin // @[Playground.scala 11:22]")
+    result should containLine("valid <= 1'h0; // @[Playground.scala 11:22]")
+    result should containLine("valid <= io_in; // @[Playground.scala 12:9]")
+  }
+
   it should "subtract positive literals instead of adding negative literals" in {
     val compiler = new VerilogCompiler
     val result = compileBody(


### PR DESCRIPTION
This commit should fix https://github.com/chipsalliance/chisel3/issues/2322

Always blocks need three FileInfo (if, true, false) to show line numbers, but initially, every always blocks only have one FileInfo (false).

RemoveReset adds the extra two FileInfo to sync always blocks, so sync always blocks can have line numbers.

Async always blocks don't provide their only FileInfo, so there are no line numbers.

This commit gives async always block the extra FileInfo like sync always blocks.

This code:

```scala
import chisel3._
import chisel3.stage._
import firrtl.CustomDefaultRegisterEmission

class Test extends Module with RequireAsyncReset {
  val io = IO(new Bundle {
    val in = Input(Bool())
    val out = Output(Bool())
  })
  val valid = RegInit(false.B)
  valid := io.in
  io.out := valid
}

object Test extends App {
  new ChiselStage().execute(Array(), Seq(
    ChiselGeneratorAnnotation(() => new Test()),
    CustomDefaultRegisterEmission(useInitAsPreset = false, disableRandomization = true)
  ))
}
```

will generate this Verilog:

```verilog
module Test(
  input   clock,
  input   reset,
  input   io_in,
  output  io_out
);
  reg  valid; // @[Playground.scala 10:22]
  assign io_out = valid; // @[Playground.scala 12:10]
  always @(posedge clock or posedge reset) begin
    if (reset) begin // @[Playground.scala 10:22]
      valid <= 1'h0; // @[Playground.scala 10:22]
    end else begin
      valid <= io_in; // @[Playground.scala 11:9]
    end
  end
endmodule
```

they have correct line numbers (10, 10, 11).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
- bug fix
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
