### PR TITLE
Fold VerilogModulusCleanup into LegalizeVerilog

### DIFF
--- a/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
+++ b/src/main/scala/firrtl/passes/VerilogModulusCleanup.scala
@@ -4,9 +4,6 @@ package firrtl
 package passes
 
 import firrtl.ir._
-import firrtl.Mappers._
-import firrtl.PrimOps.{Bits, Rem}
-import firrtl.Utils._
 import firrtl.options.Dependency
 
 import scala.collection.mutable
@@ -24,6 +21,7 @@ import scala.collection.mutable
   *  This is technically incorrect firrtl, but allows the verilog emitter
   *  to emit correct verilog without needing to add temporary nodes
   */
+@deprecated("This pass's functionality has been moved to LegalizeVerilog", "FIRRTL 1.5.2")
 object VerilogModulusCleanup extends Pass {
 
   override def prerequisites = firrtl.stage.Forms.LowFormMinimumOptimized ++
@@ -43,62 +41,5 @@ object VerilogModulusCleanup extends Pass {
 
   override def invalidates(a: Transform) = false
 
-  private def onModule(m: Module): Module = {
-    val namespace = Namespace(m)
-    def onStmt(s: Statement): Statement = {
-      val v = mutable.ArrayBuffer[Statement]()
-
-      def getWidth(e: Expression): Width = e.tpe match {
-        case t: GroundType => t.width
-        case t => UnknownWidth
-      }
-
-      def maxWidth(ws: Seq[Width]): Width = ws.reduceLeft { (x, y) =>
-        (x, y) match {
-          case (IntWidth(x), IntWidth(y)) => IntWidth(x.max(y))
-          case (x, y)                     => UnknownWidth
-        }
-      }
-
-      def verilogRemWidth(e: DoPrim)(tpe: Type): Type = {
-        val newWidth = maxWidth(e.args.map(exp => getWidth(exp)))
-        tpe.mapWidth(w => newWidth)
-      }
-
-      def removeRem(e: Expression): Expression = e match {
-        case e: DoPrim =>
-          e.op match {
-            case Rem =>
-              val name = namespace.newTemp
-              val newType = e.mapType(verilogRemWidth(e))
-              v += DefNode(get_info(s), name, e.mapType(verilogRemWidth(e)))
-              val remRef = WRef(name, newType.tpe, kind(e), flow(e))
-              val remWidth = bitWidth(e.tpe)
-              DoPrim(Bits, Seq(remRef), Seq(remWidth - 1, BigInt(0)), e.tpe)
-            case _ => e
-          }
-        case _ => e
-      }
-
-      s.map(removeRem) match {
-        case x: Block => x.map(onStmt)
-        case EmptyStmt => EmptyStmt
-        case x =>
-          v += x
-          v.size match {
-            case 1 => v.head
-            case _ => Block(v.toSeq)
-          }
-      }
-    }
-    Module(m.info, m.name, m.ports, onStmt(m.body))
-  }
-
-  def run(c: Circuit): Circuit = {
-    val modules = c.modules.map {
-      case m: Module    => onModule(m)
-      case m: ExtModule => m
-    }
-    Circuit(c.info, modules, c.main)
-  }
+  def run(c: Circuit): Circuit = c
 }

--- a/src/test/scala/firrtlTests/VerilogEquivalenceSpec.scala
+++ b/src/test/scala/firrtlTests/VerilogEquivalenceSpec.scala
@@ -241,4 +241,149 @@ class VerilogEquivalenceSpec extends FirrtlFlatSpec {
     firrtlEquivalenceWithVerilog(firrtlFalse, verilogFalse)
   }
 
+  "unsigned modulus" should "be handled correctly" in {
+    val input1 =
+      s"""
+         |circuit Modulus :
+         |  module Modulus :
+         |    input x : UInt<8>
+         |    input y : UInt<4>
+         |    input z : UInt<4>
+         |    output out : UInt<1>
+         |    out <= eq(rem(x, y), z)
+         |""".stripMargin
+    val expected1 =
+      """
+        |module ModulusRef(
+        |  input [7:0] x,
+        |  input [3:0] y,
+        |  input [3:0] z,
+        |  output      out
+        |);
+        |  wire [7:0] mod = x % y;
+        |  wire [3:0] ext = mod[3:0];
+        |  assign out = ext == z;
+        |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input1, expected1)
+
+    val input2 =
+      s"""
+         |circuit Modulus :
+         |  module Modulus :
+         |    input x : UInt<4>
+         |    input y : UInt<8>
+         |    input z : UInt<4>
+         |    output out : UInt<1>
+         |    out <= eq(rem(x, y), z)
+         |""".stripMargin
+    val expected2 =
+      """
+        |module ModulusRef(
+        |  input [3:0] x,
+        |  input [7:0] y,
+        |  input [3:0] z,
+        |  output      out
+        |);
+        |  wire [7:0] mod = x % y;
+        |  wire [3:0] ext = mod[3:0];
+        |  assign out = ext == z;
+        |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input2, expected2)
+
+    val input3 =
+      s"""
+         |circuit Modulus :
+         |  module Modulus :
+         |    input x : UInt<8>
+         |    input y : UInt<8>
+         |    input z : UInt<4>
+         |    output out : UInt<1>
+         |    out <= eq(rem(x, y), z)
+         |""".stripMargin
+    val expected3 =
+      """
+        |module ModulusRef(
+        |  input [7:0] x,
+        |  input [7:0] y,
+        |  input [3:0] z,
+        |  output      out
+        |);
+        |  wire [7:0] mod = x % y;
+        |  assign out = mod == z;
+        |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input3, expected3)
+  }
+
+  "signed modulus" should "be handled correctly" in {
+    val input1 =
+      s"""
+         |circuit Modulus :
+         |  module Modulus :
+         |    input x : SInt<8>
+         |    input y : SInt<4>
+         |    input z : SInt<4>
+         |    output out : UInt<1>
+         |    out <= eq(rem(x, y), z)
+         |""".stripMargin
+    val expected1 =
+      """
+        |module ModulusRef(
+        |  input [7:0] x,
+        |  input [3:0] y,
+        |  input [3:0] z,
+        |  output      out
+        |);
+        |  wire [7:0] mod = $signed(x) % $signed(y);
+        |  wire [3:0] ext = mod[3:0];
+        |  assign out = ext == z;
+        |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input1, expected1)
+
+    val input2 =
+      s"""
+         |circuit Modulus :
+         |  module Modulus :
+         |    input x : SInt<4>
+         |    input y : SInt<8>
+         |    input z : SInt<4>
+         |    output out : UInt<1>
+         |    out <= eq(rem(x, y), z)
+         |""".stripMargin
+    val expected2 =
+      """
+        |module ModulusRef(
+        |  input [3:0] x,
+        |  input [7:0] y,
+        |  input [3:0] z,
+        |  output      out
+        |);
+        |  wire [7:0] mod = $signed(x) % $signed(y);
+        |  wire [3:0] ext = mod[3:0];
+        |  assign out = ext == z;
+        |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input2, expected2)
+
+    val input3 =
+      s"""
+         |circuit Modulus :
+         |  module Modulus :
+         |    input x : SInt<8>
+         |    input y : SInt<8>
+         |    input z : SInt<4>
+         |    output out : UInt<1>
+         |    out <= eq(rem(x, y), z)
+         |""".stripMargin
+    val expected3 =
+      """
+        |module ModulusRef(
+        |  input [7:0] x,
+        |  input [7:0] y,
+        |  input [3:0] z,
+        |  output      out
+        |);
+        |  wire [7:0] mod = $signed(x) % $signed(y);
+        |  assign out = mod == {{4{z[3]}}, z};
+        |endmodule""".stripMargin
+    firrtlEquivalenceWithVerilog(input3, expected3)
+  }
 }


### PR DESCRIPTION
This fixes handling of signed modulus and removes some redundant work.

Fixes #2480, Fixes #2129, Fixes #2287, Fixes https://github.com/chipsalliance/chisel3/issues/2012

This has been a bug for a long time. I've marked it 1.4.x but even that might be a pain to merge due to conflicts with https://github.com/chipsalliance/firrtl/pull/2304

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix               
 - code cleanup       

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Fix handling of modulus (`rem`) on SInts

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
