### PR TITLE
Publish Dated SNAPSHOTs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,7 @@ jobs:
   publish:
     needs: [all_tests_passed]
     runs-on: ubuntu-latest
-      # TODO uncomment this before merging PR
-      #if: github.event_name == 'push'
+      if: github.event_name == 'push'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,8 @@ jobs:
   publish:
     needs: [all_tests_passed]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+      # TODO uncomment this before merging PR
+      #if: github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -126,7 +127,9 @@ jobs:
       - name: Setup GPG (for Publish)
         uses: olafurpg/setup-gpg@v3
       - name: Publish
-        run: sbt ci-release
+        run: |
+          sbt ci-release
+          sbt -Ddatedsnapshot ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,20 @@ lazy val isAtLeastScala213 = Def.setting {
   CrossVersion.partialVersion(scalaVersion.value).exists(_ >= (2, 13))
 }
 
+def currentVersion(major: String): String = {
+  val doDatedSnapshot = sys.props.get("datedsnapshot")
+  if (doDatedSnapshot.isDefined) {
+    val basicFormat = java.time.format.DateTimeFormatter.BASIC_ISO_DATE
+    val date = java.time.LocalDate.now().format(basicFormat)
+    s"$major-$date-SNAPSHOT"
+  } else {
+    s"$major-SNAPSHOT"
+  }
+}
+
 lazy val firrtlSettings = Seq(
   name := "firrtl",
-  version := "1.6-SNAPSHOT",
+  version := currentVersion("1.6"),
   addCompilerPlugin(scalafixSemanticdb),
   scalacOptions := Seq(
     "-deprecation",


### PR DESCRIPTION
The intent is that once these are being published, chisel3 can find the latest dated SNAPSHOT and then publish itself against it.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- release automation

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

  - Squash

#### Release Notes

Begin published dated SNAPSHOTs

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
