### PR TITLE
Fix faulty MemorySynthInit behavior

### DIFF
--- a/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
+++ b/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
@@ -900,14 +900,8 @@ class VerilogEmitter extends SeqTransform with Emitter {
             case MemoryLoadFileType.Binary => "$readmemb"
             case MemoryLoadFileType.Hex    => "$readmemh"
           }
-          if (emissionOptions.emitMemoryInitAsNoSynth) {
-            memoryInitials += Seq(s"""$readmem("$filename", ${s.name});""")
-          } else {
-            val inlineLoad = s"""initial begin
-                                |    $readmem("$filename", ${s.name});
-                                |  end""".stripMargin
-            memoryInitials += Seq(inlineLoad)
-          }
+          memoryInitials += Seq(s"""$readmem("$filename", ${s.name});""")
+
         case MemoryNoInit =>
         // do nothing
       }
@@ -1292,8 +1286,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
         emit(Seq("`FIRRTL_AFTER_INITIAL"))
         emit(Seq("`endif"))
         emit(Seq("`endif // SYNTHESIS"))
-        if (!emissionOptions.emitMemoryInitAsNoSynth) {
+        if (!emissionOptions.emitMemoryInitAsNoSynth && !memoryInitials.isEmpty) {
+          emit(Seq("initial begin"))
           for (x <- memoryInitials) emit(Seq(tab, x))
+          emit(Seq("end"))
         }
       }
 


### PR DESCRIPTION
- Fix & test MemorySynthInit behavior with MemoryArrayInitAnnotation and MemoryScalarInitAnnotation.
Add test case for MemoryRandomInitAnnotation which is, on the contrary, expected not to leak any randomization statement in synthesis context.

- Refactor MemoryInitSpec for improved results readability

### Context:

#2166  introduced `MemorySynthInit` annotation to control whether statement generated with `Memory*InitAnnotation` (emitted within initial begin block in verilog) should be guarded with `ifndef SYNTHESIS` or not.
Unfortunately only one configuration (`MemoryFileInlineAnnotation`) has been tested while the others have been generating incorrect verilog statements (`MemoryArrayInitAnnotation` and `MemoryScalarInitAnnotation`).
Example: 
https://scastie.scala-lang.org/rqS4FWY1SsaZKO4N49D9oA
produces illegal verilog:
```verilog
module Example(
// ...
reg [3:0] rom [0:4];
// ...
`endif // SYNTHESIS
  rom[0] = 0;
  rom[1] = 1;
  rom[2] = 3;
  rom[3] = 7;
  rom[4] = 15;
endmodule
```

while the following is expected (this PR)
```verilog
module Example(
// ...
reg [3:0] rom [0:4];
// ...
`endif // SYNTHESIS
initial begin
  rom[0] = 0;
  rom[1] = 1;
  rom[2] = 3;
  rom[3] = 7;
  rom[4] = 15;
end
endmodule
```


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
bug fix

#### API Impact
none

#### Backend Code Generation Impact
none on currently valid verilog


#### Desired Merge Strategy
rebase

#### Release Notes
Fix & test MemorySynthInit behavior with MemoryArrayInitAnnotation and MemoryScalarInitAnnotation.
Add test case for MemoryRandomInitAnnotation which is, on the contrary, expected not to leak any randomization statement in synthesis context.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
