### PR TITLE
Fix optimization of register with reset but invalid connection

### DIFF
--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -93,6 +93,9 @@ object RemoveReset extends Transform with DependencyAPIMigration {
           // addUpdate(info, Mux(reset, tv, fv, mux_type_and_widths(tv, fv)), Seq.empty)
           val infox = MultiInfo(reset.info, reset.info, info)
           Connect(infox, ref, expr)
+        case IsInvalid(_, ref @ WRef(rname, _, RegKind, _)) if resets.contains(rname) =>
+          val Reset(_, init, info) = resets(rname)
+          Connect(info, ref, init)
         case other => other.map(onStmt)
       }
     }

--- a/src/main/scala/firrtl/transforms/RemoveReset.scala
+++ b/src/main/scala/firrtl/transforms/RemoveReset.scala
@@ -52,6 +52,7 @@ object RemoveReset extends Transform with DependencyAPIMigration {
     val resets = mutable.HashMap.empty[String, Reset]
     val asyncResets = mutable.HashMap.empty[String, Reset]
     val invalids = computeInvalids(m)
+    lazy val namespace = Namespace(m)
     def onStmt(stmt: Statement): Statement = {
       stmt match {
         case reg @ DefRegister(_, name, _, _, reset, init) if isPreset(name) =>
@@ -93,9 +94,17 @@ object RemoveReset extends Transform with DependencyAPIMigration {
           // addUpdate(info, Mux(reset, tv, fv, mux_type_and_widths(tv, fv)), Seq.empty)
           val infox = MultiInfo(reset.info, reset.info, info)
           Connect(infox, ref, expr)
-        case IsInvalid(_, ref @ WRef(rname, _, RegKind, _)) if resets.contains(rname) =>
-          val Reset(_, init, info) = resets(rname)
-          Connect(info, ref, init)
+        /* Synchronously reset register that has reset value but only an invalid connection */
+        case IsInvalid(iinfo, ref @ WRef(rname, tpe, RegKind, _)) if resets.contains(rname) =>
+          // We need to mux with the invalid value to be consistent with async reset registers
+          val dummyWire = DefWire(iinfo, namespace.newName(rname), tpe)
+          val wireRef = Reference(dummyWire).copy(flow = SourceFlow)
+          val invalid = IsInvalid(iinfo, wireRef)
+          // Now mux between the invalid wire and the reset value
+          val Reset(cond, init, info) = resets(rname)
+          val muxType = Utils.mux_type_and_widths(init, wireRef)
+          val connect = Connect(info, ref, Mux(cond, init, wireRef, muxType))
+          Block(Seq(dummyWire, invalid, connect))
         case other => other.map(onStmt)
       }
     }

--- a/src/test/scala/firrtlTests/transforms/RemoveResetSpec.scala
+++ b/src/test/scala/firrtlTests/transforms/RemoveResetSpec.scala
@@ -8,7 +8,7 @@ import firrtl.testutils.FirrtlFlatSpec
 import firrtl.testutils.FirrtlCheckers._
 
 import firrtl.{CircuitState, WRef}
-import firrtl.ir.{Connect, DefRegister, Mux}
+import firrtl.ir.{Connect, DefRegister, Mux, UIntLiteral, IsInvalid}
 import firrtl.stage.{FirrtlCircuitAnnotation, FirrtlSourceAnnotation, FirrtlStage}
 
 class RemoveResetSpec extends FirrtlFlatSpec with GivenWhenThen {
@@ -45,6 +45,30 @@ class RemoveResetSpec extends FirrtlFlatSpec with GivenWhenThen {
 
     Then("'foo' is NOT connected to a reset mux")
     outputState shouldNot containTree { case Connect(_, WRef("foo", _, _, _), Mux(_, _, _, _)) => true }
+  }
+
+  it should "not generate a reset mux a sync reset register with an invalid connection" in {
+    Given("an 8-bit register 'foo' initialized to UInt(3) with an invalid connection")
+    val input =
+      """|circuit Example :
+         |  module Example :
+         |    input clock : Clock
+         |    input rst : UInt<1>
+         |    input in : UInt<1>
+         |    output out : UInt<8>
+         |
+         |    reg foo : UInt<8>, clock with : (reset => (rst, UInt(3)))
+         |    foo is invalid
+         |    out <= foo""".stripMargin
+
+    val outputState = toLowFirrtl(input)
+
+    Then("'foo' should not have a reset")
+    outputState should containTree { case DefRegister(_, "foo", _,_, UIntLiteral(value, _), WRef("foo", _,_,_)) if value == 0 => true }
+    Then("'foo' is connected to its old reset value")
+    outputState should containTree { case Connect(_, WRef("foo", _, _, _), UIntLiteral(value, _)) if value == 3 => true }
+    And("'foo' should not be invalidated")
+    outputState shouldNot containTree { case IsInvalid(_, _) => true }
   }
 
   it should "generate a reset mux for only the portion of an invalid aggregate that is reset" in {


### PR DESCRIPTION
Fixes #2516

Previously,
```
reg r : UInt<8>, clock with :
  reset => (p, UInt<8>(3))
r is invalid
```
would compile to:
```
reg r : UInt<8>, clock
r <= UInt<8>(0)
```
now it compiles to:
```
reg r : UInt<8>, clock
r <= UInt<8>(3)
```

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix        

#### API Impact

This is a 

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

 - Squash

#### Release Notes

Fix lowering of synchronously reset registers that have an invalid connection.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
