### PR TITLE
Fix serialization of whens with empty blocks

### DIFF
--- a/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -116,4 +116,9 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
     serialized should be(childModuleTabbed)
   }
 
+  it should "emit whens with empty Blocks correctly" in {
+    val when = Conditionally(NoInfo, Reference("cond"), Block(Seq()), EmptyStmt)
+    val serialized = Serializer.serialize(when, 1)
+    serialized should be("  when cond :\n    skip\n")
+  }
 }


### PR DESCRIPTION
Also get rid of whitespace-only lines that were emitted after every when block.

This fixes 2 bugs (1 functional, 1 just a little ugly):
1. Whens with empty Blocks (ie. `Block(Seq())`) were emitting with just an empty line, this fixes it to have a `skip`
2. The line after a when was blank (except it had the same number of spaces as the indenting in the when block)

This is best illustrated with some simple Chisel
```scala
class Example extends RawModule {
  val a, b = IO(Input(UInt(8.W)))
  val c, d = IO(Output(UInt(8.W)))

  d := b
  when (a === b) {
  }
  c := a
}
```

Emitted with spaces replaced by `_` to visualize whitespace

Current master/1.5.x ([Chisel 3.5-SNAPSHOT Scastie](https://scastie.scala-lang.org/HC93xZQeQX2iopVIZizVqg)):
```
__module_Example_:
____input_a_:_UInt<8>
____input_b_:_UInt<8>
____output_c_:_UInt<8>
____output_d_:_UInt<8>

____d_<=_b
____node__T_=_eq(a,_b)
____
____when__T_:
______
____c_<=_a
```

This PR:
```
__module_Example_:
____input_a_:_UInt<8>
____input_b_:_UInt<8>
____output_c_:_UInt<8>
____output_d_:_UInt<8>

____d_<=_b
____node__T_=_eq(a,_b)
____when__T_:
______skip
____c_<=_a
```
Which matches the behavior of 3.5.4 ([3.5.4 Scastie](https://scastie.scala-lang.org/EaxxAG6LTTSYyd0jQT8o2A)).

 
### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

Fix for unreleased bug so no need for release notes.

#### Type of Improvement

- bug fix

#### API Impact

No impact

#### Backend Code Generation Impact

This fixes emission of `.fir`

#### Desired Merge Strategy

 - Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
