### PR TITLE
Fix anno deserialization when class field is not first

### DIFF
--- a/src/test/scala/firrtl/JsonProtocolSpec.scala
+++ b/src/test/scala/firrtl/JsonProtocolSpec.scala
@@ -31,6 +31,8 @@ object JsonProtocolTestClasses {
       with HasSerializationHints {
     def typeHints = Seq(param.getClass)
   }
+
+  case class SimpleAnnotation(alpha: String) extends NoTargetAnnotation
 }
 
 import JsonProtocolTestClasses._
@@ -66,6 +68,16 @@ class JsonProtocolSpec extends AnyFlatSpec {
   it should "serialize and deserialize with type hints" in {
     val anno = TypeParameterizedAnnotationWithTypeHints(ChildA(1))
     val deserAnno = serializeAndDeserialize(anno)
+    assert(anno == deserAnno)
+  }
+
+  "JSON object order" should "not affect deserialization" in {
+    val anno = SimpleAnnotation("hello")
+    val serializedAnno = """[{
+      "alpha": "hello",
+      "class": "firrtlTests.JsonProtocolTestClasses$SimpleAnnotation"
+    }]"""
+    val deserAnno = JsonProtocol.deserialize(serializedAnno).head
     assert(anno == deserAnno)
   }
 }


### PR DESCRIPTION
Update `findTypeHints` to allow for the "class" field in JSON objects to appear anywhere in the object. This used to rely on the field being the very first in the object, which is easily violated when reading JSON data generated externally, since an object's order of fields is unspecified and can be arbitrarily scrambled.

Fixes #2497.

### Contributor Checklist

- [x] ~Did you add Scaladoc to every public function/method?~
- [x] ~Did you update the FIRRTL spec to include every new feature/behavior?~
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
Bug fix

#### API Impact
None

#### Backend Code Generation Impact
None

#### Desired Merge Strategy
Squash

#### Release Notes
Allow for annotation deserialization class hints to appear anywhere in a JSON object, not just the first field.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
