### PR TITLE
Fix to support verilator tests in chisel3 that use MFC to generate unittests

### DIFF
--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -188,7 +188,8 @@ object BackendCompilationUtilities extends LazyLogging {
           logger.info(line)
         },
         stderrLine => {
-          triggered = triggered || stderrLine.contains("Assertion failed") || (assertionMessageSupplied && stderrLine.contains(assertionMsg))
+          triggered = triggered || stderrLine
+            .contains("Assertion failed") || (assertionMessageSupplied && stderrLine.contains(assertionMsg))
           logger.warn(stderrLine)
         }
       )

--- a/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -163,6 +163,17 @@ object BackendCompilationUtilities extends LazyLogging {
   def cppToExe(prefix: String, dir: File): ProcessBuilder =
     Seq("make", "-C", dir.toString, "-j", "-f", s"V$prefix.mk", s"V$prefix")
 
+  /** Check for failed unit test using verilator
+    * Failure determined by
+    * - supplied assertion message on stdout
+    * - "Assertion failed" on stderr
+    * - exit code not equal to 0 or 134
+    *
+    * @param prefix program to be run after adding capital "./V" to the front
+    * @param dir           working directory for program execution
+    * @param assertionMsg  message to look for on stdout
+    * @return              true
+    */
   def executeExpectingFailure(
     prefix:       String,
     dir:          File,
@@ -176,7 +187,10 @@ object BackendCompilationUtilities extends LazyLogging {
           triggered = triggered || (assertionMessageSupplied && line.contains(assertionMsg))
           logger.info(line)
         },
-        logger.warn(_)
+        stderrLine => {
+          triggered = triggered || stderrLine.contains("Assertion failed") || (assertionMessageSupplied && stderrLine.contains(assertionMsg))
+          logger.warn(stderrLine)
+        }
       )
     // Fail if a line contained an assertion or if we get a non-zero exit code
     //  or, we get a SIGABRT (assertion failure) and we didn't provide a specific assertion message


### PR DESCRIPTION
Fix to support verilator tests in chisel3 that use MFC to generate code for `executeExpecting*` API

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you update the FIRRTL spec to include every new feature/behavior?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - code refactoring

#### API Impact

Does not change the API structure. Slightly different behavior to support MFC in chisel3

#### Backend Code Generation Impact

- does not impact code generation

#### Desired Merge Strategy

 - Squash: The PR will be squashed and merged (choose this if you have no preference. 

#### Release Notes

Detects "assertion failed" messages in stderr in addition to existing checks on execution success or failure

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.2.x, 1.3.0, 1.4.0) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
