### PR TITLE
Avoid using self reference to signal no init

### DIFF
--- a/src/main/scala/firrtl/backends/experimental/rtlil/RtlilEmitter.scala
+++ b/src/main/scala/firrtl/backends/experimental/rtlil/RtlilEmitter.scala
@@ -376,7 +376,7 @@ private[firrtl] class RtlilEmitter extends SeqTransform with Emitter with Depend
         case e =>
           Seq(Seq(tabs, "assign ", regTempName, " ", SrcInfo(e, info).str_rep))
       }
-      if (weq(init, r)) { // Synchronous Reset
+      if (reset.tpe != AsyncResetType) { // Synchronous Reset
         val InfoExpr(info, e) = netlist(r)
         processes += Seq(info)
         processes += Seq("wire ", r.tpe, " ", regTempName)
@@ -387,7 +387,6 @@ private[firrtl] class RtlilEmitter extends SeqTransform with Emitter with Depend
         processes += Seq(tab, tab, "update ", SrcInfo(r).str_rep, " ", regTempName)
         processes += Seq("end")
       } else { // Asynchronous Reset
-        assert(reset.tpe == AsyncResetType, "Error! Synchronous reset should have been removed!")
         val tv = init
         val InfoExpr(finfo, fv) = netlist(r)
         processes += Seq(finfo)

--- a/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
+++ b/src/main/scala/firrtl/backends/verilog/VerilogEmitter.scala
@@ -781,11 +781,10 @@ class VerilogEmitter extends SeqTransform with Emitter {
           }
         case e => Seq(Seq(tabs, r, " <= ", e, ";", info))
       }
-      if (weq(init, r)) { // Synchronous Reset
+      if (reset.tpe != AsyncResetType) { // Synchronous Reset
         val InfoExpr(info, e) = netlist(r)
         noResetAlwaysBlocks.getOrElseUpdate(clk, ArrayBuffer[Seq[Any]]()) ++= addUpdate(info, e, Seq.empty)
       } else { // Asynchronous Reset
-        assert(reset.tpe == AsyncResetType, "Error! Synchronous reset should have been removed!")
         val tv = init
         val InfoExpr(info, fv) = netlist(r)
         asyncResetAlwaysBlocks += (

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -71,13 +71,13 @@ object RemoveReset extends Transform with DependencyAPIMigration {
           reg
         /* A register is initialized to an invalid expression */
         case reg @ DefRegister(_, _, _, _, _, init) if invalids.contains(we(init)) =>
-          reg.copy(reset = Utils.zero, init = WRef(reg))
+          reg.copy(reset = Utils.zero)
         case reg @ DefRegister(_, rname, _, _, Utils.zero, _) =>
-          reg.copy(init = WRef(reg)) // canonicalize
+          reg // canonicalize
         case reg @ DefRegister(info, rname, _, _, reset, init) if reset.tpe != AsyncResetType =>
           // Add register reset to map
           resets(rname) = Reset(reset, init, info)
-          reg.copy(reset = Utils.zero, init = WRef(reg))
+          reg.copy(reset = Utils.zero)
         case reg @ DefRegister(info, rname, _, _, reset, init) if reset.tpe == AsyncResetType =>
           asyncResets(rname) = Reset(reset, init, info)
           reg

--- a/src/test/scala/firrtlTests/transforms/RemoveResetSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/RemoveResetSpec.scala
@@ -112,7 +112,7 @@ class RemoveResetSpec extends FirrtlFlatSpec with GivenWhenThen {
     outputState shouldNot containTree { case Connect(_, WRef("foo_b", _, _, _), Mux(_, _, _, _)) => true }
   }
 
-  it should "canvert a reset wired to UInt<0> to a canonical non-reset" in {
+  it should "convert a reset wired to UInt<0> to a canonical non-reset" in {
     Given("foo's reset is connected to zero")
     val input =
       """|circuit Example :
@@ -127,9 +127,7 @@ class RemoveResetSpec extends FirrtlFlatSpec with GivenWhenThen {
 
     val outputState = toLowFirrtl(input)
 
-    Then("foo has a canonical non-reset declaration after RemoveReset")
-    outputState should containTree { case DefRegister(_, "foo", _, _, firrtl.Utils.zero, WRef("foo", _, _, _)) => true }
-    And("foo is NOT connected to a reset mux")
+    Then("foo is NOT connected to a reset mux")
     outputState shouldNot containTree { case Connect(_, WRef("foo", _, _, _), Mux(_, _, _, _)) => true }
   }
 }


### PR DESCRIPTION
This fixes the bug in issue #2449.  
I thought these changes may or may not come in useful given the discussion in the issue so I decided to just let you decide and put this pull request here.  
But if there is an interest in supporting `useInitAsPreset` I am willing to make further adjustments and add a test.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

It avoids using `init` as self referential to signal no init.
<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

It fixes the issue in #2449.
<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
