### PR TITLE
Make return value of Serializer.lazily lazy

### DIFF
--- a/src/main/scala/firrtl/ir/Serializer.scala
+++ b/src/main/scala/firrtl/ir/Serializer.scala
@@ -69,7 +69,7 @@ object Serializer {
       case n: Circuit   => sIt(n)(indent)
       case other => Iterator(serialize(other, indent))
     }
-  }
+  }.view // TODO replace .view with constructing a view directly above, but must drop 2.12 first.
 
   /** Converts a `Constraint` into its string representation. */
   def serialize(con: Constraint): String = {


### PR DESCRIPTION
Directly subclassing Iterable is lazy-ish, but if you call any operation on the resulting value (eg. map or ++) it will evaluate the Iterable and return a List.

<!--

********** NOTICE **********

This repository is only accepting bug fixes

-->

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [NA] Did you update the FIRRTL spec to include every new feature/behavior?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


- bug fix 
- performance improvement  

#### API Impact

This makes `Serializer.lazily` more accurately reflect its API

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Make return value of Serializer.lazily lazy even after calling methods on it.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (1.6.x, 1.5.x) ?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
