### PR TITLE
Make MemConf's MemPort serialization deterministic

### DIFF
--- a/src/main/scala/firrtl/passes/memlib/MemConf.scala
+++ b/src/main/scala/firrtl/passes/memlib/MemConf.scala
@@ -3,7 +3,7 @@
 package firrtl.passes
 package memlib
 
-sealed abstract class MemPort(val name: String) extends Product with Serializable { override def toString = name }
+sealed abstract class MemPort(val name: String) { override def toString = name }
 
 case object ReadPort extends MemPort("read")
 case object WritePort extends MemPort("write")
@@ -13,22 +13,21 @@ case object MaskedReadWritePort extends MemPort("mrw")
 
 object MemPort {
 
-  // All ports, make sure that any chances to all is reflected in orderedPorts below
-  val all = Set(ReadPort, WritePort, MaskedWritePort, ReadWritePort, MaskedReadWritePort)
   // This is the order that ports will render in MemConf.portsStr
-  val orderedPorts = collection.immutable
-    .Seq(
-      MaskedReadWritePort,
-      MaskedWritePort,
-      ReadWritePort,
-      WritePort,
-      ReadPort
-    )
-    .zipWithIndex
-    .toMap
+  val ordered: Seq[MemPort] = Seq(
+    MaskedReadWritePort,
+    MaskedWritePort,
+    ReadWritePort,
+    WritePort,
+    ReadPort
+  )
 
+  val all: Set[MemPort] = ordered.toSet
   // uses orderedPorts when sorting MemPorts
-  implicit def ordering: Ordering[MemPort] = Ordering.by(e => orderedPorts(e))
+  implicit def ordering: Ordering[MemPort] = {
+    val orderedPorts = ordered.zipWithIndex.toMap
+    Ordering.by(e => orderedPorts(e))
+  }
 
   def apply(s: String): Option[MemPort] = MemPort.all.find(_.name == s)
 

--- a/src/test/scala/firrtlTests/ReplSeqMemTests.scala
+++ b/src/test/scala/firrtlTests/ReplSeqMemTests.scala
@@ -693,4 +693,16 @@ circuit Top :
          |""".stripMargin
     compileAndEmit(CircuitState(parse(input), ChirrtlForm))
   }
+
+  "MemPorts" should "serialize in a deterministic order regardless" in {
+    def compare(seq1: Seq[MemPort]) {
+      val m1 = MemConf("memconf", 8, 16, seq1.map(s => s -> 1).toMap, None)
+      val m2 = MemConf("memconf", 8, 16, seq1.reverse.map(s => s -> 1).toMap, None)
+      m1.toString should be(m2.toString)
+    }
+
+    compare(Seq(ReadPort, WritePort))
+    compare(Seq(MaskedWritePort, ReadWritePort))
+    compare(Seq(MaskedReadWritePort, WritePort, ReadWritePort))
+  }
 }


### PR DESCRIPTION
Problem: MemConf serialization of MemPorts was not deterministic
and the ordering seems to have changed as we move projects to 2.13
Downstream project can be adversely affected by changes in ordering
This changes specifies as specific ordering that should be compatible with
the historically one.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

Code cleanup

#### API Impact

This change should preserve existing behavior that was changing as we continue to move to 2.13
Without this change downstream users for MemConf output could break

#### Backend Code Generation Impact

Verilog output should not be altered

#### Desired Merge Strategy

Squash and Merge

#### Release Notes

The order of MemPort fields in serialized MemConf is now guaranteed to be in the following order:
- mrw, mwrite, rw, write, read

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
