### PR TITLE
smt: make SMTExprMap object public

### DIFF
--- a/src/main/scala/firrtl/backends/experimental/smt/SMTExprMap.scala
+++ b/src/main/scala/firrtl/backends/experimental/smt/SMTExprMap.scala
@@ -2,7 +2,9 @@
 // Author: Kevin Laeufer <laeufer@cs.berkeley.edu>
 package firrtl.backends.experimental.smt
 
-private object SMTExprMap {
+object SMTExprMap {
+
+  /** maps f over subexpressions of expr and returns expr with the results replaced */
   def mapExpr(expr: SMTExpr, f: SMTExpr => SMTExpr): SMTExpr = {
     val bv = (b: BVExpr) => f(b).asInstanceOf[BVExpr]
     val ar = (a: ArrayExpr) => f(a).asInstanceOf[ArrayExpr]


### PR DESCRIPTION
The simple functionality is needed in chiseltest.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?


#### Type of Improvement
- expose API

#### API Impact
- adds three new methods to the public API surface

#### Backend Code Generation Impact
- none

#### Desired Merge Strategy

- squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
