### PR TITLE
Use circuit name hashCode for circuit anno hashCode

### DIFF
--- a/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
+++ b/src/main/scala/firrtl/stage/FirrtlAnnotations.scala
@@ -283,8 +283,12 @@ case class FirrtlCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation 
   /* Caching the hashCode for a large circuit is necessary due to repeated queries, e.g., in
    * [[Compiler.propagateAnnotations]]. Not caching the hashCode will cause severe performance degredations for large
    * [[Annotations]].
+   * @note Uses the hashCode of the name of the circuit. Creating a HashMap with different Circuits
+   *       that nevertheless have the same name is extremely uncommon so collisions are not a concern.
+   *       Include productPrefix so that this doesn't collide with other types that use a similar
+   *       strategy and hash the same String.
    */
-  override lazy val hashCode: Int = circuit.hashCode
+  override lazy val hashCode: Int = (this.productPrefix + circuit.main).hashCode
 
 }
 


### PR DESCRIPTION
It is unclear if having more than one circuit annotation even works. If
it does, it is implausible that they would have the same circuit name
since that would correspond to a namespace collision.

Looking at flamegraphs, FirrtlCircuitAnnotation.hashCode always comes up. Creating a HashMap with different Circuits that nevertheless have the same name is extremely uncommon so collisions are not a concern. Include productPrefix so that this doesn't collide with other types that use a similar strategy and hash the same String.

This speeds up anything using Stage/Phase with FIRRTL Circuits which includes Chisel

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - performance improvement    


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Improve performance of `FirrtlCircuitAnnotation.hashCode`. This speeds up all uses of Stage/Phase.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
