### PR TITLE
Fix incorrect deprecation warning for TargetDirAnnotation

### DIFF
--- a/src/main/scala/firrtl/package.scala
+++ b/src/main/scala/firrtl/package.scala
@@ -10,10 +10,10 @@ package object firrtl {
   implicit def annoSeqToSeq(as: AnnotationSeq): Seq[Annotation] = as.toSeq
 
   /* Options as annotations compatibility items */
-  @deprecated("Use firrtl.stage.TargetDirAnnotation", "FIRRTL 1.2")
+  @deprecated("Use firrtl.options.TargetDirAnnotation", "FIRRTL 1.2")
   type TargetDirAnnotation = firrtl.options.TargetDirAnnotation
 
-  @deprecated("Use firrtl.stage.TargetDirAnnotation", "FIRRTL 1.2")
+  @deprecated("Use firrtl.options.TargetDirAnnotation", "FIRRTL 1.2")
   val TargetDirAnnotation = firrtl.options.TargetDirAnnotation
 
   type WRef = ir.Reference


### PR DESCRIPTION
Given this has been deprecated for a very long time, we should delete it, but we should at least fix the warning for most branches

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [NA] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix       

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

   - Squash

#### Release Notes

Fix incorrect deprecation warning for TargetDirAnnotation

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
