### PR TITLE
FIRRTL version support

### DIFF
--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -36,7 +36,6 @@ version
   : 'FIRRTL' 'version' semver NEWLINE
   ;
 
-// Due to lexer problems, something like 1.1.0 is lexed as DoubleLit '.' UnsignedInt
 semver
   : SemVer .*?
   ;

--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -355,7 +355,7 @@ BinaryLit
   ;
 
 SemVer
-  : Digit+ '.' Digit+ '.' Digit+
+  : UnsignedInt '.' UnsignedInt '.' UnsignedInt
   ;
 
 DoubleLit

--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -38,7 +38,7 @@ version
 
 // Due to lexer problems, something like 1.1.0 is lexed as DoubleLit '.' UnsignedInt
 semver
-  : DoubleLit '.' UnsignedInt .*?
+  : SemVer .*?
   ;
 
 module
@@ -357,6 +357,10 @@ OctalLit
 
 BinaryLit
   : '"' 'b' ( '+' | '-' )? ( BinaryDigit )+ '"'
+  ;
+
+SemVer
+  : Digit+ '.' Digit+ '.' Digit+
   ;
 
 DoubleLit

--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -29,7 +29,16 @@ import firrtl.LexerHelper;
 
 // Does there have to be at least one module?
 circuit
-  : 'circuit' id ':' info? INDENT module* DEDENT EOF
+  : version? NEWLINE* 'circuit' id ':' info? INDENT module* DEDENT EOF
+  ;
+
+version
+  : 'FIRRTL' 'version' semver NEWLINE
+  ;
+
+// Due to lexer problems, something like 1.1.0 is lexed as DoubleLit '.' UnsignedInt
+semver
+  : DoubleLit '.' UnsignedInt .*?
   ;
 
 module

--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -33,7 +33,12 @@ circuit
   ;
 
 version
-  : 'FIRRTL' 'version' SemVer NEWLINE
+  : 'FIRRTL' 'version' semver NEWLINE
+  ;
+
+// Due to lexer problems, something like 1.1.0 is lexed as DoubleLit '.' UnsignedInt
+semver
+  : DoubleLit '.' UnsignedInt
   ;
 
 module
@@ -352,10 +357,6 @@ OctalLit
 
 BinaryLit
   : '"' 'b' ( '+' | '-' )? ( BinaryDigit )+ '"'
-  ;
-
-SemVer
-  : UnsignedInt '.' UnsignedInt '.' UnsignedInt
   ;
 
 DoubleLit

--- a/src/main/antlr4/FIRRTL.g4
+++ b/src/main/antlr4/FIRRTL.g4
@@ -33,11 +33,7 @@ circuit
   ;
 
 version
-  : 'FIRRTL' 'version' semver NEWLINE
-  ;
-
-semver
-  : SemVer .*?
+  : 'FIRRTL' 'version' SemVer NEWLINE
   ;
 
 module

--- a/src/main/scala/firrtl/Parser.scala
+++ b/src/main/scala/firrtl/Parser.scala
@@ -17,6 +17,7 @@ case class ParameterRedefinedException(message: String) extends ParserException(
 case class InvalidStringLitException(message: String) extends ParserException(message)
 case class InvalidEscapeCharException(message: String) extends ParserException(message)
 case class SyntaxErrorsException(message: String) extends ParserException(message)
+case class UnsupportedVersionException(message: String) extends ParserException(message)
 
 object Parser extends LazyLogging {
 

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -58,12 +58,6 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
 
   private def string2Int(s: String): Int = string2BigInt(s).toInt
 
-  private[firrtl] def visitVersion(ctx: Option[VersionContext], parentCtx: ParserRuleContext): Option[String] =
-    ctx match {
-      case Some(c) => Some(c.semver.getText)
-      case None    => None
-    }
-
   private[firrtl] def visitInfo(ctx: Option[InfoContext], parentCtx: ParserRuleContext): Info = {
     // Convert a compressed FileInfo string into either into a singular FileInfo or a MultiInfo
     // consisting of several FileInfos

--- a/src/main/scala/firrtl/Visitor.scala
+++ b/src/main/scala/firrtl/Visitor.scala
@@ -58,6 +58,12 @@ class Visitor(infoMode: InfoMode) extends AbstractParseTreeVisitor[FirrtlNode] w
 
   private def string2Int(s: String): Int = string2BigInt(s).toInt
 
+  private[firrtl] def visitVersion(ctx: Option[VersionContext], parentCtx: ParserRuleContext): Option[String] =
+    ctx match {
+      case Some(c) => Some(c.semver.getText)
+      case None    => None
+    }
+
   private[firrtl] def visitInfo(ctx: Option[InfoContext], parentCtx: ParserRuleContext): Info = {
     // Convert a compressed FileInfo string into either into a singular FileInfo or a MultiInfo
     // consisting of several FileInfos

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -254,6 +254,7 @@ object Serializer {
 
   private def s(node: Circuit)(implicit b: StringBuilder, indent: Int): Unit = node match {
     case Circuit(info, modules, main) =>
+      b ++= "FIRRTL version 1.1.0\n"
       b ++= "circuit "; b ++= main; b ++= " :"; s(info)
       if (modules.nonEmpty) {
         newLineNoIndent(); s(modules.head)(b, indent + 1)

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -10,6 +10,8 @@ object Serializer {
   val NewLine = '\n'
   val Indent = "  "
 
+  val version = "1.1.0"
+
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.
     */
@@ -254,7 +256,7 @@ object Serializer {
 
   private def s(node: Circuit)(implicit b: StringBuilder, indent: Int): Unit = node match {
     case Circuit(info, modules, main) =>
-      b ++= "FIRRTL version 1.1.0\n"
+      b ++= s"FIRRTL version ${version}\n"
       b ++= "circuit "; b ++= main; b ++= " :"; s(info)
       if (modules.nonEmpty) {
         newLineNoIndent(); s(modules.head)(b, indent + 1)

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -16,6 +16,7 @@ object Serializer {
   val NewLine = '\n'
   val Indent = "  "
 
+  // The version supported by the serializer.
   val version = Version(1, 1, 0)
 
   /** Converts a `FirrtlNode` into its string representation with

--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -6,11 +6,17 @@ import firrtl.Utils
 import firrtl.backends.experimental.smt.random.DefRandom
 import firrtl.constraint.Constraint
 
+case class Version(major: Int, minor: Int, patch: Int) {
+  def serialize: String = s"$major.$minor.$patch"
+  def incompatible(that: Version): Boolean =
+    this.major > that.major || (this.major == that.major && this.minor > that.minor)
+}
+
 object Serializer {
   val NewLine = '\n'
   val Indent = "  "
 
-  val version = "1.1.0"
+  val version = Version(1, 1, 0)
 
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.
@@ -256,7 +262,7 @@ object Serializer {
 
   private def s(node: Circuit)(implicit b: StringBuilder, indent: Int): Unit = node match {
     case Circuit(info, modules, main) =>
-      b ++= s"FIRRTL version ${version}\n"
+      b ++= s"FIRRTL version ${version.serialize}\n"
       b ++= "circuit "; b ++= main; b ++= " :"; s(info)
       if (modules.nonEmpty) {
         newLineNoIndent(); s(modules.head)(b, indent + 1)

--- a/src/main/scala/firrtl/parser/Listener.scala
+++ b/src/main/scala/firrtl/parser/Listener.scala
@@ -27,7 +27,7 @@ private[firrtl] class Listener(infoMode: InfoMode) extends FIRRTLBaseListener {
 
   override def exitCircuit(ctx: FIRRTLParser.CircuitContext): Unit = {
     if (ctx.version != null) {
-      val version = ctx.version.SemVer.getText
+      val version = ctx.version.semver.getText
       val parts = version.split("\\.")
       val (major, minor, patch) = (parts(0).toInt, parts(1).toInt, parts(2).toInt)
       if (Version(major, minor, patch).incompatible(Serializer.version)) {

--- a/src/main/scala/firrtl/parser/Listener.scala
+++ b/src/main/scala/firrtl/parser/Listener.scala
@@ -26,16 +26,13 @@ private[firrtl] class Listener(infoMode: InfoMode) extends FIRRTLBaseListener {
   }
 
   override def exitCircuit(ctx: FIRRTLParser.CircuitContext): Unit = {
-    Option(ctx.version) match {
-      case Some(c) => {
-        val version = c.semver.getText
-        val parts = version.split("\\.")
-        val (major, minor) = (parts(0).toInt, parts(1).toInt)
-        if (major > 1 || (major == 1 && minor > 1)) {
-          throw new UnsupportedVersionException(s"FIRRTL version ${version} is not supported (greater than 1.1.x)")
-        }
+    if (ctx.version != null) {
+      val version = ctx.version.semver.getText
+      val parts = version.split("\\.")
+      val (major, minor) = (parts(0).toInt, parts(1).toInt)
+      if (major > 1 || (major == 1 && minor > 1)) {
+        throw new UnsupportedVersionException(s"FIRRTL version ${version} is not supported (greater than 1.1.x)")
       }
-      case _ =>
     }
     info = Some(visitor.visitInfo(Option(ctx.info), ctx))
     main = Some(ctx.id.getText)

--- a/src/main/scala/firrtl/parser/Listener.scala
+++ b/src/main/scala/firrtl/parser/Listener.scala
@@ -6,6 +6,7 @@ import firrtl.antlr.{FIRRTLParser, _}
 import firrtl.Visitor
 import firrtl.Parser.InfoMode
 import firrtl.ir._
+import firrtl.UnsupportedVersionException
 
 import scala.collection.mutable
 import scala.concurrent.{Await, Future}
@@ -27,6 +28,16 @@ private[firrtl] class Listener(infoMode: InfoMode) extends FIRRTLBaseListener {
   override def exitCircuit(ctx: FIRRTLParser.CircuitContext): Unit = {
     info = Some(visitor.visitInfo(Option(ctx.info), ctx))
     main = Some(ctx.id.getText)
+    visitor.visitVersion(Option(ctx.version), ctx) match {
+      case Some(version) => {
+        val parts = version.split("\\.")
+        val (major, minor) = (parts(0).toInt, parts(1).toInt)
+        if (major > 1 || (major == 1 && minor > 1)) {
+          throw new UnsupportedVersionException(s"FIRRTL version ${version} is not supported (greater than 1.1.x)")
+        }
+      }
+      case _ =>
+    }
     ctx.children = null // Null out to save memory
   }
 

--- a/src/main/scala/firrtl/parser/Listener.scala
+++ b/src/main/scala/firrtl/parser/Listener.scala
@@ -27,11 +27,13 @@ private[firrtl] class Listener(infoMode: InfoMode) extends FIRRTLBaseListener {
 
   override def exitCircuit(ctx: FIRRTLParser.CircuitContext): Unit = {
     if (ctx.version != null) {
-      val version = ctx.version.semver.getText
+      val version = ctx.version.SemVer.getText
       val parts = version.split("\\.")
-      val (major, minor) = (parts(0).toInt, parts(1).toInt)
-      if (major > 1 || (major == 1 && minor > 1)) {
-        throw new UnsupportedVersionException(s"FIRRTL version ${version} is not supported (greater than 1.1.x)")
+      val (major, minor, patch) = (parts(0).toInt, parts(1).toInt, parts(2).toInt)
+      if (Version(major, minor, patch).incompatible(Serializer.version)) {
+        throw new UnsupportedVersionException(
+          s"FIRRTL version ${version} is not supported (greater than ${Serializer.version.serialize})"
+        )
       }
     }
     info = Some(visitor.visitInfo(Option(ctx.info), ctx))

--- a/src/main/scala/firrtl/parser/Listener.scala
+++ b/src/main/scala/firrtl/parser/Listener.scala
@@ -26,10 +26,9 @@ private[firrtl] class Listener(infoMode: InfoMode) extends FIRRTLBaseListener {
   }
 
   override def exitCircuit(ctx: FIRRTLParser.CircuitContext): Unit = {
-    info = Some(visitor.visitInfo(Option(ctx.info), ctx))
-    main = Some(ctx.id.getText)
-    visitor.visitVersion(Option(ctx.version), ctx) match {
-      case Some(version) => {
+    Option(ctx.version) match {
+      case Some(c) => {
+        val version = c.semver.getText
         val parts = version.split("\\.")
         val (major, minor) = (parts(0).toInt, parts(1).toInt)
         if (major > 1 || (major == 1 && minor > 1)) {
@@ -38,6 +37,8 @@ private[firrtl] class Listener(infoMode: InfoMode) extends FIRRTLBaseListener {
       }
       case _ =>
     }
+    info = Some(visitor.visitInfo(Option(ctx.info), ctx))
+    main = Some(ctx.id.getText)
     ctx.children = null // Null out to save memory
   }
 

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -107,6 +107,20 @@ class ParserSpec extends FirrtlFlatSpec {
     firrtl.Parser.parse(c.serialize)
   }
 
+  // FIRRTL version number
+  an[UnsupportedVersionException] should be thrownBy {
+    val input = """
+                  |FIRRTL version 1.2.0
+                  |circuit Test :
+                  |  module Test :
+                  |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }
+                  |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
+                  |    in.0.1 <= in.0.0
+                  |    in2.4.23.bar.123 <= in2.4.23.foo
+      """.stripMargin
+    firrtl.Parser.parse(input)
+  }
+
   // ********** Memories **********
   "Memories" should "allow arbitrary ordering of fields" in {
     val fields = MemTests.fieldsToSeq(MemTests.fields)

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -121,8 +121,8 @@ class ParserSpec extends FirrtlFlatSpec {
     val input = """
                   |circuit Test :
                   |  module Test :
-                  |    input in : UInt<1>
-                  |    in <= UInt(0)
+                  |    input in : { 0 : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } } }
+                  |    in.0.0.1 <= in.0.0.0
       """.stripMargin
     val c = firrtl.Parser.parse(input)
     firrtl.Parser.parse(c.serialize)

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -107,7 +107,6 @@ class ParserSpec extends FirrtlFlatSpec {
     firrtl.Parser.parse(c.serialize)
   }
 
-  // FIRRTL version number
   an[UnsupportedVersionException] should be thrownBy {
     val input = """
                   |FIRRTL version 1.2.0
@@ -117,6 +116,20 @@ class ParserSpec extends FirrtlFlatSpec {
                   |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
                   |    in.0.1 <= in.0.0
                   |    in2.4.23.bar.123 <= in2.4.23.foo
+      """.stripMargin
+    firrtl.Parser.parse(input)
+  }
+
+  an[UnsupportedVersionException] should be thrownBy {
+    val input = """
+                  |FIRRTL version 1.2.0
+                  |crcuit Test :
+                  |  module Test @@#!# :
+                  |    input in1 : UInt<2>
+                  |    input in2 : UInt<3>
+                  |    output out : UInt<4>
+                  |    out[1:0] <= in1
+                  |    out[3:2] <= in2[1:0]
       """.stripMargin
     firrtl.Parser.parse(input)
   }

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -92,10 +92,24 @@ class ParserSpec extends FirrtlFlatSpec {
     ) ++ PrimOps.listing
   }
 
-  // FIRRTL version number
-  "Version" should "be parsed" in {
+  // ********** FIRRTL version number **********
+  "Version 1.1.0" should "be accepted" in {
     val input = """
                   |FIRRTL version 1.1.0
+                  |circuit Test :
+                  |  module Test :
+                  |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }
+                  |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
+                  |    in.0.1 <= in.0.0
+                  |    in2.4.23.bar.123 <= in2.4.23.foo
+      """.stripMargin
+    val c = firrtl.Parser.parse(input)
+    firrtl.Parser.parse(c.serialize)
+  }
+
+  "Version 1.1.1" should "be accepted" in {
+    val input = """
+                  |FIRRTL version 1.1.1
                   |circuit Test :
                   |  module Test :
                   |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -98,10 +98,8 @@ class ParserSpec extends FirrtlFlatSpec {
                   |FIRRTL version 1.1.0
                   |circuit Test :
                   |  module Test :
-                  |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }
-                  |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
-                  |    in.0.1 <= in.0.0
-                  |    in2.4.23.bar.123 <= in2.4.23.foo
+                  |    input in : UInt<1>
+                  |    in <= UInt(0)
       """.stripMargin
     val c = firrtl.Parser.parse(input)
     firrtl.Parser.parse(c.serialize)
@@ -112,10 +110,19 @@ class ParserSpec extends FirrtlFlatSpec {
                   |FIRRTL version 1.1.1
                   |circuit Test :
                   |  module Test :
-                  |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }
-                  |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
-                  |    in.0.1 <= in.0.0
-                  |    in2.4.23.bar.123 <= in2.4.23.foo
+                  |    input in : UInt<1>
+                  |    in <= UInt(0)
+      """.stripMargin
+    val c = firrtl.Parser.parse(input)
+    firrtl.Parser.parse(c.serialize)
+  }
+
+  "No version" should "be accepted" in {
+    val input = """
+                  |circuit Test :
+                  |  module Test :
+                  |    input in : UInt<1>
+                  |    in <= UInt(0)
       """.stripMargin
     val c = firrtl.Parser.parse(input)
     firrtl.Parser.parse(c.serialize)
@@ -126,17 +133,15 @@ class ParserSpec extends FirrtlFlatSpec {
                   |FIRRTL version 1.2.0
                   |circuit Test :
                   |  module Test :
-                  |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }
-                  |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
-                  |    in.0.1 <= in.0.0
-                  |    in2.4.23.bar.123 <= in2.4.23.foo
+                  |    input in : UInt<1>
+                  |    in <= UInt(0)
       """.stripMargin
     firrtl.Parser.parse(input)
   }
 
   an[UnsupportedVersionException] should be thrownBy {
     val input = """
-                  |FIRRTL version 1.2.0
+                  |FIRRTL version 2.0.0
                   |crcuit Test :
                   |  module Test @@#!# :
                   |    input in1 : UInt<2>

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -92,6 +92,21 @@ class ParserSpec extends FirrtlFlatSpec {
     ) ++ PrimOps.listing
   }
 
+  // FIRRTL version number
+  "Version" should "be parsed" in {
+    val input = """
+                  |FIRRTL version 1.1.0
+                  |circuit Test :
+                  |  module Test :
+                  |    input in : { 0 : { 0 : UInt<32>, flip 1 : UInt<32> } }
+                  |    input in2 : { 4 : { 23 : { foo : UInt<32>, bar : { flip 123 : UInt<32> } } } }
+                  |    in.0.1 <= in.0.0
+                  |    in2.4.23.bar.123 <= in2.4.23.foo
+      """.stripMargin
+    val c = firrtl.Parser.parse(input)
+    firrtl.Parser.parse(c.serialize)
+  }
+
   // ********** Memories **********
   "Memories" should "allow arbitrary ordering of fields" in {
     val fields = MemTests.fieldsToSeq(MemTests.fields)

--- a/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -63,7 +63,7 @@ object SerializerSpec {
   val childModuleTabbed: String = tab(childModule)
 
   val simpleCircuit: String =
-    "circuit test :\n" + childModuleTabbed + "\n\n" + testModuleTabbed + "\n"
+    s"FIRRTL version ${Serializer.version}\ncircuit test :\n" + childModuleTabbed + "\n\n" + testModuleTabbed + "\n"
 }
 
 class SerializerSpec extends AnyFlatSpec with Matchers {

--- a/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -63,7 +63,7 @@ object SerializerSpec {
   val childModuleTabbed: String = tab(childModule)
 
   val simpleCircuit: String =
-    s"FIRRTL version ${Serializer.version}\ncircuit test :\n" + childModuleTabbed + "\n\n" + testModuleTabbed + "\n"
+    s"FIRRTL version ${Serializer.version.serialize}\ncircuit test :\n" + childModuleTabbed + "\n\n" + testModuleTabbed + "\n"
 }
 
 class SerializerSpec extends AnyFlatSpec with Matchers {


### PR DESCRIPTION
Now that FIRRTL supports version specifiers (https://github.com/chipsalliance/firrtl-spec/pull/30), the parser here should accept versions and the serializer should emit a version. The current version of FIRRTL is 1.1.0. This FIRRTL compiler will throw an error if used to compile FIRRTL with a version greater than 1.1.x (e.g., >= 1.2.0). The serializer currently emits FIRRTL version 1.1.0.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

The serializer will now emit a FIRRTL version number, and the parser will accept one and throw an error if it is above 1.1.0.

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->
No impact.
#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->
Squash.
#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
The serializer will now emit a FIRRTL version number, and the parser will accept one and throw an error if it is above 1.1.0.
### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
