### PR TITLE
Add 1.5.x to Github Actions push triggers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 1.5.x
       - 1.4.x
       - 1.3.x
       - 1.2.x


### PR DESCRIPTION
It seems that you have to have the rule on the branch you want to trigger on push https://github.community/t/workflow-files-only-picked-up-from-master/16129/16

IMO this is really stupid, what's the point of having any branches in the YAML here? If the file has to be present on that actual branch then there is no point in the meaning being anything but "this branch". It's especially annoying because GitHub [reasonably] does not allow bots to merge changes to workflow files, but this means you can't have any automation here.