### PR TITLE
Bump protobuf runtime to avoid CVE-2021-22569

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val protobufSettings = Seq(
+  ProtobufConfig / version := "3.18.2", // CVE-2021-22569
   ProtobufConfig / sourceDirectory := baseDirectory.value / "src" / "main" / "proto",
   ProtobufConfig / protobufRunProtoc := (args => com.github.os72.protocjar.Protoc.runProtoc("-v351" +: args.toArray))
 )


### PR DESCRIPTION
See https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-wrvw-hg22-4m67

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - bug fix      


#### API Impact

No impact, minor bump of dependency

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash
#### Release Notes

Bump protobuf runtime to avoid CVE-2021-22569

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
