### PR TITLE
Update serialization to firrtl-spec 1.2.0

### DIFF
--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -17,7 +17,7 @@ object Serializer {
   val Indent = "  "
 
   // The version supported by the serializer.
-  val version = Version(1, 1, 0)
+  val version = Version(1, 2, 0)
 
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.

--- a/src/test/scala/firrtlTests/ParserSpec.scala
+++ b/src/test/scala/firrtlTests/ParserSpec.scala
@@ -118,6 +118,30 @@ class ParserSpec extends FirrtlFlatSpec {
     firrtl.Parser.parse(c.serialize)
   }
 
+  "Version 1.2.0" should "be accepted" in {
+    val input = """
+                  |FIRRTL version 1.2.0
+                  |circuit Test :
+                  |  module Test :
+                  |    input in : UInt<1>
+                  |    in <= UInt(0)
+      """.stripMargin
+    val c = firrtl.Parser.parse(input)
+    firrtl.Parser.parse(c.serialize)
+  }
+
+  "Version 1.2.1" should "be accepted" in {
+    val input = """
+                  |FIRRTL version 1.2.1
+                  |circuit Test :
+                  |  module Test :
+                  |    input in : UInt<1>
+                  |    in <= UInt(0)
+      """.stripMargin
+    val c = firrtl.Parser.parse(input)
+    firrtl.Parser.parse(c.serialize)
+  }
+
   "No version" should "be accepted" in {
     val input = """
                   |circuit Test :
@@ -129,10 +153,10 @@ class ParserSpec extends FirrtlFlatSpec {
     firrtl.Parser.parse(c.serialize)
   }
 
-  "Version 1.2.0" should "be rejected" in {
+  "Version 1.3.0" should "be rejected" in {
     an[UnsupportedVersionException] should be thrownBy {
       val input = """
-                    |FIRRTL version 1.2.0
+                    |FIRRTL version 1.3.0
                     |circuit Test :
                     |  module Test :
                     |    input in : UInt<1>


### PR DESCRIPTION
<!--

********** NOTICE **********

This repository is only accepting bug fixes

-->

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

 - new feature/API 

#### API Impact

We now use FIRRTL spec version 1.2.0 (which is closer to what we've always been doing anyway). Both for emission and for parsing.

#### Backend Code Generation Impact

Emitted .fir is now [FIRRTL spec version 1.2.0](https://github.com/chipsalliance/firrtl-spec/releases/tag/v1.2.0).

#### Desired Merge Strategy

 - Squash

#### Release Notes

Update FIRRTL spec version in serialized .fir to 1.2.0.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.6.x, 1.5.x) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
